### PR TITLE
chore: add VS Code workspace config and editor tooling

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -15,13 +15,29 @@
           {
             "type": "command",
             "command": "jq -r '.tool_input.file_path // .tool_input.path // empty' | { read file_path; if [ -n \"$file_path\" ] && echo \"$file_path\" | grep -qE '\\.(yaml|yml)$'; then prettier --write \"$file_path\" 2>/dev/null || true; fi; }"
+          },
+          {
+            "type": "command",
+            "command": "jq -r '.tool_input.file_path // .tool_input.path // empty' | { read file_path; if [ -n \"$file_path\" ] && echo \"$file_path\" | grep -qE '\\.(md|json|jsonc)$'; then prettier --write \"$file_path\" 2>/dev/null || true; fi; }"
+          }
+        ]
+      }
+    ],
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "echo \"$TOOL_INPUT\" | jq -r '.command // empty' | { read cmd; if echo \"$cmd\" | grep -qE '^(cargo test|cargo build|cargo run)'; then echo '⚙️  Running Rust command...' >&2; fi; }"
           }
         ]
       }
     ]
   },
   "enabledPlugins": {
-    "rust-analyzer-lsp@claude-plugins-official": true
+    "rust-analyzer-lsp@claude-plugins-official": true,
+    "ralph-loop@claude-plugins-official": true
   },
   "pluginMarketplaces": [
     "https://github.com/anthropics/claude-plugins-official.git"

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,34 @@
+# EditorConfig is awesome: https://EditorConfig.org
+
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.rs]
+indent_style = space
+indent_size = 4
+max_line_length = 100
+
+[*.toml]
+indent_style = space
+indent_size = 2
+
+[*.{yaml,yml}]
+indent_style = space
+indent_size = 2
+
+[*.{json,jsonc}]
+indent_style = space
+indent_size = 2
+
+[*.md]
+indent_style = space
+indent_size = 2
+trim_trailing_whitespace = false
+
+[Makefile]
+indent_style = tab

--- a/.gitignore
+++ b/.gitignore
@@ -9,7 +9,12 @@ docs/node_modules/
 
 # IDE
 .idea/
-.vscode/
+# Allow VSCode config files (team-shared)
+.vscode/*
+!.vscode/settings.json
+!.vscode/extensions.json
+!.vscode/launch.json
+!.vscode/tasks.json
 *.swp
 *.swo
 *~

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,0 +1,28 @@
+{
+  "printWidth": 100,
+  "tabWidth": 2,
+  "useTabs": false,
+  "semi": true,
+  "singleQuote": false,
+  "quoteProps": "as-needed",
+  "trailingComma": "es5",
+  "bracketSpacing": true,
+  "arrowParens": "always",
+  "proseWrap": "preserve",
+  "endOfLine": "lf",
+  "overrides": [
+    {
+      "files": "*.yaml",
+      "options": {
+        "printWidth": 80
+      }
+    },
+    {
+      "files": "*.md",
+      "options": {
+        "proseWrap": "always",
+        "printWidth": 80
+      }
+    }
+  ]
+}

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,29 @@
+{
+  "recommendations": [
+    // Rust Development
+    "rust-lang.rust-analyzer",
+    "vadimcn.vscode-lldb",
+    "dustypomerleau.rust-syntax",
+    "serayuzgur.crates",
+
+    // File Format Support
+    "tamasfe.even-better-toml",
+    "redhat.vscode-yaml",
+    "esbenp.prettier-vscode",
+
+    // Code Quality & Utilities
+    "usernamehw.errorlens",
+    "streetsidesoftware.code-spell-checker",
+    "editorconfig.editorconfig",
+
+    // Git
+    "eamodio.gitlens",
+
+    // Testing
+    "swellaby.vscode-rust-test-adapter",
+
+    // Documentation
+    "yzhang.markdown-all-in-one"
+  ],
+  "unwantedRecommendations": []
+}

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,84 @@
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "type": "lldb",
+      "request": "launch",
+      "name": "Debug unit tests in library 'weavster-core'",
+      "cargo": {
+        "args": [
+          "test",
+          "--no-run",
+          "--lib",
+          "--package=weavster-core"
+        ],
+        "filter": {
+          "name": "weavster-core",
+          "kind": "lib"
+        }
+      },
+      "args": [],
+      "cwd": "${workspaceFolder}"
+    },
+    {
+      "type": "lldb",
+      "request": "launch",
+      "name": "Debug executable 'weavster'",
+      "cargo": {
+        "args": [
+          "build",
+          "--bin=weavster",
+          "--package=weavster-cli"
+        ],
+        "filter": {
+          "name": "weavster",
+          "kind": "bin"
+        }
+      },
+      "args": [],
+      "cwd": "${workspaceFolder}"
+    },
+    {
+      "type": "lldb",
+      "request": "launch",
+      "name": "Debug 'weavster run'",
+      "cargo": {
+        "args": [
+          "build",
+          "--bin=weavster",
+          "--package=weavster-cli"
+        ],
+        "filter": {
+          "name": "weavster",
+          "kind": "bin"
+        }
+      },
+      "args": [
+        "run",
+        "--once"
+      ],
+      "cwd": "${workspaceFolder}"
+    },
+    {
+      "type": "lldb",
+      "request": "launch",
+      "name": "Debug 'weavster init'",
+      "cargo": {
+        "args": [
+          "build",
+          "--bin=weavster",
+          "--package=weavster-cli"
+        ],
+        "filter": {
+          "name": "weavster",
+          "kind": "bin"
+        }
+      },
+      "args": [
+        "init",
+        "."
+      ],
+      "cwd": "${workspaceFolder}/test-project"
+    }
+  ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,200 @@
+{
+  // ============================================
+  // Rust-Analyzer Configuration
+  // ============================================
+  "rust-analyzer.check.command": "clippy",
+  "rust-analyzer.check.extraArgs": [
+    "--",
+    "-D",
+    "warnings"
+  ],
+  "rust-analyzer.cargo.features": "all",
+  "rust-analyzer.workspace.symbol.search.scope": "workspace_and_dependencies",
+  "rust-analyzer.lens.enable": true,
+  "rust-analyzer.lens.implementations.enable": true,
+  "rust-analyzer.lens.references.adt.enable": true,
+  "rust-analyzer.lens.references.enumVariant.enable": true,
+  "rust-analyzer.lens.references.method.enable": true,
+  "rust-analyzer.lens.references.trait.enable": true,
+  "rust-analyzer.inlayHints.typeHints.enable": true,
+  "rust-analyzer.inlayHints.parameterHints.enable": true,
+  "rust-analyzer.inlayHints.chainingHints.enable": true,
+
+  // ============================================
+  // Editor Settings
+  // ============================================
+  "editor.formatOnSave": true,
+  "editor.rulers": [
+    100
+  ],
+  "editor.bracketPairColorization.enabled": true,
+  "editor.guides.bracketPairs": true,
+  "editor.semanticHighlighting.enabled": true,
+  "editor.linkedEditing": true,
+  "editor.codeActionsOnSave": {
+    "source.fixAll": "explicit",
+    "source.organizeImports": "explicit"
+  },
+
+  // ============================================
+  // File Settings
+  // ============================================
+  "files.insertFinalNewline": true,
+  "files.trimTrailingWhitespace": true,
+  "files.trimFinalNewlines": true,
+  "files.associations": {
+    "*.yaml": "yaml",
+    "*.yml": "yaml",
+    "CLAUDE.md": "markdown"
+  },
+  "files.exclude": {
+    "**/.git": true,
+    "**/target": true,
+    "**/.weavster": true,
+    "**/node_modules": true,
+    "**/.docusaurus": true
+  },
+
+  // ============================================
+  // Language-Specific Settings
+  // ============================================
+  "[rust]": {
+    "editor.defaultFormatter": "rust-lang.rust-analyzer",
+    "editor.formatOnSave": true,
+    "editor.tabSize": 4,
+    "editor.insertSpaces": true
+  },
+  "[toml]": {
+    "editor.defaultFormatter": "tamasfe.even-better-toml",
+    "editor.formatOnSave": true,
+    "editor.tabSize": 2,
+    "editor.insertSpaces": true
+  },
+  "[yaml]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode",
+    "editor.formatOnSave": true,
+    "editor.tabSize": 2,
+    "editor.insertSpaces": true
+  },
+  "[markdown]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode",
+    "editor.formatOnSave": true,
+    "editor.tabSize": 2,
+    "editor.insertSpaces": true,
+    "editor.wordWrap": "on"
+  },
+  "[json]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode",
+    "editor.formatOnSave": true,
+    "editor.tabSize": 2,
+    "editor.insertSpaces": true
+  },
+  "[jsonc]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode",
+    "editor.formatOnSave": true,
+    "editor.tabSize": 2,
+    "editor.insertSpaces": true
+  },
+
+  // ============================================
+  // YAML Schema Association
+  // ============================================
+  "yaml.schemas": {
+    "./schemas/weavster.schema.json": [
+      "weavster.yaml",
+      "weavster.yml"
+    ],
+    "./schemas/flow.schema.json": [
+      "flows/*.yaml",
+      "flows/*.yml"
+    ]
+  },
+  "yaml.format.enable": true,
+  "yaml.validate": true,
+
+  // ============================================
+  // Search & Explorer
+  // ============================================
+  "search.exclude": {
+    "**/target": true,
+    "**/node_modules": true,
+    "**/.weavster": true,
+    "**/docs/build": true,
+    "**/docs/.docusaurus": true
+  },
+  "explorer.fileNesting.enabled": true,
+  "explorer.fileNesting.patterns": {
+    "Cargo.toml": "Cargo.lock, rust-toolchain.toml, rustfmt.toml, .rustfmt.toml",
+    "package.json": "package-lock.json, yarn.lock, pnpm-lock.yaml",
+    "README.md": "CLAUDE.md, CHANGELOG.md, CONTRIBUTING.md, LICENSE*"
+  },
+
+  // ============================================
+  // Terminal
+  // ============================================
+  "terminal.integrated.env.osx": {
+    "RUST_BACKTRACE": "1"
+  },
+  "terminal.integrated.env.linux": {
+    "RUST_BACKTRACE": "1"
+  },
+
+  // ============================================
+  // Testing
+  // ============================================
+  "rust-analyzer.runnables.command": "cargo",
+
+  // ============================================
+  // Error Lens (if installed)
+  // ============================================
+  "errorLens.enabledDiagnosticLevels": [
+    "error",
+    "warning"
+  ],
+  "errorLens.excludeBySource": [
+    "cSpell"
+  ],
+
+  // ============================================
+  // Spell Checker
+  // ============================================
+  "cSpell.words": [
+    "weavster",
+    "apalis",
+    "minijinja",
+    "WASI",
+    "WASM",
+    "wasmtime",
+    "postgresql",
+    "sqlx",
+    "tokio",
+    "serde",
+    "thiserror",
+    "anyhow",
+    "clap",
+    "rstest",
+    "testcontainers",
+    "taplo",
+    "docusaurus",
+    "YAGNI",
+    "phf",
+    "oras"
+  ],
+  "cSpell.enableFiletypes": [
+    "rust",
+    "toml",
+    "yaml"
+  ],
+
+  // ============================================
+  // Git
+  // ============================================
+  "gitlens.codeLens.enabled": false,
+  "gitlens.currentLine.enabled": false,
+
+  // ============================================
+  // Prettier
+  // ============================================
+  "prettier.configPath": ".prettierrc.json",
+  "prettier.requireConfig": false
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,98 @@
+{
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "label": "cargo build",
+      "type": "shell",
+      "command": "cargo",
+      "args": [
+        "build"
+      ],
+      "group": "build",
+      "presentation": {
+        "reveal": "always",
+        "panel": "new"
+      },
+      "problemMatcher": "$rustc"
+    },
+    {
+      "label": "cargo test",
+      "type": "shell",
+      "command": "cargo",
+      "args": [
+        "test"
+      ],
+      "group": {
+        "kind": "test",
+        "isDefault": true
+      },
+      "presentation": {
+        "reveal": "always",
+        "panel": "new"
+      },
+      "problemMatcher": "$rustc"
+    },
+    {
+      "label": "cargo clippy",
+      "type": "shell",
+      "command": "cargo",
+      "args": [
+        "clippy",
+        "--",
+        "-D",
+        "warnings"
+      ],
+      "group": "build",
+      "presentation": {
+        "reveal": "always",
+        "panel": "new"
+      },
+      "problemMatcher": "$rustc"
+    },
+    {
+      "label": "cargo fmt",
+      "type": "shell",
+      "command": "cargo",
+      "args": [
+        "fmt"
+      ],
+      "group": "build",
+      "presentation": {
+        "reveal": "silent",
+        "panel": "shared"
+      }
+    },
+    {
+      "label": "cargo check",
+      "type": "shell",
+      "command": "cargo",
+      "args": [
+        "check",
+        "--workspace"
+      ],
+      "group": "build",
+      "presentation": {
+        "reveal": "always",
+        "panel": "new"
+      },
+      "problemMatcher": "$rustc"
+    },
+    {
+      "label": "Pre-commit checks",
+      "dependsOn": [
+        "cargo fmt",
+        "cargo clippy",
+        "cargo test"
+      ],
+      "dependsOrder": "sequence",
+      "group": {
+        "kind": "build",
+        "isDefault": true
+      },
+      "presentation": {
+        "reveal": "always",
+        "panel": "new"
+      }
+    }
+  ]
+}

--- a/VSCODE_SETUP.md
+++ b/VSCODE_SETUP.md
@@ -1,0 +1,190 @@
+# VSCode Setup Complete ✨
+
+Your VSCode environment is now optimized for Rust development with Claude Code!
+
+## What Was Configured
+
+### 1. Extensions ([.vscode/extensions.json](/.vscode/extensions.json))
+
+**Essential:**
+- `rust-lang.rust-analyzer` - Rust language server
+- `vadimcn.vscode-lldb` - Debugger for Rust
+
+**Code Quality:**
+- `tamasfe.even-better-toml` - TOML support
+- `redhat.vscode-yaml` - YAML validation
+- `esbenp.prettier-vscode` - Auto-formatting
+- `usernamehw.errorlens` - Inline error display
+- `serayuzgur.crates` - Dependency management
+
+**Utilities:**
+- `editorconfig.editorconfig` - Editor consistency
+- `eamodio.gitlens` - Git enhancements
+- `streetsidesoftware.code-spell-checker` - Spell checking
+- `yzhang.markdown-all-in-one` - Markdown support
+
+### 2. Workspace Settings ([.vscode/settings.json](/.vscode/settings.json))
+
+**Rust-Analyzer:**
+- Runs `cargo clippy -- -D warnings` on check
+- Enables all workspace features
+- Shows inlay hints for types and parameters
+- Displays code lens for references and implementations
+
+**Auto-Formatting:**
+- `*.rs` → `cargo fmt`
+- `*.toml` → `taplo`
+- `*.yaml`, `*.yml` → `prettier`
+- `*.md`, `*.json` → `prettier`
+
+**Editor:**
+- 100-character ruler for Rust
+- Bracket colorization enabled
+- Trim trailing whitespace
+- Insert final newline
+
+**File Nesting:**
+- Groups related files in explorer
+- `Cargo.toml` shows `Cargo.lock`, etc.
+
+### 3. Debug Configurations ([.vscode/launch.json](/.vscode/launch.json))
+
+- Debug unit tests in `weavster-core`
+- Debug CLI executable
+- Debug `weavster run --once`
+- Debug `weavster init`
+
+### 4. Tasks ([.vscode/tasks.json](/.vscode/tasks.json))
+
+- `cargo build`
+- `cargo test` (default test task)
+- `cargo clippy`
+- `cargo fmt`
+- `cargo check`
+- **Pre-commit checks** (runs fmt, clippy, test sequentially)
+
+### 5. Claude Code Hooks ([.claude/settings.json](/.claude/settings.json))
+
+**PostToolUse Hooks:**
+- Auto-format Rust files with `cargo fmt`
+- Auto-format TOML files with `taplo`
+- Auto-format YAML files with `prettier`
+- Auto-format Markdown/JSON files with `prettier`
+
+**Enabled Plugins:**
+- `rust-analyzer-lsp` - LSP integration
+- `ralph-loop` - Iterative workflow
+
+### 6. Additional Configuration
+
+- [.prettierrc.json](/.prettierrc.json) - Prettier settings
+- [.editorconfig](/.editorconfig) - Editor consistency across IDEs
+- [.vscode/README.md](/.vscode/README.md) - Detailed setup guide
+- [.gitignore](/.gitignore) - Updated to allow VSCode configs
+
+## Quick Start
+
+### 1. Install Extensions
+
+```
+Cmd+Shift+P → "Extensions: Show Recommended Extensions" → Install All
+```
+
+### 2. Install Required Tools
+
+```bash
+# Update Rust
+rustup update
+rustup component add rust-analyzer rustfmt clippy
+
+# Install TOML formatter
+cargo install taplo-cli --locked
+
+# Install Prettier (requires Node.js)
+npm install -g prettier
+```
+
+### 3. Verify Setup
+
+```bash
+cargo build
+cargo test
+cargo clippy -- -D warnings
+```
+
+## Key Features
+
+### Format on Save
+All files auto-format when you save (Cmd+S / Ctrl+S)
+
+### Inline Errors
+Error Lens shows Clippy warnings and errors directly in your code
+
+### Code Actions
+Press `Cmd+.` / `Ctrl+.` on any code to see available quick fixes
+
+### Debug with Breakpoints
+1. Click gutter to set breakpoint
+2. Press `F5` to start debugging
+3. Use debug toolbar to step through
+
+### Run Tasks
+Press `Cmd+Shift+B` / `Ctrl+Shift+B` to run the default build task
+
+### Smart Code Completion
+rust-analyzer provides:
+- Auto-complete
+- Go to definition (F12)
+- Find references (Shift+F12)
+- Inline type hints
+- Documentation on hover
+
+## Claude Code Integration
+
+When Claude Code edits files, they're automatically formatted via hooks:
+
+```
+Edit .rs file → cargo fmt runs automatically
+Edit .toml file → taplo fmt runs automatically
+Edit .yaml file → prettier runs automatically
+```
+
+This ensures consistent formatting across all Claude Code changes!
+
+## Keyboard Shortcuts
+
+| Action | macOS | Windows/Linux |
+|--------|-------|---------------|
+| Quick Open File | Cmd+P | Ctrl+P |
+| Command Palette | Cmd+Shift+P | Ctrl+Shift+P |
+| Go to Definition | F12 | F12 |
+| Find References | Shift+F12 | Shift+F12 |
+| Quick Fix | Cmd+. | Ctrl+. |
+| Start Debug | F5 | F5 |
+| Build Task | Cmd+Shift+B | Ctrl+Shift+B |
+| Toggle Terminal | Cmd+J | Ctrl+J |
+
+## Troubleshooting
+
+### Extensions Not Installing?
+Open Command Palette → "Extensions: Show Recommended Extensions"
+
+### Format on Save Not Working?
+1. Check formatters are installed: `cargo fmt --version`, `taplo --version`, `prettier --version`
+2. Reload window: Cmd+Shift+P → "Developer: Reload Window"
+
+### rust-analyzer Issues?
+1. Check output: View → Output → Select "rust-analyzer"
+2. Reinstall: `rustup component add rust-analyzer`
+3. Reload VSCode
+
+## Next Steps
+
+✅ Install recommended extensions
+✅ Install required tools (taplo, prettier)
+✅ Run `cargo build && cargo test`
+✅ Start coding with auto-formatting and inline errors!
+
+---
+
+📖 For more details, see [.vscode/README.md](.vscode/README.md)


### PR DESCRIPTION
## Summary

- Add team-shared VS Code configuration (settings, extensions, launch configs, tasks) optimized for Rust development with rust-analyzer, CodeLLDB debugging, and format-on-save
- Add EditorConfig and Prettier config for consistent formatting across editors
- Update `.gitignore` to allow specific `.vscode/` config files while excluding the rest
- Add Claude Code hooks for auto-formatting markdown/JSON files and enable ralph-loop plugin

🤖 Generated with [Claude Code](https://claude.com/claude-code)