### PR TITLE
fix: add plugin marketplace URL for rust-analyzer-lsp

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -21,8 +21,9 @@
     ]
   },
   "enabledPlugins": {
-    "code-review@claude-plugins-official": true,
-    "pr-review-toolkit@claude-plugins-official": true,
     "rust-analyzer-lsp@claude-plugins-official": true
-  }
+  },
+  "pluginMarketplaces": [
+    "https://github.com/anthropics/claude-plugins-official.git"
+  ]
 }

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -48,6 +48,7 @@ jobs:
           ENABLE_LSP_TOOL: "1"
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          plugin_marketplaces: https://github.com/anthropics/claude-plugins-official.git
           plugins: rust-analyzer-lsp@claude-plugins-official
           prompt: |
             REPO: ${{ github.repository }}
@@ -120,6 +121,7 @@ jobs:
           ENABLE_LSP_TOOL: "1"
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          plugin_marketplaces: https://github.com/anthropics/claude-plugins-official.git
           plugins: rust-analyzer-lsp@claude-plugins-official
           prompt: |
             REPO: ${{ github.repository }}
@@ -176,6 +178,7 @@ jobs:
           ENABLE_LSP_TOOL: "1"
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          plugin_marketplaces: https://github.com/anthropics/claude-plugins-official.git
           plugins: rust-analyzer-lsp@claude-plugins-official
           prompt: |
             REPO: ${{ github.repository }}


### PR DESCRIPTION
## Summary

- Add `pluginMarketplaces` configuration to `.claude/settings.json` for local development
- Add `plugin_marketplaces` parameter to all claude-code-action jobs in CI workflow
- Remove unused `code-review` and `pr-review-toolkit` plugins from settings

## Problem

CI was failing with:
```
No marketplaces specified, skipping marketplace setup
✘ Failed to install plugin "rust-analyzer-lsp@claude-plugins-official": Plugin "rust-analyzer-lsp" not found in marketplace "claude-plugins-official"
```

The `rust-analyzer-lsp` plugin exists in [claude-plugins-official](https://github.com/anthropics/claude-plugins-official/tree/main/plugins/rust-analyzer-lsp), but the marketplace URL needs to be explicitly registered.

## Test plan

- [ ] Verify CI passes with the new marketplace configuration
- [ ] Confirm rust-analyzer-lsp plugin loads in local Claude Code sessions

Closes #21

🤖 Generated with [Claude Code](https://claude.ai/code)