### PR TITLE
[Docs] Add unreleased banner to /next version

### DIFF
--- a/docs/docusaurus.config.ts
+++ b/docs/docusaurus.config.ts
@@ -43,6 +43,7 @@ const config: Config = {
             current: {
               label: "next",
               path: "next",
+              banner: "unreleased",
             },
           },
         },


### PR DESCRIPTION
## Summary

- Adds an "unreleased" banner to the `/next` documentation pages

This displays Docusaurus's built-in warning banner on all development docs:
> "This is unreleased documentation for the next version."

## Why

- Users installing from releases should use versioned docs that match their version
- `/next` reflects the `main` branch which may be ahead of any release
- Follows standard OSS documentation conventions (React, Docusaurus, etc.)

Closes #19

🤖 Generated with [Claude Code](https://claude.ai/code)