### PR TITLE
Move design plan content out of CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,6 +14,8 @@ Weavster is a developer-friendly tool for building real-time data transformation
 - **Zero-config local dev**: Embedded PostgreSQL, single binary distribution
 - **Safe transforms**: WASM sandboxing for untrusted code (escape hatch only)
 
+For architecture details and design decisions, see `plans/architecture-and-design.md`.
+
 ## Quick Start
 
 ```bash
@@ -43,9 +45,9 @@ This is a Cargo workspace with multiple crates:
 | Crate | Purpose | Depends On |
 |-------|---------|------------|
 | `weavster-core` | Shared library: config, transforms, connectors | - |
+| `weavster-codegen` | Transform compilation: YAML → Rust → WASM | `weavster-core` |
 | `weavster-runtime` | Execution engine for Docker deployment | `weavster-core` |
 | `weavster-cli` | Developer CLI tool | `weavster-core`, `weavster-runtime` |
-| `weavster-python` | PyO3 bindings for Python ecosystem | `weavster-core` |
 
 ### Dependency Rules
 
@@ -53,60 +55,6 @@ This is a Cargo workspace with multiple crates:
 - `weavster-runtime` depends ONLY on `weavster-core`
 - `weavster-cli` can depend on any workspace crate
 - Keep `weavster-runtime` minimal for small Docker images
-
-## Architecture
-
-### Core Concepts
-
-- **Project**: Collection of flows organized in a directory with `weavster.yaml`
-- **Flow**: 1 input → N outputs with transforms in between
-- **Connector**: Input/Output adapter (Kafka, Postgres, HTTP, File, etc.)
-- **Bridge**: Special connector linking flows together
-- **Transform**: Data manipulation (rename, filter, compute, etc.)
-
-### Transform Pipeline
-
-```
-YAML Config → Parse → Rust Codegen → WASM Compile → Execute (wasmtime)
-```
-
-**All transforms compile to WASM.** The YAML transform DSL is parsed and translated
-into Rust code, which is then compiled to WASM. This provides:
-
-- **Sandboxed execution** - Transforms can't escape the WASM sandbox
-- **Portable artifacts** - Same WASM runs anywhere wasmtime runs
-- **Supply chain security** - OCI artifacts can be signed and verified
-
-Transform types:
-- **Simple mappings** - Direct field assignments (zero overhead)
-- **Regex** - Pattern matching via `regex` crate compiled into WASM
-- **Jinja templates** - `minijinja` compiled into WASM
-- **Lookups** - Translation tables embedded as `phf` static maps
-
-### Local Development Runtime
-
-```
-weavster run
-    │
-    ├── Start postgresql_embedded (if local mode)
-    ├── Run migrations (apalis tables)
-    ├── Parse weavster.yaml + flows/*.yaml
-    ├── Render Jinja templates
-    ├── Start connector workers
-    └── Process messages through flows
-```
-
-### Configuration Hierarchy
-
-```
-weavster.yaml           # Project config, runtime settings
-├── flows/
-│   ├── flow_a.yaml     # Individual flow definitions
-│   └── flow_b.yaml
-├── connectors/
-│   └── kafka.yaml      # Reusable connector configs
-└── profiles.yaml       # Environment-specific overrides (like dbt)
-```
 
 ## Coding Standards
 
@@ -177,33 +125,11 @@ mod tests {
 
 - All public APIs must have doc comments
 - Include examples in doc comments where helpful
-- Update CHANGELOG.md for user-facing changes
 - Documentation is part of "done" for all features and fixes
 
 ## Documentation Site
 
 User-facing documentation lives in `/docs` (Docusaurus) and is published to https://docs.weavster.dev
-
-### Structure
-
-```
-docs/
-├── docs/                    # Markdown source files
-│   ├── index.md             # Homepage
-│   ├── getting-started/     # Installation, first flow
-│   ├── configuration/       # Project, flows config
-│   ├── concepts/            # Transforms, connectors
-│   └── cli/                 # CLI reference
-├── docusaurus.config.ts     # Site configuration
-└── sidebars.ts              # Sidebar structure
-```
-
-### Versioning
-
-- `next` - Built from `main` branch (development docs)
-- `X.Y.Z` - Snapshot created on each release
-
-### Local Development
 
 ```bash
 cd docs
@@ -212,19 +138,9 @@ npm start           # Dev server at localhost:3000
 npm run build       # Production build
 ```
 
-### Deployment
-
 Docs are automatically deployed via GitHub Actions:
 - **Push to main** → Deploys `next` version
 - **Release published** → Creates version snapshot and deploys
-
-### Writing Docs
-
-When adding features or making changes:
-1. Update relevant docs in `/docs/docs/`
-2. Follow existing patterns for YAML examples
-3. Include practical examples where helpful
-4. PR template includes documentation checklist
 
 ## Git & Version Control Rules
 
@@ -247,124 +163,6 @@ We strongly value applying YAGNI principles:
 - Wait to extract concerns/services until there's a clear need
 - Avoid premature optimization - add indexes, caching, etc. only when performance issues arise
 - Keep implementations simple and direct until complexity is actually required
-
-## Key Design Decisions
-
-### Why Rust?
-- Single binary distribution (like dbt)
-- Memory safety without GC
-- Excellent WASM compilation (both host and target)
-- PyO3 for Python bindings
-- Performance for real-time processing
-
-### Why WASM for all transforms?
-- Security: Sandboxed execution, no escape to host
-- Portability: Same binary runs anywhere
-- Supply chain: OCI artifacts can be signed
-- Performance: Near-native speed via wasmtime
-- Embedding: regex, minijinja, phf all compile cleanly to WASM
-
-### Why OCI for packaging?
-- Industry standard for artifact distribution
-- Signing via cosign/sigstore
-- No OS attack surface (FROM scratch)
-- Works with existing registry infrastructure
-- Versioning and immutability built-in
-
-### Why postgresql_embedded?
-- Zero-config local development
-- Same semantics as production Postgres
-- No Docker required for local dev
-- Bundled feature includes PG in binary
-
-### Why apalis for job queue?
-- Native Postgres support (matches our embedded story)
-- Async-native (tokio)
-- Can swap to Redis for distributed deployments
-
-### Why MiniJinja?
-- Created by Armin Ronacher (Flask/Jinja creator)
-- Familiar to dbt users
-- Pure Rust, compiles to WASM
-- No Python dependency
-
-## Compile & Package Pipeline
-
-### Transform Compilation
-
-```bash
-weavster compile                    # YAML → Rust → WASM for all flows
-weavster compile --flow myflow      # Single flow
-weavster compile --debug            # Output generated Rust for inspection
-```
-
-The compile process:
-1. Parse `flows/*.yaml` and `weavster.yaml`
-2. For each flow, generate Rust source code
-3. Embed artifacts (translation tables, regex patterns) as static data
-4. Compile to `wasm32-wasi` target
-5. Cache in `.weavster/cache/`
-
-### OCI Packaging
-
-```bash
-weavster package                    # Create OCI artifact
-weavster package --sign             # Create and sign with cosign
-weavster push <registry>            # Push to OCI registry
-weavster pull <registry>            # Pull from registry
-```
-
-OCI artifact structure (FROM scratch - no OS):
-```
-manifest.json
-├── flow.wasm                       # Compiled transform
-├── config/
-│   └── flow.yaml                   # Original config (reference)
-├── artifacts/
-│   ├── translations/*.csv          # Lookup tables
-│   └── patterns/*.json             # Regex patterns
-└── signatures/
-    └── cosign.sig                  # Optional signature
-```
-
-### Codegen Architecture
-
-```
-crates/weavster-codegen/
-├── src/
-│   ├── lib.rs                      # Public API
-│   ├── parser.rs                   # YAML → IR
-│   ├── ir.rs                       # Intermediate representation
-│   ├── generator.rs                # IR → Rust source
-│   ├── compiler.rs                 # Rust → WASM
-│   └── transforms/
-│       ├── mod.rs
-│       ├── map.rs                  # Field mapping codegen
-│       ├── regex.rs                # Regex codegen
-│       ├── template.rs             # Jinja codegen
-│       └── lookup.rs               # Translation table codegen
-└── templates/
-    └── transform.rs.tmpl           # Rust code template
-```
-
-## File Organization
-
-### Adding a New Connector
-
-1. Create `crates/weavster-core/src/connectors/{name}.rs`
-2. Implement `Connector` trait
-3. Register in `crates/weavster-core/src/connectors/mod.rs`
-4. Add config parsing in `crates/weavster-core/src/config/connectors.rs`
-5. Add tests in `crates/weavster-core/tests/connectors/{name}.rs`
-6. Document in `docs/docs/concepts/connectors.md`
-
-### Adding a New Transform
-
-1. Create `crates/weavster-core/src/transforms/{name}.rs`
-2. Implement `Transform` trait
-3. Register in transform DSL parser
-4. Add tests with fixture YAML files
-5. Document in `docs/docs/concepts/transforms.md`
 
 ## Dependencies Policy
 
@@ -414,34 +212,6 @@ crates/weavster-codegen/
    - Docker images to GHCR
    - crates.io (future)
    - PyPI via maturin (future)
-
-## Common Tasks
-
-### Running a Single Flow for Testing
-
-```bash
-cargo run -p weavster-cli -- run --flow flows/my_flow.yaml --once
-```
-
-### Debugging Transform Execution
-
-```bash
-RUST_LOG=weavster_core::transforms=debug cargo run -p weavster-cli -- run
-```
-
-### Testing with Real Kafka
-
-```bash
-docker-compose -f docker/docker-compose.test.yml up -d
-cargo test --features integration-tests
-```
-
-### Building Minimal Runtime Image
-
-```bash
-docker build -f docker/Dockerfile.runtime -t weavster-runtime .
-# Results in ~50MB image with just the runtime binary
-```
 
 ## Troubleshooting
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Weavster is a developer-friendly tool for building real-time data transformation
 
 ```bash
 # Install
-curl -fsSL https://weavster.io/install.sh | sh
+curl -fsSL https://weavster.dev/install.sh | sh
 
 # Create a project
 weavster init my-project
@@ -78,21 +78,21 @@ outputs:
 
 ### Transforms
 
-| Transform | Description |
-|-----------|-------------|
-| `rename` | Rename fields |
-| `add_fields` | Add static or computed fields |
-| `compute` | Calculate new values with expressions |
-| `filter` | Include/exclude messages |
-| `drop_fields` | Remove fields |
-| `coalesce` | Use first non-null value |
+| Transform     | Description                           |
+| ------------- | ------------------------------------- |
+| `rename`      | Rename fields                         |
+| `add_fields`  | Add static or computed fields         |
+| `compute`     | Calculate new values with expressions |
+| `filter`      | Include/exclude messages              |
+| `drop_fields` | Remove fields                         |
+| `coalesce`    | Use first non-null value              |
 
 ### Runtime Modes
 
-| Mode | Use Case | Backend |
-|------|----------|---------|
-| Local | Development | Embedded PostgreSQL |
-| Remote | Production | External Postgres + Redis |
+| Mode   | Use Case    | Backend                   |
+| ------ | ----------- | ------------------------- |
+| Local  | Development | Embedded PostgreSQL       |
+| Remote | Production  | External Postgres + Redis |
 
 ## Development
 
@@ -132,12 +132,14 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines.
 Weavster is licensed under the [Business Source License 1.1](LICENSE) (BSL 1.1).
 
 **What this means:**
+
 - **Free for most uses**: You can use, modify, and distribute Weavster for any purpose that doesn't compete with our paid offerings
 - **Source available**: Full source code is always available
 - **Converts to open source**: Each version automatically converts to [MPL 2.0](https://www.mozilla.org/en-US/MPL/2.0/) after 4 years
 - **Free products exempt**: Products offered free of charge are never considered competitive
 
 **Not permitted** without a commercial license:
+
 - Offering Weavster as a hosted service that competes with Weavster Dev's paid products
 - Embedding Weavster in a competing commercial product
 

--- a/plans/architecture-and-design.md
+++ b/plans/architecture-and-design.md
@@ -1,0 +1,201 @@
+# Weavster Architecture & Design Plan
+
+This document captures the planned architecture, design decisions, and future features for Weavster. These may evolve as implementation progresses.
+
+## Core Concepts
+
+- **Project**: Collection of flows organized in a directory with `weavster.yaml`
+- **Flow**: 1 input → N outputs with transforms in between
+- **Connector**: Input/Output adapter (Kafka, Postgres, HTTP, File, etc.)
+- **Bridge**: Special connector linking flows together
+- **Transform**: Data manipulation (rename, filter, compute, etc.)
+
+## Transform Pipeline
+
+```
+YAML Config → Parse → Rust Codegen → WASM Compile → Execute (wasmtime)
+```
+
+**All transforms compile to WASM.** The YAML transform DSL is parsed and translated
+into Rust code, which is then compiled to WASM. This provides:
+
+- **Sandboxed execution** - Transforms can't escape the WASM sandbox
+- **Portable artifacts** - Same WASM runs anywhere wasmtime runs
+- **Supply chain security** - OCI artifacts can be signed and verified
+
+Transform types:
+- **Simple mappings** - Direct field assignments (zero overhead)
+- **Regex** - Pattern matching via `regex` crate compiled into WASM
+- **Jinja templates** - `minijinja` compiled into WASM
+- **Lookups** - Translation tables embedded as `phf` static maps
+
+## Local Development Runtime
+
+```
+weavster run
+    │
+    ├── Start postgresql_embedded (if local mode)
+    ├── Run migrations (apalis tables)
+    ├── Parse weavster.yaml + flows/*.yaml
+    ├── Render Jinja templates
+    ├── Start connector workers
+    └── Process messages through flows
+```
+
+## Configuration Hierarchy
+
+```
+weavster.yaml           # Project config, runtime settings
+├── flows/
+│   ├── flow_a.yaml     # Individual flow definitions
+│   └── flow_b.yaml
+├── connectors/
+│   └── kafka.yaml      # Reusable connector configs
+└── profiles.yaml       # Environment-specific overrides (like dbt)
+```
+
+## Key Design Decisions
+
+### Why Rust?
+- Single binary distribution (like dbt)
+- Memory safety without GC
+- Excellent WASM compilation (both host and target)
+- PyO3 for Python bindings
+- Performance for real-time processing
+
+### Why WASM for all transforms?
+- Security: Sandboxed execution, no escape to host
+- Portability: Same binary runs anywhere
+- Supply chain: OCI artifacts can be signed
+- Performance: Near-native speed via wasmtime
+- Embedding: regex, minijinja, phf all compile cleanly to WASM
+
+### Why OCI for packaging?
+- Industry standard for artifact distribution
+- Signing via cosign/sigstore
+- No OS attack surface (FROM scratch)
+- Works with existing registry infrastructure
+- Versioning and immutability built-in
+
+### Why postgresql_embedded?
+- Zero-config local development
+- Same semantics as production Postgres
+- No Docker required for local dev
+- Bundled feature includes PG in binary
+
+### Why apalis for job queue?
+- Native Postgres support (matches our embedded story)
+- Async-native (tokio)
+- Can swap to Redis for distributed deployments
+
+### Why MiniJinja?
+- Created by Armin Ronacher (Flask/Jinja creator)
+- Familiar to dbt users
+- Pure Rust, compiles to WASM
+- No Python dependency
+
+## Compile & Package Pipeline
+
+### Transform Compilation
+
+```bash
+weavster compile                    # YAML → Rust → WASM for all flows
+weavster compile --flow myflow      # Single flow
+weavster compile --debug            # Output generated Rust for inspection
+```
+
+The compile process:
+1. Parse `flows/*.yaml` and `weavster.yaml`
+2. For each flow, generate Rust source code
+3. Embed artifacts (translation tables, regex patterns) as static data
+4. Compile to `wasm32-wasi` target
+5. Cache in `.weavster/cache/`
+
+### OCI Packaging
+
+```bash
+weavster package                    # Create OCI artifact
+weavster package --sign             # Create and sign with cosign
+weavster push <registry>            # Push to OCI registry
+weavster pull <registry>            # Pull from registry
+```
+
+OCI artifact structure (FROM scratch - no OS):
+```
+manifest.json
+├── flow.wasm                       # Compiled transform
+├── config/
+│   └── flow.yaml                   # Original config (reference)
+├── artifacts/
+│   ├── translations/*.csv          # Lookup tables
+│   └── patterns/*.json             # Regex patterns
+└── signatures/
+    └── cosign.sig                  # Optional signature
+```
+
+### Codegen Architecture
+
+```
+crates/weavster-codegen/
+├── src/
+│   ├── lib.rs                      # Public API
+│   ├── parser.rs                   # YAML → IR
+│   ├── ir.rs                       # Intermediate representation
+│   ├── generator.rs                # IR → Rust source
+│   ├── compiler.rs                 # Rust → WASM
+│   └── transforms/
+│       ├── mod.rs
+│       ├── map.rs                  # Field mapping codegen
+│       ├── regex.rs                # Regex codegen
+│       ├── template.rs             # Jinja codegen
+│       └── lookup.rs               # Translation table codegen
+└── templates/
+    └── transform.rs.tmpl           # Rust code template
+```
+
+## File Organization
+
+### Adding a New Connector
+
+1. Create `crates/weavster-core/src/connectors/{name}.rs`
+2. Implement `Connector` trait
+3. Register in `crates/weavster-core/src/connectors/mod.rs`
+4. Add config parsing in `crates/weavster-core/src/config/connectors.rs`
+5. Add tests in `crates/weavster-core/tests/connectors/{name}.rs`
+6. Document in `docs/docs/concepts/connectors.md`
+
+### Adding a New Transform
+
+1. Create `crates/weavster-core/src/transforms/{name}.rs`
+2. Implement `Transform` trait
+3. Register in transform DSL parser
+4. Add tests with fixture YAML files
+5. Document in `docs/docs/concepts/transforms.md`
+
+## Planned CLI Commands
+
+### Running a Single Flow for Testing
+
+```bash
+cargo run -p weavster-cli -- run --flow flows/my_flow.yaml --once
+```
+
+### Debugging Transform Execution
+
+```bash
+RUST_LOG=weavster_core::transforms=debug cargo run -p weavster-cli -- run
+```
+
+### Testing with Real Kafka
+
+```bash
+docker-compose -f docker/docker-compose.test.yml up -d
+cargo test --features integration-tests
+```
+
+### Building Minimal Runtime Image
+
+```bash
+docker build -f docker/Dockerfile.runtime -t weavster-runtime .
+# Results in ~50MB image with just the runtime binary
+```


### PR DESCRIPTION
## Summary
- Move architecture, design decisions, and planned features from CLAUDE.md to `plans/architecture-and-design.md`
- Keep CLAUDE.md focused on coding guidance: build commands, standards, error handling, testing, CI, dependencies
- Fix workspace table: add `weavster-codegen` (exists), remove `weavster-python` (doesn't exist)
- Condense documentation site section to essentials
- Remove "Update CHANGELOG.md" instruction (changelog is auto-generated by git-cliff)

🤖 Generated with [Claude Code](https://claude.com/claude-code)