### PR TITLE
docs: add CNAME for custom domain docs.weavster.dev

### DIFF
--- a/docs/static/CNAME
+++ b/docs/static/CNAME
@@ -1,0 +1,1 @@
+docs.weavster.dev


### PR DESCRIPTION
## Summary

- Add CNAME file to `docs/static/` for custom domain `docs.weavster.dev`
- Ensures the custom domain setting persists across deployments

Fixes #11

🤖 Generated with [Claude Code](https://claude.com/claude-code)