### PR TITLE
docs: clean up SQLite local runtime config

### DIFF
--- a/.spektacular/plans/20260502160602-sqlite-local-runtime-docs-cleanup/context.md
+++ b/.spektacular/plans/20260502160602-sqlite-local-runtime-docs-cleanup/context.md
@@ -1,0 +1,61 @@
+# Context: 20260502160602-sqlite-local-runtime-docs-cleanup
+
+## Current State Analysis
+
+Current main already documents SQLite as the local state store in the README and docs, but a focused scan still finds stale or misleading local-runtime remnants:
+
+- `crates/weavster-core/src/config.rs:135` — `RuntimeMode::Local` comment still says embedded PostgreSQL.
+- `crates/weavster-core/src/config.rs:145` — `LocalConfig.data_dir` comment still says embedded Postgres.
+- `crates/weavster-core/src/config.rs:149` — `LocalConfig.port` comment still says port for embedded PostgreSQL.
+- `crates/weavster-core/src/config.rs:167` — `default_pg_port` helper name and comment preserve the old Postgres framing.
+- `crates/weavster-cli/src/commands/init.rs:54` — generated starter config still writes `runtime.local.port: 5433`.
+- `docs/docs/configuration/project.md:19` — docs example still includes the local port value.
+- `docs/docs/configuration/project.md:49` — docs table currently labels the field as partial and ties it to SQLite-vs-Postgres wording.
+- `crates/weavster-core/src/config.rs:1155` and `crates/weavster-core/tests/config_integration_test.rs:390` — existing tests assert local port values still parse, which is the compatibility behavior this plan preserves.
+
+## Per-Phase Technical Notes
+
+### Phase 1.1: Clean up SQLite local runtime wording
+
+- `crates/weavster-cli/src/commands/init.rs:50` — remove the generated `port: 5433` entry from the default `weavster.yaml` template.
+- `crates/weavster-core/src/config.rs:135` — change local mode comment from embedded PostgreSQL to SQLite-backed local state.
+- `crates/weavster-core/src/config.rs:145` — change local data-dir comment from embedded Postgres to SQLite state and caches.
+- `crates/weavster-core/src/config.rs:149` — change local port comment to compatibility-only wording.
+- `crates/weavster-core/src/config.rs:150` and `crates/weavster-core/src/config.rs:167` — rename `default_pg_port` to a neutral local-port default helper, leaving the default value unchanged.
+- `docs/docs/configuration/project.md:14` — remove `port: 5433` from the recommended project config example.
+- `docs/docs/configuration/project.md:49` — adjust the local port row to describe the field as legacy/compatibility-only rather than part of the local SQLite runtime.
+- `crates/weavster-core/src/config.rs:1140` and `crates/weavster-core/tests/config_integration_test.rs:350` — leave existing tests with local port values intact to prove compatibility.
+
+**Complexity**: Low
+**Token estimate**: ~8k
+**Agent strategy**: Single agent, sequential execution
+
+## Testing Strategy
+
+Run the existing Rust verification suite because the cleanup touches generated config and config comments/helper naming. Existing config tests should continue to cover legacy local port parsing. Add no new tests unless editing the init template exposes an existing CLI test expectation that needs a direct assertion update.
+
+Also run a targeted stale-claim scan across README, docs, and Rust source for embedded PostgreSQL local-runtime claims and local port recommendations.
+
+## Project References
+
+- `.spektacular/specs/20260502160602-sqlite-local-runtime-docs-cleanup.md` — approved scope for this replacement cleanup.
+- `.spektacular/plans/20260428024252-docs-current-vs-planned-alignment/plan.md` — prior docs baseline and status-label model.
+- `https://github.com/weavster-dev/weavster/pull/36` — stale PR being replaced with this narrower current-main cleanup.
+
+## Token Management Strategy
+
+| Tier | Token Budget | Agent Strategy |
+|------|-------------|----------------|
+| Low | ~10k | Single agent, sequential |
+| Medium | ~25k | 2-3 parallel agents |
+| High | ~50k+ | Parallel analysis, sequential integration |
+
+This plan is low-tier because it changes a small set of comments, templates, docs examples, and compatibility-preserving helper names.
+
+## Migration Notes
+
+No migration is required. Existing projects may keep `runtime.local.port`; it remains accepted but is not recommended in new starter projects.
+
+## Performance Considerations
+
+No runtime performance impact is expected. The cleanup does not change state-store selection or execution behavior.

--- a/.spektacular/plans/20260502160602-sqlite-local-runtime-docs-cleanup/plan.md
+++ b/.spektacular/plans/20260502160602-sqlite-local-runtime-docs-cleanup/plan.md
@@ -1,0 +1,98 @@
+# Plan: 20260502160602-sqlite-local-runtime-docs-cleanup
+
+<!-- Metadata -->
+<!-- Created: 2026-05-02T16:08:36Z -->
+<!-- Commit: 6d593fe -->
+<!-- Branch: cleanup-sqlite-local-runtime-docs -->
+<!-- Repository: https://github.com/weavster-dev/weavster.git -->
+
+## Overview
+
+This plan cleans up the remaining local-runtime wording that still implies embedded PostgreSQL is part of the current local development path. Users and contributors should see SQLite as the local state backend, while existing configuration compatibility is preserved.
+
+## Architecture & Design Decisions
+
+The chosen direction is a compatibility-preserving cleanup. We will update generated starter configuration, documentation examples, and source-facing comments so they no longer describe embedded PostgreSQL or an active local service port as part of the SQLite local runtime.
+
+The important trade-off is that this plan does not remove the existing local port config field. That field is still accepted by the config parser and covered by existing tests, so removing it would turn a wording cleanup into a public configuration compatibility change. See `research.md#alternatives-considered-and-rejected` for why removing the field and merging the old stale PR as-is were rejected.
+
+## Component Breakdown
+
+- **Starter project generation** owns the default configuration shown to new users. It should omit unused local runtime port guidance while keeping the generated project otherwise unchanged.
+- **Project configuration model** owns compatibility with existing configuration files. It should keep parsing the local port field but describe it as compatibility-only rather than as embedded PostgreSQL configuration.
+- **Documentation pages** own user-facing examples and status labels. They should avoid showing the local port as part of the recommended starter path and keep the SQLite local-state wording consistent.
+- **Tests** own the compatibility proof. Existing config tests should continue to demonstrate that legacy local port values parse successfully.
+
+## Data Structures & Interfaces
+
+No new data structures or public interfaces are introduced. The existing project configuration shape remains compatible with `runtime.local.port`, but generated starter configuration no longer recommends that field.
+
+## Implementation Detail
+
+The implementation follows the existing documentation/status model from the current README and docs site. It removes recommended usage of the local port from generated and docs examples, updates comments to describe SQLite local state, and keeps the config parser behavior unchanged.
+
+No new abstraction is introduced. This is a narrow text and scaffold cleanup around the existing local runtime configuration surface.
+
+## Dependencies
+
+- **Existing config parser**: Provides backward compatibility for legacy local port values and does not need behavior changes.
+- **Existing CLI init command**: Provides the generated starter project and needs a small template update.
+- **Existing docs baseline**: Provides current/partial/config-only status language and needs small alignment edits.
+- **Closed PR #36**: Provides the motivating stale cleanup, but its broad docs changes are not reused because current main has superseded them.
+
+## Testing Approach
+
+Testing focuses on regression and compatibility. Existing config tests should continue to prove legacy local port parsing works, while CLI/docs checks confirm the recommended path no longer presents the local port or embedded PostgreSQL as local runtime setup.
+
+The load-bearing assertions are that no unmarked embedded PostgreSQL local-runtime claims remain, generated starter config no longer contains the local port, and the workspace still passes the normal Rust and docs verification checks.
+
+## Milestones & Phases
+
+### Milestone 1: Local runtime wording matches SQLite behavior
+
+**What changes**: New users and contributors no longer encounter stale embedded-PostgreSQL setup language in the local runtime path. Starter configuration and reference docs present SQLite-backed local state accurately while existing projects remain compatible.
+
+#### - [x] Phase 1.1: Clean up SQLite local runtime wording
+
+This phase removes the remaining stale embedded-PostgreSQL wording from source-facing comments, starter config, and docs examples. It keeps legacy local port parsing intact so existing configuration files are not broken by a documentation cleanup.
+
+*Technical detail:* [context.md#phase-11-clean-up-sqlite-local-runtime-wording](./context.md#phase-11-clean-up-sqlite-local-runtime-wording)
+
+**Acceptance criteria**:
+
+- [x] Starter projects no longer include a local runtime port value by default.
+- [x] Documentation examples no longer present the local port as part of the recommended local runtime configuration.
+- [x] Source-facing comments describe SQLite-backed local state and compatibility parsing rather than embedded PostgreSQL.
+- [x] Legacy configuration containing a local runtime port still parses successfully.
+- [x] Verification passes for formatting, tests, clippy, docs, and stale-claim scans.
+
+## Open Questions
+
+There are no open questions. The cleanup scope and compatibility boundary are fixed.
+
+## Out of Scope
+
+- Removing the `runtime.local.port` field from the configuration API.
+- Changing SQLite or Postgres state-store selection.
+- Reworking remote runtime support.
+- Resurrecting the broad stale documentation edits from closed PR #36.
+
+## Changelog
+
+### 2026-05-02 — Phase 1.1: Clean up SQLite local runtime wording
+
+**What was done**: Removed `runtime.local.port` from generated starter configuration and the docs example, updated source-facing local runtime comments to describe SQLite-backed state, and renamed the internal default helper away from Postgres terminology. Added a CLI integration assertion that checks the raw generated YAML omits the local port while leaving compatibility parsing intact.
+
+**Deviations**: None.
+
+**Files changed**:
+- `crates/weavster-cli/src/commands/init.rs`
+- `crates/weavster-cli/tests/cli_test.rs`
+- `crates/weavster-core/src/config.rs`
+- `docs/docs/configuration/project.md`
+- `.spektacular/specs/20260502160602-sqlite-local-runtime-docs-cleanup.md`
+- `.spektacular/plans/20260502160602-sqlite-local-runtime-docs-cleanup/plan.md`
+- `.spektacular/plans/20260502160602-sqlite-local-runtime-docs-cleanup/context.md`
+- `.spektacular/plans/20260502160602-sqlite-local-runtime-docs-cleanup/research.md`
+
+**Discoveries**: The remaining `port: 5433` occurrences after cleanup are compatibility/test values, not generated or recommended configuration. The README and first-flow docs still contain negated wording that explicitly says local state uses SQLite, not embedded PostgreSQL.

--- a/.spektacular/plans/20260502160602-sqlite-local-runtime-docs-cleanup/research.md
+++ b/.spektacular/plans/20260502160602-sqlite-local-runtime-docs-cleanup/research.md
@@ -1,0 +1,66 @@
+# Research: 20260502160602-sqlite-local-runtime-docs-cleanup
+
+## Alternatives considered and rejected
+
+### Option A: Merge stale PR #36 as-is
+
+PR #36 broadly replaces embedded PostgreSQL references and removes the local port field.
+
+**Rejected**: Current main has superseded most of PR #36's docs shape, and `git merge-tree` shows conflicts in README and docs pages. The PR would also reintroduce old docs concepts such as `database.url` and old first-flow wording, which conflicts with the current status baseline.
+
+### Option B: Remove `runtime.local.port` from the config API
+
+This would delete the field from `LocalConfig`, remove the default helper, and update tests.
+
+**Rejected**: Existing tests at `crates/weavster-core/src/config.rs:1155` and `crates/weavster-core/tests/config_integration_test.rs:390` prove the field currently parses. Removing it would turn a wording cleanup into a compatibility change.
+
+### Option C: Leave source comments unchanged
+
+This would close PR #36 and rely on README/docs wording from the prior docs baseline.
+
+**Rejected**: A focused scan still finds embedded PostgreSQL comments in `crates/weavster-core/src/config.rs:135`, `crates/weavster-core/src/config.rs:145`, and `crates/weavster-core/src/config.rs:149`, which keeps the stale framing alive for contributors.
+
+## Chosen approach — evidence
+
+The chosen approach is to update generated starter config, docs examples, and source-facing comments while preserving config compatibility.
+
+- `crates/weavster-cli/src/commands/init.rs:54` shows the generated starter config still includes `port: 5433`, even though the local state path is SQLite.
+- `docs/docs/configuration/project.md:19` shows the recommended project config example still includes `port: 5433`.
+- `crates/weavster-core/src/config.rs:135`, `crates/weavster-core/src/config.rs:145`, and `crates/weavster-core/src/config.rs:149` contain the remaining embedded PostgreSQL source comments.
+- `crates/weavster-core/src/config.rs:1155` and `crates/weavster-core/tests/config_integration_test.rs:390` confirm the compatibility boundary: local port values still parse.
+
+## Files examined
+
+- `crates/weavster-cli/src/commands/init.rs:54` — generated starter config includes the unused local port.
+- `crates/weavster-core/src/config.rs:135` — local mode comment still names embedded PostgreSQL.
+- `crates/weavster-core/src/config.rs:145` — data directory comment still names embedded Postgres.
+- `crates/weavster-core/src/config.rs:149` — local port comment still names embedded PostgreSQL.
+- `crates/weavster-core/src/config.rs:1155` — unit test asserts a custom local port parses.
+- `crates/weavster-core/tests/config_integration_test.rs:390` — integration test asserts profile resolution preserves local port values.
+- `docs/docs/configuration/project.md:19` — project config example includes the local port.
+- `docs/docs/configuration/project.md:49` — project field table marks the local port as partial.
+- `README.md:169` — README already clearly states local state uses SQLite, not embedded PostgreSQL.
+- `docs/docs/getting-started/first-flow.md:89` — first-flow docs already clearly state local state uses SQLite, not embedded PostgreSQL.
+
+## External references
+
+None. The current codebase and PR history are sufficient for this cleanup.
+
+## Prior plans / specs consulted
+
+- `.spektacular/plans/20260428024252-docs-current-vs-planned-alignment/plan.md` — established current/partial/config-only status labels and documented SQLite local state.
+- `.spektacular/specs/20260502160602-sqlite-local-runtime-docs-cleanup.md` — defines the cleanup boundary and non-goals.
+
+## Open assumptions
+
+No open assumptions. The compatibility boundary is verified by existing tests and the runtime behavior is not changed.
+
+## Rehydration cues
+
+Re-run:
+
+```bash
+rg -n "embedded PostgreSQL|Embedded PostgreSQL|embedded Postgres|runtime\\.local\\.port|port: 5433|Port for embedded|default_pg_port" . --glob '!target' --glob '!docs/build'
+```
+
+Then re-read `crates/weavster-core/src/config.rs`, `crates/weavster-cli/src/commands/init.rs`, and `docs/docs/configuration/project.md`.

--- a/.spektacular/specs/20260502160602-sqlite-local-runtime-docs-cleanup.md
+++ b/.spektacular/specs/20260502160602-sqlite-local-runtime-docs-cleanup.md
@@ -1,0 +1,116 @@
+# Feature: 20260502160602-sqlite-local-runtime-docs-cleanup
+
+<!--
+  OVERVIEW
+  A concise 2-3 sentence summary of the feature. Answer three questions:
+    1. What is being built?
+    2. What problem does it solve?
+    3. Who benefits and why does it matter?
+  Avoid implementation details — this should be readable by any stakeholder.
+-->
+## Overview
+
+This cleanup removes stale wording that suggests the local runtime starts or depends on embedded PostgreSQL. It keeps the current SQLite-based local runtime story consistent for users and contributors so generated starter projects and reference material do not imply unused setup requirements.
+
+<!--
+  REQUIREMENTS
+  Specific, testable behaviours the feature must deliver.
+  Format: bold title on the checkbox line, detail indented below.
+  Rules:
+    - Use active voice: "Users can...", "The system must..."
+    - Each requirement should be independently verifiable
+    - Focus on WHAT, not HOW — avoid prescribing implementation
+    - Keep each item atomic — one behaviour per line
+-->
+## Requirements
+
+- [ ] **Local runtime wording matches current behavior**
+  Users can read starter configuration, reference docs, and source-facing comments without seeing embedded PostgreSQL presented as the local runtime backend.
+
+- [ ] **Starter projects avoid unused local port guidance**
+  New projects should not include a local runtime port value that only made sense for the old embedded PostgreSQL framing.
+
+- [ ] **Existing configuration compatibility is preserved**
+  Existing projects that still include the local runtime port field must continue to parse successfully.
+
+
+<!--
+  CONSTRAINTS
+  Hard boundaries the solution must operate within. These are non-negotiable.
+  Examples:
+    - Must integrate with the existing authentication system
+    - Cannot introduce breaking changes to the public API
+    - Must support the current minimum supported runtime versions
+  Leave blank if there are no constraints.
+-->
+## Constraints
+
+- Do not remove public config fields in this cleanup.
+- Do not change runtime backend selection or state-store behavior.
+- Keep the change small enough to replace the valid part of the closed stale PR.
+
+<!--
+  ACCEPTANCE CRITERIA
+  The specific, binary conditions that define "done".
+  Format: bold title on the checkbox line, verifiable detail indented below.
+  Each criterion must be:
+    - Independently verifiable (pass/fail, not subjective)
+    - Traceable back to a requirement above
+    - Testable by someone who didn't write the code
+-->
+## Acceptance Criteria
+
+- [ ] **No stale embedded PostgreSQL local-runtime claims remain**
+  Searches across README, docs, and Rust source do not find unmarked claims that embedded PostgreSQL backs local runtime state.
+
+- [ ] **Generated starter config omits the local port**
+  `weavster init` no longer writes `runtime.local.port` into the starter `weavster.yaml`.
+
+- [ ] **Legacy local port config still parses**
+  Existing config tests continue to prove that `runtime.local.port` remains accepted for compatibility.
+
+- [ ] **Verification passes**
+  Formatting, tests, clippy, and docs checks pass for the cleanup.
+
+
+<!--
+  TECHNICAL APPROACH
+  High-level technical direction to guide the planning agent. Include:
+    - Key architectural decisions already made
+    - Preferred patterns or technologies if known
+    - Integration points with existing systems
+    - Known risks or areas of uncertainty
+  Leave blank if you want the planner to propose the approach.
+-->
+## Technical Approach
+
+- Update Rust comments and helper naming around local runtime config to describe SQLite-backed local state and compatibility parsing.
+- Remove `runtime.local.port` from the CLI init template and docs examples while retaining the field in the config struct.
+- Keep docs wording consistent with the existing current/partial/config-only status model.
+
+<!--
+  SUCCESS METRICS
+  How you will know the feature is working well after delivery. Be specific:
+    - Quantitative: "p99 latency < 200ms", "error rate < 0.1%"
+    - Behavioural: "users complete the flow without support intervention"
+  Leave blank if not applicable.
+-->
+## Success Metrics
+
+- New users do not see embedded PostgreSQL or a local runtime port in generated starter config.
+- Contributors scanning config code can tell that the local port field is compatibility-only and not a SQLite runtime requirement.
+
+<!--
+  NON-GOALS
+  Explicitly state what this spec does NOT cover. This is as important as
+  the requirements — it prevents scope creep and sets clear expectations.
+  Examples:
+    - "Mobile support is out of scope (tracked in #456)"
+    - "Internationalisation will be addressed in a follow-up spec"
+  Leave blank if there are no explicit exclusions to call out.
+-->
+## Non-Goals
+
+- Removing the `runtime.local.port` field from the configuration API.
+- Changing SQLite or Postgres state-store selection.
+- Reworking remote runtime support.

--- a/.spektacular/state.json
+++ b/.spektacular/state.json
@@ -12,9 +12,9 @@
     "update_repo_changelog",
     "finished"
   ],
-  "created_at": "2026-04-28T02:58:04.923578Z",
-  "updated_at": "2026-04-28T03:12:59.660867Z",
+  "created_at": "2026-05-02T16:10:15.920219Z",
+  "updated_at": "2026-05-02T16:15:56.97707Z",
   "data": {
-    "name": "20260428024252-docs-current-vs-planned-alignment"
+    "name": "20260502160602-sqlite-local-runtime-docs-cleanup"
   }
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to the Weavster project will be documented in this file.
 
 This project follows a Spektacular-driven documentation workflow where approved specs and plans contribute to this master file.
 
+## 20260502160602-sqlite-local-runtime-docs-cleanup
+
+Starter projects and configuration documentation now present SQLite-backed local state without recommending an unused local runtime port. Existing projects that still include the legacy local port remain compatible, but new generated configuration no longer implies embedded PostgreSQL setup. This replaces the valid part of the old embedded-Postgres cleanup with a current-main scoped change.
+
 ## 20260428024252-docs-current-vs-planned-alignment
 
 The README and docs site now clearly separate what Weavster supports today from partial, config-only, placeholder, and planned functionality. New users get a source-based install path, a generated file-flow quick start that matches the current CLI, and explicit limits around non-file connectors, local SQLite state, package signing, and placeholder commands. The documentation now gives contributors a single status baseline for future README, docs, and test-health updates.

--- a/crates/weavster-cli/src/commands/init.rs
+++ b/crates/weavster-cli/src/commands/init.rs
@@ -51,7 +51,6 @@ runtime:
   mode: local
   local:
     data_dir: ".weavster/data"
-    port: 5433
 
 # Global variables available in Jinja templates
 vars:

--- a/crates/weavster-cli/tests/cli_test.rs
+++ b/crates/weavster-cli/tests/cli_test.rs
@@ -16,6 +16,18 @@ fn test_init_and_run_once() {
     assert!(dir.path().join("connectors/file.yaml").exists());
     assert!(dir.path().join("data/input.jsonl").exists());
 
+    let config = std::fs::read_to_string(dir.path().join("weavster.yaml")).unwrap();
+    let config_yaml: serde_yaml::Value = serde_yaml::from_str(&config).unwrap();
+    let local_config = config_yaml
+        .get("runtime")
+        .and_then(|runtime| runtime.get("local"))
+        .and_then(serde_yaml::Value::as_mapping)
+        .expect("generated weavster.yaml should contain runtime.local");
+    assert!(
+        !local_config.contains_key(serde_yaml::Value::String("port".to_string())),
+        "generated weavster.yaml should omit runtime.local.port"
+    );
+
     // Run --once
     cargo_bin_cmd!("weavster")
         .args(["--config", dir.path().to_str().unwrap(), "run", "--once"])

--- a/crates/weavster-core/src/config.rs
+++ b/crates/weavster-core/src/config.rs
@@ -132,7 +132,7 @@ pub struct RuntimeConfig {
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, Default, PartialEq, Eq)]
 #[serde(rename_all = "lowercase")]
 pub enum RuntimeMode {
-    /// Local mode with embedded PostgreSQL
+    /// Local mode with SQLite-backed state
     #[default]
     Local,
     /// Remote mode connecting to external services
@@ -142,12 +142,12 @@ pub enum RuntimeMode {
 /// Local runtime configuration
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct LocalConfig {
-    /// Directory for local data (embedded Postgres, caches)
+    /// Directory for local data (SQLite state, caches)
     #[serde(default = "default_data_dir")]
     pub data_dir: String,
 
-    /// Port for embedded PostgreSQL
-    #[serde(default = "default_pg_port")]
+    /// Legacy local runtime port, parsed for compatibility but not used by SQLite state
+    #[serde(default = "default_local_port")]
     pub port: u16,
 }
 
@@ -155,7 +155,7 @@ impl Default for LocalConfig {
     fn default() -> Self {
         Self {
             data_dir: default_data_dir(),
-            port: default_pg_port(),
+            port: default_local_port(),
         }
     }
 }
@@ -164,8 +164,8 @@ fn default_data_dir() -> String {
     ".weavster/data".to_string()
 }
 
-fn default_pg_port() -> u16 {
-    5433 // Avoid conflict with system Postgres on 5432
+fn default_local_port() -> u16 {
+    5433
 }
 
 /// Remote runtime configuration

--- a/docs/docs/configuration/project.md
+++ b/docs/docs/configuration/project.md
@@ -16,7 +16,6 @@ runtime:
   mode: local
   local:
     data_dir: ".weavster/data"
-    port: 5433
 
 vars:
   environment: development
@@ -46,7 +45,7 @@ macros_dir: macros
 | `version` | Current | Project version, defaults to `0.1.0` |
 | `runtime.mode` | Config-only | Parsed from config, but it does not currently select the runtime backend |
 | `runtime.local.data_dir` | Current | Local runtime data directory |
-| `runtime.local.port` | Partial | Config field exists; local state currently uses SQLite rather than embedded PostgreSQL |
+| `runtime.local.port` | Compatibility-only | Legacy field accepted by config parsing; not used by SQLite local state and not included in new starter projects |
 | `runtime.remote.postgres_url` | Config-only | Parsed from config; current CLI runtime selects Postgres state only from the `WEAVSTER_PG_URL` environment variable |
 | `runtime.remote.redis_url` | Planned | Modeled in config; distributed Redis runtime is not implemented |
 | `vars` | Current | Static variables available for config-level Jinja substitution |


### PR DESCRIPTION
## Summary
- replace the valid part of stale PR #36 with a current-main scoped cleanup
- remove runtime.local.port from generated starter config and docs examples
- update local runtime comments to SQLite/compatibility wording while preserving legacy port parsing
- add a CLI integration assertion that generated weavster.yaml omits runtime.local.port

## Verification
- cargo fmt --check
- cargo test --all-features
- cargo clippy --all-targets --all-features -- -D warnings
- RUSTDOCFLAGS='-D warnings' cargo doc --no-deps --all-features
- npm run build in docs/
- npm run typecheck in docs/
- targeted stale-claim scan