### PR TITLE
ci: align workflow quality with Spektacular

### DIFF
--- a/.github/workflows/workflow-quality.yml
+++ b/.github/workflows/workflow-quality.yml
@@ -26,17 +26,19 @@ jobs:
             src/**
             **/*.rs
 
-      - name: Check for wf-changelog.md
+      - name: Check for release-note artifacts
         id: check
         run: |
           CODE_CHANGED="${{ steps.changed-files.outputs.any_changed }}"
 
-          # Check if any wf-changelog.md was added or modified in the PR
-          CHANGELOG_CHANGED=$(git diff --name-only origin/${{ github.base_ref }}...HEAD | grep "wf-changelog.md" || true)
+          # Code changes should carry current documentation artifacts:
+          # - a user-facing root changelog entry, or
+          # - Spektacular spec/plan artifacts for the change.
+          RELEASE_NOTES_CHANGED=$(git diff --name-only origin/${{ github.base_ref }}...HEAD | grep -E '^(CHANGELOG\.md|\.spektacular/(specs|plans)/)' || true)
 
-          if [ "$CODE_CHANGED" = "true" ] && [ -z "$CHANGELOG_CHANGED" ]; then
+          if [ "$CODE_CHANGED" = "true" ] && [ -z "$RELEASE_NOTES_CHANGED" ]; then
             echo "needs_changelog=true" >> $GITHUB_OUTPUT
-            echo "::warning::PR changes code but missing wf-changelog.md in thoughts/ directory"
+            echo "::warning::PR changes Rust code but is missing a root changelog update or Spektacular spec/plan artifacts"
           else
             echo "needs_changelog=false" >> $GITHUB_OUTPUT
           fi
@@ -44,110 +46,84 @@ jobs:
   fail-if-missing:
     name: Fail if Missing
     needs: check-changelog
-    if: needs.check-changelog.outputs.needs_changelog == 'true' && !contains(github.event.pull_request.labels.*.name, 'gemini-autofix')
+    if: needs.check-changelog.outputs.needs_changelog == 'true' && (!contains(github.event.pull_request.labels.*.name, 'codex-autofix') || github.event.pull_request.head.repo.full_name != github.repository)
     runs-on: ubuntu-latest
     steps:
       - name: Fail check
         run: |
-          echo "ERROR: This PR modifies code but is missing a workflow changelog (wf-changelog.md)."
-          echo "Please use the /wf-update-changelog skill to document your changes."
-          echo "Or add the 'gemini-autofix' label to have this automatically generated for you."
+          echo "ERROR: This PR modifies Rust code but is missing release-note documentation."
+          echo "Update CHANGELOG.md or add Spektacular spec/plan artifacts under .spektacular/specs/ and .spektacular/plans/."
+          echo "For same-repository PRs, maintainers may add the 'codex-autofix' label to generate a root CHANGELOG.md entry."
           exit 1
 
   auto-generate-changelog:
     name: Auto-generate Changelog
     needs: check-changelog
-    if: needs.check-changelog.outputs.needs_changelog == 'true' && contains(github.event.pull_request.labels.*.name, 'gemini-autofix')
+    if: needs.check-changelog.outputs.needs_changelog == 'true' && contains(github.event.pull_request.labels.*.name, 'codex-autofix') && github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     permissions:
       contents: write
       pull-requests: write
-      id-token: write
     steps:
-      - name: Checkout repository
+      - name: Checkout PR branch
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
           ref: ${{ github.event.pull_request.head.ref }}
 
-      - name: Generate Workflow Changelog
-        uses: google-github-actions/run-gemini-cli@v0
+      - name: Fetch base branch
         env:
-          ENABLE_LSP_TOOL: "1"
+          BASE_REF: ${{ github.base_ref }}
+        run: git fetch --no-tags origin "$BASE_REF"
+
+      - name: Generate changelog entry with Codex
+        uses: openai/codex-action@v1
         with:
-          gemini_api_key: ${{ secrets.GEMINI_API_KEY }}
+          openai-api-key: ${{ secrets.OPENAI_API_KEY }}
+          sandbox: workspace-write
           prompt: |
-            This PR is missing a required `wf-changelog.md` file in the `thoughts/` directory.
-            PR NUMBER: #${{ github.event.pull_request.number }}
-            PR TITLE: ${{ github.event.pull_request.title }}
-            PR BODY: ${{ github.event.pull_request.body }}
+            You are updating release-note documentation for a pull request in ${{ github.repository }}.
 
-            INSTRUCTIONS:
-            1. Analyze the changes in this PR using `git diff origin/${{ github.base_ref }}...HEAD`
-            2. Determine the appropriate feature slug for this work. Check `thoughts/` for existing directories or create a new one based on the branch name.
-            3. Generate a `wf-changelog.md` following the established project conventions:
-               - Use the feature directory: `thoughts/{namespace}/{NNNN-slug}/`
-               - File path: `thoughts/{namespace}/{NNNN-slug}/wf-changelog.md`
-            4. If a `wf-plan.md` doesn't exist, create a minimal placeholder plan to satisfy the workflow directory requirements.
-            5. Commit these files directly to the PR branch.
-            6. Post a comment on the PR informing the developer that Gemini CLI (via automation) has auto-generated the documentation.
+            The PR modifies Rust code but is missing current release-note evidence.
+            Update only the root CHANGELOG.md file.
 
-            Context:
-            - This is the Weavster project (Rust ESB/data pipelines).
-            - Refer to AGENTS.md for core project conventions.
+            Requirements:
+            - Inspect the PR diff with: git diff --stat origin/${{ github.base_ref }}...HEAD
+            - Inspect relevant code changes with: git diff origin/${{ github.base_ref }}...HEAD
+            - Add one concise user-facing entry near the top of CHANGELOG.md.
+            - Prefer a heading based on the PR branch or title.
+            - Do not create retired per-workflow changelog files.
+            - Do not create retired planning-directory files.
+            - Do not create Spektacular specs or plans.
+            - Do not modify source code or workflow files.
 
-            --allowed-tools "Bash(git:*),Bash(gh pr view:*),Bash(gh pr diff:*),Bash(gh pr comment:*),Bash(ls:*),Bash(mkdir:*),Write,Edit,Read"
+            PR title:
+            ${{ github.event.pull_request.title }}
+
+            PR body:
+            ${{ github.event.pull_request.body }}
+
+      - name: Commit generated changelog
+        env:
+          HEAD_REF: ${{ github.event.pull_request.head.ref }}
+        run: |
+          if git diff --quiet -- CHANGELOG.md; then
+            echo "ERROR: Codex did not update CHANGELOG.md."
+            exit 1
+          fi
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add CHANGELOG.md
+          git commit -m "docs: add changelog entry"
+          git push origin "HEAD:$HEAD_REF"
 
   sync-master-changelog:
     name: Sync Master Changelog
     needs: check-changelog
-    # If a changelog was added/updated (manually OR by autofix), sync it to root CHANGELOG.md
     if: always() && needs.check-changelog.result == 'success'
     runs-on: ubuntu-latest
-    permissions:
-      contents: write
-      pull-requests: write
-      id-token: write
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-          ref: ${{ github.event.pull_request.head.ref }}
-
-      - name: Check if wf-changelog.md was updated
-        id: check_update
+      - name: Report current master changelog workflow
         run: |
-          # Check if any wf-changelog.md was added or modified in the PR branch
-          CHANGELOG_CHANGED=$(git diff --name-only origin/${{ github.base_ref }}...HEAD | grep "wf-changelog.md" || true)
-          if [ -n "$CHANGELOG_CHANGED" ]; then
-            echo "has_update=true" >> $GITHUB_OUTPUT
-          else
-            echo "has_update=false" >> $GITHUB_OUTPUT
-          fi
-
-      - name: Sync to root CHANGELOG.md
-        if: steps.check_update.outputs.has_update == 'true'
-        uses: google-github-actions/run-gemini-cli@v0
-        env:
-          ENABLE_LSP_TOOL: "1"
-        with:
-          gemini_api_key: ${{ secrets.GEMINI_API_KEY }}
-          prompt: |
-            A workflow changelog was added or updated in this PR. Please sync its contents to the root `CHANGELOG.md` file under the `## [Unreleased]` section.
-
-            PR TITLE: ${{ github.event.pull_request.title }}
-            PR BODY: ${{ github.event.pull_request.body }}
-
-            INSTRUCTIONS:
-            1. Find the newly updated `wf-changelog.md` files in the `thoughts/` directory using `git diff --name-only origin/${{ github.base_ref }}...HEAD | grep "wf-changelog.md"`
-            2. Read their contents.
-            3. Synthesize a concise summary for the root `CHANGELOG.md`.
-            4. Append this summary under the `## [Unreleased]` header in `CHANGELOG.md`.
-            5. If `CHANGELOG.md` doesn't exist, create it.
-            6. Ensure the tone is professional and consistent with existing entries.
-            7. Commit the changes to the PR branch.
-
-            IMPORTANT: Do not duplicate entries. Check if a summary for this PR is already in the `CHANGELOG.md`.
-
-            --allowed-tools "Bash(git:*),Bash(gh pr view:*),Bash(gh pr diff:*),Bash(ls:*),Write,Edit,Read"
+          echo "Root CHANGELOG.md updates are committed directly as part of Spektacular workflows."

--- a/.spektacular/plans/20260502165842-workflow-quality-spektacular-alignment/context.md
+++ b/.spektacular/plans/20260502165842-workflow-quality-spektacular-alignment/context.md
@@ -1,0 +1,73 @@
+# Context: 20260502165842-workflow-quality-spektacular-alignment
+
+## Current State Analysis
+
+The failing check on PR #35 and PR #40 is `Workflow Quality / Fail if Missing`. The job fails because `check-changelog` reports code changes without `wf-changelog.md`.
+
+- `.github/workflows/workflow-quality.yml:29` — step name checks for `wf-changelog.md`.
+- `.github/workflows/workflow-quality.yml:35` — detection only greps for `wf-changelog.md`.
+- `.github/workflows/workflow-quality.yml:39` — warning says the file should be in `thoughts/`.
+- `.github/workflows/workflow-quality.yml:47` — failure is skipped only when the `gemini-autofix` label is present.
+- `.github/workflows/workflow-quality.yml:52` — failure message says code PRs are missing `wf-changelog.md`.
+- `.github/workflows/workflow-quality.yml:53` — failure message points to `/wf-update-changelog`.
+- `.github/workflows/workflow-quality.yml:60` through `.github/workflows/workflow-quality.yml:95` — auto-generation job calls Gemini CLI and writes retired `thoughts/` artifacts.
+- `.github/workflows/workflow-quality.yml:118` through `.github/workflows/workflow-quality.yml:153` — sync job also depends on `wf-changelog.md` and Gemini CLI.
+- `AGENTS.md:21` and `AGENTS.md:22` — current workflow stores specs and plans under `.spektacular/`.
+
+## Per-Phase Technical Notes
+
+### Phase 1.1: Replace retired changelog gate
+
+- `.github/workflows/workflow-quality.yml:29` — rename the step to check for current release-note artifacts rather than `wf-changelog.md`.
+- `.github/workflows/workflow-quality.yml:35` — replace `wf-changelog.md` detection with a diff check for `CHANGELOG.md`, `.spektacular/specs/`, or `.spektacular/plans/`.
+- `.github/workflows/workflow-quality.yml:39` — update the warning to mention root changelog or Spektacular artifacts.
+- `.github/workflows/workflow-quality.yml:47` — replace the `gemini-autofix` label condition with a `codex-autofix` same-repository guard.
+- `.github/workflows/workflow-quality.yml:52` through `.github/workflows/workflow-quality.yml:54` — update the failure message to current Spektacular wording.
+- `.github/workflows/workflow-quality.yml:58` through `.github/workflows/workflow-quality.yml:105` — replace the Gemini auto-generation job with `openai/codex-action@v1`, scoped to same-repository PRs labeled `codex-autofix`.
+- `.github/workflows/workflow-quality.yml:106` onward — keep the sync job as a no-op status compatibility job because Codex updates the root changelog directly.
+
+**Complexity**: Low
+**Token estimate**: ~8k
+**Agent strategy**: Single agent, sequential execution
+
+## Testing Strategy
+
+Validate the workflow YAML syntax and run static greps to ensure the PR quality workflow no longer references Gemini, `wf-changelog.md`, `/wf-update-changelog`, or `thoughts/`.
+
+For behavior, use local git-diff simulations against current `main` to confirm:
+
+- a code-only diff would set `needs_changelog=true`;
+- a code diff with `CHANGELOG.md` would set `needs_changelog=false`;
+- a code diff with `.spektacular/specs/**` or `.spektacular/plans/**` would set `needs_changelog=false`.
+
+Static review should also verify that the Codex autofix job:
+
+- requires the `codex-autofix` label;
+- only runs for PR branches in the same repository;
+- instructs Codex to update only `CHANGELOG.md`;
+- commits only `CHANGELOG.md`.
+
+## Project References
+
+- `.spektacular/specs/20260502165842-workflow-quality-spektacular-alignment.md` — approved workflow-fix scope.
+- `.spektacular/plans/20260428024252-docs-current-vs-planned-alignment/plan.md` — prior plan establishing Spektacular changelog practice.
+- `https://github.com/weavster-dev/weavster/pull/35` — currently failing `Fail if Missing`.
+- `https://github.com/weavster-dev/weavster/pull/40` — currently failing `Fail if Missing`.
+
+## Token Management Strategy
+
+| Tier | Token Budget | Agent Strategy |
+|------|-------------|----------------|
+| Low | ~10k | Single agent, sequential |
+| Medium | ~25k | 2-3 parallel agents |
+| High | ~50k+ | Parallel analysis, sequential integration |
+
+This is low-tier because it changes one workflow file plus Spektacular/release-note artifacts.
+
+## Migration Notes
+
+After this PR merges, open PR branches may need to rebase or merge `main` to pick up the updated pull request workflow.
+
+## Performance Considerations
+
+No runtime performance impact. The workflow should avoid old Gemini jobs on normal PRs; `codex-autofix` adds work only when explicitly requested by label.

--- a/.spektacular/plans/20260502165842-workflow-quality-spektacular-alignment/plan.md
+++ b/.spektacular/plans/20260502165842-workflow-quality-spektacular-alignment/plan.md
@@ -1,0 +1,99 @@
+# Plan: 20260502165842-workflow-quality-spektacular-alignment
+
+<!-- Metadata -->
+<!-- Created: 2026-05-02T17:00:26Z -->
+<!-- Commit: 6d593fe -->
+<!-- Branch: fix-workflow-quality-spektacular -->
+<!-- Repository: https://github.com/weavster-dev/weavster.git -->
+
+## Overview
+
+This plan updates pull request quality checks so they align with the current Spektacular documentation workflow instead of the retired Gemini workflow changelog process. Code PRs should no longer fail because they lack obsolete `wf-changelog.md` artifacts, while contributors still get a clear release-note requirement and maintainers can request a Codex-generated root changelog entry.
+
+## Architecture & Design Decisions
+
+The chosen direction is to keep the workflow and key job names in place but replace the obsolete artifact detection and messaging. This preserves the visible PR check surface while changing the gate to recognize current artifacts: root changelog edits and Spektacular specs/plans.
+
+The plan deliberately replaces the Gemini autofix path with Codex and scopes it to same-repository PRs. Codex may update only the root changelog; Spektacular specs and plans remain human/agent workflow artifacts, not CI-generated files. See `research.md#alternatives-considered-and-rejected` for why the plan does not delete the whole workflow or update release publishing automation in this PR.
+
+## Component Breakdown
+
+- **Pull request quality workflow** owns the additional release-note gate for code changes. It should detect Rust code changes, inspect current documentation artifacts, and produce actionable messages.
+- **Spektacular artifacts** provide the current per-change planning and changelog evidence for substantial work. The workflow should count those artifacts as satisfying the code-change documentation requirement.
+- **Root changelog** provides the user-facing release-note summary. The workflow should count root changelog updates as satisfying the requirement.
+- **Codex autofix path** provides a maintainer-triggered fallback for same-repository PRs that are missing release-note evidence. It should modify only the root changelog and commit that change back to the PR branch.
+
+## Data Structures & Interfaces
+
+No application data structures or public interfaces change. The workflow contract changes from "code changes require `wf-changelog.md`" to "code changes require either a root changelog update or Spektacular spec/plan artifacts."
+
+## Implementation Detail
+
+The workflow keeps `Check Workflow Changelog` and `Fail if Missing` as job names, but updates the check script and failure message to current terminology. The old Gemini auto-generation path is replaced by `openai/codex-action@v1` behind a `codex-autofix` label and same-repository guard.
+
+The check remains intentionally lightweight. It uses changed-file detection for Rust code and a git diff against the PR base to detect `CHANGELOG.md`, `.spektacular/specs/**`, or `.spektacular/plans/**` changes.
+
+## Dependencies
+
+- **GitHub Actions**: Runs the pull request workflow and needs valid YAML only.
+- **OpenAI Codex Action**: Provides maintainer-triggered changelog generation and requires an `OPENAI_API_KEY` secret.
+- **tj-actions/changed-files**: Already used by the workflow to detect code changes; no version change required.
+- **Spektacular artifacts**: Current repository workflow for specs/plans; no behavior change required.
+
+## Testing Approach
+
+Testing focuses on workflow validity and deterministic shell logic. The workflow YAML should parse, the updated workflow should no longer contain Gemini or `wf-changelog.md` references, and a local script-equivalent check should demonstrate that code changes with Spektacular or root changelog artifacts do not set `needs_changelog=true`. Static review should also confirm the Codex autofix path is same-repository only and commits only `CHANGELOG.md`.
+
+## Milestones & Phases
+
+### Milestone 1: PR quality checks match Spektacular
+
+**What changes**: Code pull requests are evaluated against the repository's current documentation workflow. Contributors no longer see instructions for retired Gemini labels or old workflow changelog files.
+
+#### - [x] Phase 1.1: Replace retired changelog gate
+
+This phase updates the PR quality workflow to look for current changelog evidence and replaces the old Gemini autofix path with a Codex-based root changelog generator. It keeps the existing high-level quality gate active so code PRs still need release-note coverage without relying on retired artifacts.
+
+*Technical detail:* [context.md#phase-11-replace-retired-changelog-gate](./context.md#phase-11-replace-retired-changelog-gate)
+
+**Acceptance criteria**:
+
+- [x] Code PR quality checks no longer require `wf-changelog.md`.
+- [x] PR quality workflow output no longer references Gemini autofix, old workflow changelog skills, or `thoughts/` artifacts.
+- [x] Code PRs with a root changelog update or Spektacular spec/plan artifacts satisfy the documentation gate.
+- [x] Same-repository code PRs labeled `codex-autofix` can generate and commit a root changelog entry with Codex.
+- [x] Workflow YAML and local shell checks validate the new gate behavior.
+
+## Open Questions
+
+There are no open questions. Release and nightly workflow cleanup is intentionally separate.
+
+## Out of Scope
+
+- Updating release or nightly release workflows.
+- Running Codex autofix on fork PRs.
+- Generating Spektacular specs or plans from CI.
+- Changing Rust CI, docs CI, coverage, or formatting checks.
+- Rebasing open PRs after this workflow fix lands.
+
+## Changelog
+
+### FINAL SUMMARY
+
+The PR quality workflow now checks Rust code changes against the current release-note evidence model: root `CHANGELOG.md` edits or Spektacular spec/plan artifacts. The retired `wf-changelog.md`, Gemini autofix label, Gemini CLI action, and `thoughts/` artifact references are no longer part of the gate output or automation. A maintainer-triggered `codex-autofix` path can generate a root changelog entry for same-repository PRs.
+
+**Total phases**: 1/1 completed
+
+**Notable deviations from the plan**: No committed automated test was added because the repository has no existing convention for testing GitHub Actions workflow shell logic. After initial implementation, the plan was updated to add a same-repository `codex-autofix` path for root changelog generation.
+
+### 2026-05-02 — Phase 1.1: Replace retired changelog gate
+
+**What was done**: The workflow gate was aligned with Spektacular-era release-note evidence by accepting root changelog updates and `.spektacular/specs/` or `.spektacular/plans/` changes. The visible failure path now gives contributors current instructions instead of asking for retired workflow changelog artifacts, and same-repository PRs can use `codex-autofix` to generate a root changelog entry.
+
+**Deviations**: No committed automated test was added because this repository only has Rust test conventions and no existing framework for GitHub Actions workflow shell logic. The final workflow includes a Codex autofix path requested after the original no-generator plan.
+
+**Files changed**:
+- `.github/workflows/workflow-quality.yml`
+- `.spektacular/plans/20260502165842-workflow-quality-spektacular-alignment/plan.md`
+
+**Discoveries**: Existing tests are Rust integration/CLI tests under `crates/**/tests`; there is no committed workflow-shell test convention to extend.

--- a/.spektacular/plans/20260502165842-workflow-quality-spektacular-alignment/research.md
+++ b/.spektacular/plans/20260502165842-workflow-quality-spektacular-alignment/research.md
@@ -1,0 +1,72 @@
+# Research: 20260502165842-workflow-quality-spektacular-alignment
+
+## Alternatives considered and rejected
+
+### Option A: Add `wf-changelog.md` to each failing PR
+
+This would satisfy the old gate for PR #35 and PR #40.
+
+**Rejected**: The repository has moved to Spektacular artifacts and root changelog entries. Adding retired `wf-changelog.md` files would perpetuate the obsolete flow exposed by `.github/workflows/workflow-quality.yml:35`.
+
+### Option B: Delete the Workflow Quality workflow
+
+This would remove the failing gate entirely.
+
+**Rejected**: Removing the whole workflow could disrupt expected check names and would eliminate a useful code-change release-note reminder. Keeping the check but updating its artifact model is lower risk.
+
+### Option C: Update release and nightly workflows in the same PR
+
+Release workflows also contain Gemini references.
+
+**Rejected**: The active PR failure is in the pull request quality workflow. Release automation has a different blast radius and should be reviewed separately.
+
+### Option D: Generate Spektacular artifacts from CI
+
+This would ask automation to create specs and plans when code PRs are missing release-note evidence.
+
+**Rejected**: Spektacular specs and plans are source-of-truth planning artifacts that should be created by the explicit Spektacular workflow, not synthesized after the fact by CI. A generated root changelog entry is a narrower and safer autofix.
+
+## Chosen approach — evidence
+
+The chosen approach updates `.github/workflows/workflow-quality.yml` to recognize current Spektacular/root changelog artifacts.
+
+- `.github/workflows/workflow-quality.yml:35` proves the current gate only accepts `wf-changelog.md`.
+- `.github/workflows/workflow-quality.yml:47` proves the failure path is tied to `gemini-autofix`.
+- `.github/workflows/workflow-quality.yml:74` and `.github/workflows/workflow-quality.yml:131` prove the original workflow still called Gemini CLI.
+- `openai/codex-action@v1` supports running Codex in GitHub Actions with an `OPENAI_API_KEY` secret and a prompt, which fits a maintainer-triggered changelog update path.
+- `AGENTS.md:21` and `AGENTS.md:22` define the current `.spektacular/specs/` and `.spektacular/plans/` locations.
+- `CHANGELOG.md:5` states the project follows a Spektacular-driven documentation workflow.
+
+## Files examined
+
+- `.github/workflows/workflow-quality.yml:29` — step name and logic still target `wf-changelog.md`.
+- `.github/workflows/workflow-quality.yml:47` — fail gate still references the Gemini label.
+- `.github/workflows/workflow-quality.yml:60` — auto-generation job is Gemini-specific.
+- `.github/workflows/workflow-quality.yml:104` — changelog sync job is also tied to retired artifacts.
+- `.github/workflows/ci.yml:1` — core Rust/docs CI is separate and should not change.
+- `AGENTS.md:21` — specs live under `.spektacular/specs/`.
+- `AGENTS.md:22` — plans live under `.spektacular/plans/`.
+- `CHANGELOG.md:5` — root changelog documents Spektacular-driven workflow.
+
+## External references
+
+- `https://github.com/openai/codex-action` — official Codex GitHub Action documentation; confirms `openai/codex-action@v1`, `openai-api-key`, `prompt`, and sandbox inputs.
+
+## Prior plans / specs consulted
+
+- `.spektacular/plans/20260428024252-docs-current-vs-planned-alignment/plan.md` — shows current Spektacular plan/changelog practice.
+- `.spektacular/specs/20260502165842-workflow-quality-spektacular-alignment.md` — defines the workflow quality alignment scope.
+
+## Open assumptions
+
+The plan assumes keeping the `Check Workflow Changelog` and `Fail if Missing` job names is safer for branch protection than deleting the jobs outright. If branch protection requires different names, the implementer must stop and ask.
+
+The Codex autofix path assumes the repository has an `OPENAI_API_KEY` secret configured. If that secret is missing, the autofix job will fail and maintainers should add the changelog manually or configure the secret.
+
+## Rehydration cues
+
+Re-read `.github/workflows/workflow-quality.yml`, `AGENTS.md`, and `CHANGELOG.md`, then run:
+
+```bash
+rg -n "wf-changelog|wf-update-changelog|gemini-autofix|run-gemini-cli|GEMINI_API_KEY|thoughts/" .github/workflows/workflow-quality.yml
+```

--- a/.spektacular/specs/20260502165842-workflow-quality-spektacular-alignment.md
+++ b/.spektacular/specs/20260502165842-workflow-quality-spektacular-alignment.md
@@ -1,0 +1,124 @@
+# Feature: 20260502165842-workflow-quality-spektacular-alignment
+
+<!--
+  OVERVIEW
+  A concise 2-3 sentence summary of the feature. Answer three questions:
+    1. What is being built?
+    2. What problem does it solve?
+    3. Who benefits and why does it matter?
+  Avoid implementation details — this should be readable by any stakeholder.
+-->
+## Overview
+
+Pull request quality checks should match the current Spektacular documentation workflow instead of enforcing the retired Gemini changelog process. This prevents valid code PRs from failing on obsolete automation while keeping a lightweight release-note check for contributors and reviewers.
+
+<!--
+  REQUIREMENTS
+  Specific, testable behaviours the feature must deliver.
+  Format: bold title on the checkbox line, detail indented below.
+  Rules:
+    - Use active voice: "Users can...", "The system must..."
+    - Each requirement should be independently verifiable
+    - Focus on WHAT, not HOW — avoid prescribing implementation
+    - Keep each item atomic — one behaviour per line
+-->
+## Requirements
+
+- [ ] **Code PRs are checked against current release-note artifacts**
+  Pull requests that change Rust code should satisfy the quality check when they update the root changelog or add Spektacular spec/plan artifacts for the change.
+
+- [ ] **Retired Gemini automation is no longer part of PR quality gating**
+  Contributors should not be told to use Gemini labels, Gemini autofix, or the old workflow changelog skill to make PR checks pass.
+
+- [ ] **Maintainers can request Codex changelog generation**
+  Same-repository pull requests with missing release-note evidence can be labeled for Codex to add a root changelog entry automatically.
+
+- [ ] **Existing quality job names remain stable where practical**
+  The workflow should keep recognizable check names so existing PR review habits and branch protection expectations are not disrupted unnecessarily.
+
+
+<!--
+  CONSTRAINTS
+  Hard boundaries the solution must operate within. These are non-negotiable.
+  Examples:
+    - Must integrate with the existing authentication system
+    - Cannot introduce breaking changes to the public API
+    - Must support the current minimum supported runtime versions
+  Leave blank if there are no constraints.
+-->
+## Constraints
+
+- Do not change release or nightly publishing workflows in this PR.
+- Do not add a replacement auto-generation bot in this PR.
+- Do not weaken Rust CI, docs CI, coverage, or formatting checks.
+
+<!--
+  ACCEPTANCE CRITERIA
+  The specific, binary conditions that define "done".
+  Format: bold title on the checkbox line, verifiable detail indented below.
+  Each criterion must be:
+    - Independently verifiable (pass/fail, not subjective)
+    - Traceable back to a requirement above
+    - Testable by someone who didn't write the code
+-->
+## Acceptance Criteria
+
+- [ ] **Code changes with current changelog artifacts pass the quality gate**
+  A PR that changes Rust code and updates the root changelog or includes Spektacular artifacts is not failed for missing `wf-changelog.md`.
+
+- [ ] **Old Gemini instructions are removed from pull request quality output**
+  The workflow no longer references `gemini-autofix`, `wf-update-changelog`, `wf-changelog.md`, or Gemini CLI in PR quality jobs.
+
+- [ ] **Codex autofix updates only the root changelog**
+  When a same-repository code PR is labeled for autofix, the workflow asks Codex to update `CHANGELOG.md` and does not create retired workflow changelog artifacts.
+
+- [ ] **Quality workflow remains valid GitHub Actions YAML**
+  The workflow can be parsed by GitHub Actions and keeps the PR quality check active for pull requests to main.
+
+- [ ] **Verification passes**
+  YAML checks and repository grep checks confirm the PR quality workflow is aligned with Spektacular.
+
+
+<!--
+  TECHNICAL APPROACH
+  High-level technical direction to guide the planning agent. Include:
+    - Key architectural decisions already made
+    - Preferred patterns or technologies if known
+    - Integration points with existing systems
+    - Known risks or areas of uncertainty
+  Leave blank if you want the planner to propose the approach.
+-->
+## Technical Approach
+
+- Update the pull request quality workflow to detect Rust code changes and then look for current documentation artifacts: root `CHANGELOG.md` changes, `.spektacular/specs/**`, or `.spektacular/plans/**`.
+- Keep the existing `Check Workflow Changelog` and `Fail if Missing` job names, but update their behavior and messages to current terminology.
+- Replace the Gemini autofix path with `openai/codex-action@v1` for same-repository PRs labeled `codex-autofix`.
+- Keep Codex generation scoped to root `CHANGELOG.md`; Spektacular artifacts are produced by the normal Spektacular workflow, not CI.
+
+<!--
+  SUCCESS METRICS
+  How you will know the feature is working well after delivery. Be specific:
+    - Quantitative: "p99 latency < 200ms", "error rate < 0.1%"
+    - Behavioural: "users complete the flow without support intervention"
+  Leave blank if not applicable.
+-->
+## Success Metrics
+
+- Open code PRs such as the codegen optimization and SQLite cleanup are not blocked by the obsolete `wf-changelog.md` requirement after they include current changelog/Spektacular artifacts or rebase onto the fixed workflow.
+- Same-repository code PRs with `codex-autofix` receive a generated root changelog entry instead of a failure.
+
+<!--
+  NON-GOALS
+  Explicitly state what this spec does NOT cover. This is as important as
+  the requirements — it prevents scope creep and sets clear expectations.
+  Examples:
+    - "Mobile support is out of scope (tracked in #456)"
+    - "Internationalisation will be addressed in a follow-up spec"
+  Leave blank if there are no explicit exclusions to call out.
+-->
+## Non-Goals
+
+- Updating release or nightly release workflows that still reference Gemini.
+- Requiring every documentation-only PR to include Spektacular artifacts.
+- Running Codex autofix on fork PRs.
+- Generating Spektacular specs or plans from CI.

--- a/.spektacular/state.json
+++ b/.spektacular/state.json
@@ -12,9 +12,9 @@
     "update_repo_changelog",
     "finished"
   ],
-  "created_at": "2026-04-28T02:58:04.923578Z",
-  "updated_at": "2026-04-28T03:12:59.660867Z",
+  "created_at": "2026-05-02T17:04:11.743322Z",
+  "updated_at": "2026-05-02T17:06:59.226671Z",
   "data": {
-    "name": "20260428024252-docs-current-vs-planned-alignment"
+    "name": "20260502165842-workflow-quality-spektacular-alignment"
   }
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to the Weavster project will be documented in this file.
 
 This project follows a Spektacular-driven documentation workflow where approved specs and plans contribute to this master file.
 
+## 20260502165842-workflow-quality-spektacular-alignment
+
+Pull request quality checks now recognize the current Spektacular documentation workflow. Code changes can satisfy the release-note gate with a root changelog update or Spektacular spec/plan artifacts, and contributors no longer receive instructions for retired workflow changelog or Gemini autofix processes. Same-repository PRs can use a maintainer-applied `codex-autofix` label to generate a root changelog entry with Codex when release-note evidence is missing.
+
 ## 20260428024252-docs-current-vs-planned-alignment
 
 The README and docs site now clearly separate what Weavster supports today from partial, config-only, placeholder, and planned functionality. New users get a source-based install path, a generated file-flow quick start that matches the current CLI, and explicit limits around non-file connectors, local SQLite state, package signing, and placeholder commands. The documentation now gives contributors a single status baseline for future README, docs, and test-health updates.


### PR DESCRIPTION
## Summary
- replace the obsolete wf-changelog/Gemini PR quality gate with Spektacular-era release-note detection
- accept CHANGELOG.md updates or .spektacular specs/plans as release-note evidence for Rust code changes
- add a same-repository, maintainer-triggered codex-autofix path that uses openai/codex-action@v1 to update only CHANGELOG.md
- keep existing check names while removing old Gemini workflow output and retired artifact requirements

## Verification
- Ruby YAML parse for .github/workflows/workflow-quality.yml
- grep confirmed no wf-changelog / wf-update-changelog / gemini-autofix / Gemini CLI / old thoughts references remain in the PR quality workflow
- local shell-equivalent gate simulation for code-only, changelog, Spektacular spec, Spektacular plan, docs-only, fail-job, and codex-autofix cases

## Notes
The codex-autofix job only runs for same-repository PRs with the codex-autofix label and requires an OPENAI_API_KEY repository secret. It is intentionally scoped to CHANGELOG.md and does not generate Spektacular specs/plans.

After this merges, open PRs with code changes can rebase or merge main to pick up the updated workflow.