### PR TITLE
fix: CI workflow improvements

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,11 +108,11 @@ jobs:
           name: weavster-${{ matrix.target }}
           path: target/${{ matrix.target }}/release/${{ matrix.artifact }}
 
-  # Build Docker images (only on main)
+  # Build Docker images (temporarily disabled - re-enable when needed)
   docker:
     name: Docker Build
     needs: [fmt, clippy, test]
-    if: github.ref == 'refs/heads/main'
+    if: false # Disabled: was github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.octocov.yml
+++ b/.octocov.yml
@@ -31,4 +31,4 @@ comment:
 report:
   if: is_default_branch
   datastores:
-    - artifact://
+    - artifact://${GITHUB_REPOSITORY}


### PR DESCRIPTION
## Summary

- Disable Docker build job temporarily as images are not currently needed
- Fix octocov datastore artifact path to use full repository path

Closes #9

## Changes

**Docker Build Disabled**
- Added `if: false` to the docker job to skip Docker image builds
- Preserved original condition in comment for easy re-enabling
- Reduces CI time during early development

**Octocov Fix**
- Changed artifact path from `artifact://` to `artifact://${GITHUB_REPOSITORY}`
- Fixes coverage report storage

🤖 Generated with [Claude Code](https://claude.com/claude-code)