### PR TITLE
fix: use workflow runs API for nightly CI status check

### DIFF
--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -17,9 +17,9 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          # Get the latest CI run on main
-          STATUS=$(gh api repos/${{ github.repository }}/commits/main/check-runs \
-            --jq '[.check_runs[] | select(.name | test("Clippy|Test|Format"))] | if length == 0 then "no_runs" else (if all(.conclusion == "success") then "success" else "failure" end) end')
+          # Get the latest CI workflow run on main branch
+          STATUS=$(gh api repos/${{ github.repository }}/actions/workflows/ci.yml/runs \
+            --jq '.workflow_runs | map(select(.head_branch == "main")) | first | .conclusion // "no_runs"')
 
           if [ "$STATUS" != "success" ]; then
             echo "ERROR: CI is not green on main branch (status: $STATUS)"


### PR DESCRIPTION
## Summary

- Fixes nightly release workflow always failing with `status: no_runs` at the "Verify CI Status" step
- The previous approach queried commit check runs for names matching `Clippy|Test|Format`, but these were absent when the latest main commit was created by a non-CI workflow (e.g., docs deploy)
- Now queries the GitHub Actions workflow runs API directly (`actions/workflows/ci.yml/runs`), which reliably returns the latest CI result regardless of which commit is at HEAD

Closes #24

🤖 Generated with [Claude Code](https://claude.com/claude-code)