### PR TITLE
chore: replace embedded Postgres references with SQLite

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -113,7 +113,7 @@ jobs:
             Generate a release name and summary for Weavster version ${{ needs.validate.outputs.version }}.
 
             Weavster is a modern Enterprise Service Bus - like dbt but for real-time transactions.
-            Built with Rust, WASM sandboxing, and embedded PostgreSQL.
+            Built with Rust, WASM sandboxing, and SQLite.
 
             Get the commits since the last release:
             ```bash

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Weavster is a developer-friendly tool for building real-time data transformation
 
 - **YAML Configuration**: Define flows, transforms, and connectors in simple YAML
 - **Jinja Templating**: Use familiar Jinja syntax for dynamic configuration
-- **Zero-Config Local Dev**: Embedded PostgreSQL - just run `weavster run`
+- **Zero-Config Local Dev**: SQLite - just run `weavster run`
 - **Single Binary**: No dependencies to install
 
 ## Quick Start
@@ -102,7 +102,7 @@ outputs:
 
 | Mode   | Use Case    | Backend                   |
 | ------ | ----------- | ------------------------- |
-| Local  | Development | Embedded PostgreSQL       |
+| Local  | Development | SQLite       |
 | Remote | Production  | External Postgres + Redis |
 
 ## Development

--- a/crates/weavster-cli/src/commands/init.rs
+++ b/crates/weavster-cli/src/commands/init.rs
@@ -51,7 +51,6 @@ runtime:
   mode: local
   local:
     data_dir: ".weavster/data"
-    port: 5433
 
 # Global variables available in Jinja templates
 vars:

--- a/crates/weavster-core/src/config.rs
+++ b/crates/weavster-core/src/config.rs
@@ -132,7 +132,7 @@ pub struct RuntimeConfig {
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, Default, PartialEq, Eq)]
 #[serde(rename_all = "lowercase")]
 pub enum RuntimeMode {
-    /// Local mode with embedded PostgreSQL
+    /// Local mode with SQLite
     #[default]
     Local,
     /// Remote mode connecting to external services
@@ -142,30 +142,21 @@ pub enum RuntimeMode {
 /// Local runtime configuration
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct LocalConfig {
-    /// Directory for local data (embedded Postgres, caches)
+    /// Directory for local data (SQLite, caches)
     #[serde(default = "default_data_dir")]
     pub data_dir: String,
-
-    /// Port for embedded PostgreSQL
-    #[serde(default = "default_pg_port")]
-    pub port: u16,
 }
 
 impl Default for LocalConfig {
     fn default() -> Self {
         Self {
             data_dir: default_data_dir(),
-            port: default_pg_port(),
         }
     }
 }
 
 fn default_data_dir() -> String {
     ".weavster/data".to_string()
-}
-
-fn default_pg_port() -> u16 {
-    5433 // Avoid conflict with system Postgres on 5432
 }
 
 /// Remote runtime configuration
@@ -1144,7 +1135,6 @@ runtime:
   mode: local
   local:
     data_dir: ".data"
-    port: 5434
 vars:
   environment: production
 "#;
@@ -1152,7 +1142,6 @@ vars:
         assert_eq!(config.name, "test-project");
         assert_eq!(config.version, "1.0.0");
         assert_eq!(config.runtime.mode, RuntimeMode::Local);
-        assert_eq!(config.runtime.local.port, 5434);
     }
 
     #[test]

--- a/crates/weavster-core/tests/config_integration_test.rs
+++ b/crates/weavster-core/tests/config_integration_test.rs
@@ -359,7 +359,6 @@ vars:
 runtime:
   mode: local
   local:
-    port: 5433
 profiles:
   minimal:
     vars:
@@ -387,7 +386,6 @@ profiles:
         resolved.runtime.mode,
         weavster_core::config::RuntimeMode::Local
     );
-    assert_eq!(resolved.runtime.local.port, 5433);
 }
 
 // =============================================================================

--- a/crates/weavster-runtime/src/engine.rs
+++ b/crates/weavster-runtime/src/engine.rs
@@ -293,7 +293,6 @@ mod tests {
                     mode: RuntimeMode::Local,
                     local: LocalConfig {
                         data_dir: ".weavster/data".to_string(),
-                        port: 5433,
                     },
                     remote: Default::default(),
                 },

--- a/docs/docs/configuration/project.md
+++ b/docs/docs/configuration/project.md
@@ -17,9 +17,8 @@ runtime:
   workers: 4
   log_level: info
 
-# Database (optional - uses embedded by default)
+# Database (optional - uses SQLite by default)
 database:
-  embedded: true
   # Or connect to external:
   # url: postgres://user:pass@host:5432/db
 ```
@@ -44,7 +43,6 @@ database:
 
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
-| `database.embedded` | bool | true | Use embedded PostgreSQL |
 | `database.url` | string | - | External database URL |
 
 ## Environment Variables
@@ -61,10 +59,6 @@ database:
 Use `profiles.yaml` for environment-specific overrides (similar to dbt):
 
 ```yaml title="profiles.yaml"
-development:
-  database:
-    embedded: true
-
 production:
   database:
     url: ${DATABASE_URL}

--- a/docs/docs/getting-started/first-flow.md
+++ b/docs/docs/getting-started/first-flow.md
@@ -54,7 +54,7 @@ weavster run
 ```
 
 Weavster will:
-1. Start an embedded PostgreSQL instance (for job queue)
+1. Start an SQLite database (for job queue)
 2. Load your flow configuration
 3. Process data from input through transforms to output
 

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -12,7 +12,7 @@ Weavster is a developer-friendly tool for building real-time data transformation
 
 - **dbt-like DX** - YAML configuration, Jinja templating, simple CLI
 - **Real-time focus** - FIFO queues, not batch processing
-- **Zero-config local dev** - Embedded PostgreSQL, single binary distribution
+- **Zero-config local dev** - SQLite, single binary distribution
 - **Safe transforms** - WASM sandboxing for untrusted code
 
 ## Quick Start
@@ -25,7 +25,7 @@ cargo install weavster-cli
 weavster init my-project
 cd my-project
 
-# Run locally with embedded Postgres
+# Run locally with SQLite
 weavster run
 ```
 

--- a/wf-changelog.md
+++ b/wf-changelog.md
@@ -1,0 +1,1 @@
+Replaced embedded Postgres references with SQLite


### PR DESCRIPTION
This commit updates all references from "Embedded PostgreSQL" and "embedded Postgres" to "SQLite" across the codebase documentation, configs, and Rust source code. Since SQLite is used, the port configuration for the Local runtime mode has been removed as it is no longer necessary.

---
*PR created automatically by Jules for task [16915901058387688889](https://jules.google.com/task/16915901058387688889) started by @gregoryhunt*