### PR TITLE
[Bug] Fix git-cliff-action Docker failure

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -18,13 +18,13 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Generate changelog
-        uses: orhun/git-cliff-action@v3
+      - name: Install git-cliff
+        uses: taiki-e/install-action@v2
         with:
-          config: cliff.toml
-          args: --verbose
-        env:
-          OUTPUT: CHANGELOG.md
+          tool: git-cliff
+
+      - name: Generate changelog
+        run: git-cliff --config cliff.toml --output CHANGELOG.md --verbose
 
       - name: Commit changelog
         run: |

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -48,6 +48,7 @@ jobs:
           ENABLE_LSP_TOOL: "1"
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          plugins: rust-analyzer-lsp@claude-plugins-official
           prompt: |
             REPO: ${{ github.repository }}
             PR NUMBER: ${{ github.event.pull_request.number }}
@@ -108,10 +109,18 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Setup Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rust-analyzer
+
       - name: Respond to mention
         uses: anthropics/claude-code-action@v1
+        env:
+          ENABLE_LSP_TOOL: "1"
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          plugins: rust-analyzer-lsp@claude-plugins-official
           prompt: |
             REPO: ${{ github.repository }}
             ISSUE/PR NUMBER: ${{ github.event.issue.number }}
@@ -156,10 +165,18 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Setup Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rust-analyzer
+
       - name: Assist with issue
         uses: anthropics/claude-code-action@v1
+        env:
+          ENABLE_LSP_TOOL: "1"
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          plugins: rust-analyzer-lsp@claude-plugins-official
           prompt: |
             REPO: ${{ github.repository }}
             ISSUE NUMBER: ${{ github.event.issue.number }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -216,14 +216,20 @@ jobs:
           echo "release_name=v${{ needs.validate.outputs.version }}: $NAME" >> $GITHUB_OUTPUT
           echo "release_summary=$SUMMARY" >> $GITHUB_OUTPUT
 
-      - name: Generate changelog for release
-        uses: orhun/git-cliff-action@v3
-        id: changelog
+      - name: Install git-cliff
+        uses: taiki-e/install-action@v2
         with:
-          config: cliff.toml
-          args: --verbose --latest --strip header
-        env:
-          OUTPUT: CHANGES.md
+          tool: git-cliff
+
+      - name: Generate changelog for release
+        id: changelog
+        run: |
+          # Generate changelog for latest tag only
+          CONTENT=$(git-cliff --config cliff.toml --latest --strip header)
+          # Handle multiline output for GitHub Actions
+          echo "content<<EOF" >> $GITHUB_OUTPUT
+          echo "$CONTENT" >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
 
       - name: Create release
         uses: softprops/action-gh-release@v2


### PR DESCRIPTION
## Summary

- Replace broken `orhun/git-cliff-action@v3` with `taiki-e/install-action@v2`
- Update both `changelog.yml` and `release.yml` workflows
- Uses pre-built binaries instead of Docker, avoiding Debian Buster EOL issues
- Enable `rust-analyzer-lsp` plugin in Claude code review workflow
  - Add explicit `plugins` input (action doesn't read from settings.json)
  - Add Rust toolchain setup to all jobs
  - Add `ENABLE_LSP_TOOL` env var to all jobs

Fixes #15

🤖 Generated with [Claude Code](https://claude.com/claude-code)