### PR TITLE
🔒 Fix potential panic in package command

### DIFF
--- a/crates/weavster-cli/src/commands/package.rs
+++ b/crates/weavster-cli/src/commands/package.rs
@@ -48,10 +48,7 @@ pub async fn run(
         let entry = entry?;
         let path = entry.path();
         if path.extension().is_some_and(|ext| ext == "wasm") {
-            let file_name = path
-                .file_name()
-                .context("Failed to get file name from path")?;
-            let dest = wasm_dir.join(file_name);
+            let dest = wasm_dir.join(entry.file_name());
             std::fs::copy(&path, &dest)?;
             tracing::debug!("Copied {}", path.display());
         }

--- a/crates/weavster-cli/src/commands/package.rs
+++ b/crates/weavster-cli/src/commands/package.rs
@@ -48,7 +48,10 @@ pub async fn run(
         let entry = entry?;
         let path = entry.path();
         if path.extension().is_some_and(|ext| ext == "wasm") {
-            let dest = wasm_dir.join(path.file_name().unwrap());
+            let file_name = path
+                .file_name()
+                .context("Failed to get file name from path")?;
+            let dest = wasm_dir.join(file_name);
             std::fs::copy(&path, &dest)?;
             tracing::debug!("Copied {}", path.display());
         }


### PR DESCRIPTION
This PR replaces a call to .unwrap() on the result of path.file_name() in the package command with safe error handling using .context()? from anyhow. This prevents a potential panic and provides a more helpful error message if the file name cannot be retrieved from the path.

---
*PR created automatically by Jules for task [4571979528639686886](https://jules.google.com/task/4571979528639686886) started by @gregoryhunt*