### PR TITLE
ci: pin Codex changelog model

### DIFF
--- a/.github/workflows/workflow-quality.yml
+++ b/.github/workflows/workflow-quality.yml
@@ -80,6 +80,7 @@ jobs:
         uses: openai/codex-action@v1
         with:
           openai-api-key: ${{ secrets.OPENAI_API_KEY }}
+          model: gpt-5-nano
           sandbox: workspace-write
           prompt: |
             You are updating release-note documentation for a pull request in ${{ github.repository }}.

--- a/.spektacular/plans/20260503134624-pin-codex-action-nano-model/context.md
+++ b/.spektacular/plans/20260503134624-pin-codex-action-nano-model/context.md
@@ -1,0 +1,57 @@
+# Context: 20260503134624-pin-codex-action-nano-model
+
+## Current State Analysis
+
+The workflow quality automation already has a Codex autofix path for same-repository pull requests labeled `codex-autofix`.
+
+- `.github/workflows/workflow-quality.yml:59` — `auto-generate-changelog` job owns the Codex autofix path.
+- `.github/workflows/workflow-quality.yml:62` — job only runs when release-note evidence is missing, `codex-autofix` is present, and the PR branch is in the same repository.
+- `.github/workflows/workflow-quality.yml:80` — job uses `openai/codex-action@v1`.
+- `.github/workflows/workflow-quality.yml:82` — action receives `OPENAI_API_KEY`.
+- `.github/workflows/workflow-quality.yml:83` — action uses `workspace-write` sandbox.
+- `.github/workflows/workflow-quality.yml:84` — action prompt starts; existing prompt content should remain unchanged.
+- `.github/workflows/workflow-quality.yml:106` — commit step verifies only `CHANGELOG.md` changed before committing.
+
+## Per-Phase Technical Notes
+
+### Phase 1.1: Pin the Codex model
+
+- `.github/workflows/workflow-quality.yml:82` — keep `openai-api-key: ${{ secrets.OPENAI_API_KEY }}` unchanged.
+- `.github/workflows/workflow-quality.yml:83` — add `model: gpt-5-nano` near the other Codex action inputs.
+- `.github/workflows/workflow-quality.yml:84` — keep `sandbox: workspace-write` unchanged.
+- `.github/workflows/workflow-quality.yml:84-104` — keep the changelog prompt unchanged.
+- `.github/workflows/workflow-quality.yml:106-119` — keep generated changelog commit behavior unchanged.
+
+**Complexity**: Low
+**Token estimate**: ~5k
+**Agent strategy**: Single agent, sequential execution
+
+## Testing Strategy
+
+Run static checks that confirm the action step now contains `model: gpt-5-nano` and the existing workflow guard strings remain present. Parse the workflow YAML if a local YAML-capable tool is available; otherwise rely on direct review because the edit is a single YAML key in an existing mapping.
+
+No Rust tests are required because no Rust source or behavior changes.
+
+## Project References
+
+- `.spektacular/specs/20260503134624-pin-codex-action-nano-model.md` — approved scope and acceptance criteria.
+- `.spektacular/plans/20260502165842-workflow-quality-spektacular-alignment/plan.md` — prior plan that introduced the Codex autofix path.
+- `.spektacular/plans/20260502165842-workflow-quality-spektacular-alignment/research.md` — prior research documenting why Codex autofix exists and why CI should not generate Spektacular specs.
+
+## Token Management Strategy
+
+| Tier | Token Budget | Agent Strategy |
+|------|-------------|----------------|
+| Low | ~10k | Single agent, sequential |
+| Medium | ~25k | 2-3 parallel agents |
+| High | ~50k+ | Parallel analysis, sequential integration |
+
+This work is low-tier because it touches one workflow key plus Spektacular documentation artifacts.
+
+## Migration Notes
+
+No migration steps are required. Existing pull requests and labels continue to work through the same workflow conditions.
+
+## Performance Considerations
+
+The configured model is the cost-efficient nano GPT-5 variant, so successful Codex autofix runs should use a lower-cost model than the default may have selected. No application runtime performance changes.

--- a/.spektacular/plans/20260503134624-pin-codex-action-nano-model/plan.md
+++ b/.spektacular/plans/20260503134624-pin-codex-action-nano-model/plan.md
@@ -1,0 +1,100 @@
+# Plan: 20260503134624-pin-codex-action-nano-model
+
+<!-- Metadata -->
+<!-- Created: 2026-05-03T13:48:35Z -->
+<!-- Commit: fa7fdd6 -->
+<!-- Branch: ci-pin-codex-gpt-5-nano -->
+<!-- Repository: https://github.com/weavster-dev/weavster.git -->
+
+## Overview
+
+This plan pins the changelog autofix automation to the nano GPT-5 model instead of relying on a moving default. It keeps the existing pull request quality workflow intact while making maintainer-triggered Codex changelog updates cheaper and more predictable.
+
+## Architecture & Design Decisions
+
+The chosen direction is a one-input workflow configuration change: keep the existing Codex action, prompt, sandbox, authentication, permissions, and commit behavior, and add an explicit model selection. This delivers the requested behavior with the smallest blast radius.
+
+The model identifier will be `gpt-5-nano`, because OpenAI's current model documentation lists that as the GPT-5 nano alias and does not document a `gpt-5.5-nano` alias. Using the documented alias avoids introducing an invalid GitHub Actions configuration.
+
+The plan deliberately does not pin the Codex action or Codex CLI package version in the same change. Those are valid follow-ups, but this request is about model selection; combining version pinning would create a broader CI behavior change. See `research.md#alternatives-considered-and-rejected` for rejected options.
+
+## Component Breakdown
+
+- **Pull request quality workflow** owns the release-note evidence gate and the maintainer-triggered changelog autofix path. It remains the only changed component.
+- **Codex changelog generator step** owns invoking Codex to update the root changelog when the existing label and same-repository conditions are met. It gains an explicit model input while preserving existing prompt and sandbox behavior.
+- **Spektacular plan artifacts** document the approved scope and implementation verification for this workflow-only change.
+
+## Data Structures & Interfaces
+
+No application data structures or public interfaces change. The only contract change is the GitHub Action input set for the Codex step:
+
+```yaml
+model: gpt-5-nano
+```
+
+The workflow event contract, labels, permissions, and generated changelog commit contract remain unchanged.
+
+## Implementation Detail
+
+The implementation adds a single `model` input beside the existing Codex action inputs. The surrounding YAML should remain stable so reviewers can see that the action still uses the same OpenAI secret, sandbox, and prompt.
+
+No new module, script, helper, or workflow job is introduced. The developer experience for reading the workflow remains the same, with the model now visible in the step configuration and future action logs.
+
+## Dependencies
+
+- **GitHub Actions**: Provides workflow execution and YAML validation; no version change required.
+- **OpenAI Codex Action**: Provides the `model` input for `codex exec`; no action version change required.
+- **OpenAI model catalog**: Provides the supported `gpt-5-nano` model alias; no repository dependency change required.
+- **Prior workflow quality plan**: Established the Codex autofix path and same-repository guard; this plan builds on that behavior without changing it.
+
+## Testing Approach
+
+Testing is static verification for a workflow-only configuration change. The load-bearing assertion is that the Codex action step now has an explicit `model: gpt-5-nano` input while its existing trigger conditions, prompt, sandbox, secret, permissions, and commit behavior remain unchanged.
+
+No Rust unit tests are added because no Rust code or application behavior changes. YAML parsing and targeted text checks cover the changed surface.
+
+## Milestones & Phases
+
+### Milestone 1: Changelog autofix uses the nano model
+
+**What changes**: Maintainer-triggered changelog autofix jobs no longer depend on the Codex CLI default model. They explicitly request the documented nano GPT-5 model while keeping the current workflow behavior.
+
+#### - [x] Phase 1.1: Pin the Codex model
+
+This phase adds the explicit nano GPT-5 model selection to the changelog autofix step. It keeps the current automation shape unchanged so maintainers still use the same label and same-repository guard to request a generated changelog entry.
+
+*Technical detail:* [context.md#phase-11-pin-the-codex-model](./context.md#phase-11-pin-the-codex-model)
+
+**Acceptance criteria**:
+
+- [x] The changelog generator step explicitly selects the documented nano GPT-5 model.
+- [x] The workflow still uses the existing OpenAI secret, sandbox, prompt, permissions, label guard, and same-repository guard.
+- [x] No Rust source, generated code, or release-note content changes.
+
+## Open Questions
+
+There are no open questions. The undocumented `gpt-5.5-nano` wording from the request was resolved to the documented `gpt-5-nano` alias before implementation.
+
+## Out of Scope
+
+- Changing the Codex action version or Codex CLI package version.
+- Adding fallback behavior for a missing OpenAI secret.
+- Modifying the generated changelog prompt.
+- Changing Rust code, application tests, or release-note content.
+
+## Changelog
+
+### 2026-05-03 — Phase 1.1: Pin the Codex model
+
+**What was done**: The changelog autofix workflow now passes `model: gpt-5-nano` to the Codex action. Existing secret, sandbox, prompt, label guard, same-repository guard, and changelog commit behavior were left unchanged.
+
+**Deviations**: No committed automated test was added because this is a single GitHub Actions input change and the repository has no workflow-test harness; static YAML and action-input checks verified the behavior.
+
+**Files changed**:
+- `.github/workflows/workflow-quality.yml`
+- `.spektacular/specs/20260503134624-pin-codex-action-nano-model.md`
+- `.spektacular/plans/20260503134624-pin-codex-action-nano-model/plan.md`
+- `.spektacular/plans/20260503134624-pin-codex-action-nano-model/context.md`
+- `.spektacular/plans/20260503134624-pin-codex-action-nano-model/research.md`
+
+**Discoveries**: OpenAI documentation lists `gpt-5-nano` as the supported nano GPT-5 model alias; `gpt-5.5-nano` is not documented.

--- a/.spektacular/plans/20260503134624-pin-codex-action-nano-model/research.md
+++ b/.spektacular/plans/20260503134624-pin-codex-action-nano-model/research.md
@@ -1,0 +1,60 @@
+# Research: 20260503134624-pin-codex-action-nano-model
+
+## Alternatives considered and rejected
+
+### Option A: Leave the Codex model unset
+
+This preserves the current workflow and lets Codex CLI choose its default model.
+
+**Rejected**: The current workflow has no `model` input at `.github/workflows/workflow-quality.yml:80-84`, so behavior can drift when Codex CLI defaults change. The spec requires explicit nano GPT-5 selection.
+
+### Option B: Configure `gpt-5.5-nano`
+
+This would match the user's phrase literally.
+
+**Rejected**: OpenAI's model documentation lists `gpt-5-nano` as the GPT-5 nano alias and does not document a `gpt-5.5-nano` alias. Adding an undocumented model ID risks breaking the action before it can generate changelog entries.
+
+### Option C: Pin Codex action and CLI versions in the same PR
+
+This would make more of the action runtime deterministic.
+
+**Rejected**: The current request is model selection only. The action already supports a model input, and changing action or CLI versions would broaden CI behavior beyond the approved spec.
+
+## Chosen approach — evidence
+
+- `.github/workflows/workflow-quality.yml:80` shows the action is already `openai/codex-action@v1`, so the existing step can be configured in place.
+- `.github/workflows/workflow-quality.yml:82-83` shows the action inputs are already grouped under `with`, making a single `model` input the narrowest change.
+- `.github/workflows/workflow-quality.yml:62` shows the same-repository and label guards already exist and do not need modification.
+- `.github/workflows/workflow-quality.yml:106-119` shows generated changelog commit behavior is separate from model selection and can remain unchanged.
+- `https://raw.githubusercontent.com/openai/codex-action/v1/action.yml` documents `model` as an action input.
+- `https://platform.openai.com/docs/models/gpt-5-nano/` documents `gpt-5-nano` as the GPT-5 nano model alias.
+
+## Files examined
+
+- `.github/workflows/workflow-quality.yml:59` — identified the auto-generation job to change.
+- `.github/workflows/workflow-quality.yml:62` — confirmed existing label and same-repository guard.
+- `.github/workflows/workflow-quality.yml:80` — confirmed Codex action version.
+- `.github/workflows/workflow-quality.yml:82-84` — confirmed existing action input block and insertion point.
+- `.github/workflows/workflow-quality.yml:106-119` — confirmed commit behavior should stay unchanged.
+- `.spektacular/plans/20260502165842-workflow-quality-spektacular-alignment/plan.md:32` — prior plan says the Gemini path was replaced by `openai/codex-action@v1`.
+- `.spektacular/plans/20260502165842-workflow-quality-spektacular-alignment/research.md:64` — prior research notes `OPENAI_API_KEY` is required for the Codex autofix path.
+- `.spektacular/knowledge/conventions.md:11` — repository convention asks for tests for new functionality, but this workflow-only config change has no Rust test surface.
+
+## External references
+
+- `https://raw.githubusercontent.com/openai/codex-action/v1/action.yml` — official action metadata; confirms a `model` input is supported.
+- `https://platform.openai.com/docs/models/gpt-5-nano/` — official model page; confirms `gpt-5-nano` is the GPT-5 nano alias.
+
+## Prior plans / specs consulted
+
+- `.spektacular/specs/20260503134624-pin-codex-action-nano-model.md` — defines the current scope and acceptance criteria.
+- `.spektacular/plans/20260502165842-workflow-quality-spektacular-alignment/plan.md` — shows the current Codex autofix workflow design.
+- `.spektacular/plans/20260502165842-workflow-quality-spektacular-alignment/research.md` — records prior decisions around root changelog generation and OpenAI secret assumptions.
+
+## Open assumptions
+
+The plan assumes `gpt-5-nano` is available to the repository's configured OpenAI API key. If the model is not available to that account, implementation must stop and ask for the desired fallback model.
+
+## Rehydration cues
+
+Re-read `.github/workflows/workflow-quality.yml`, `.spektacular/specs/20260503134624-pin-codex-action-nano-model.md`, and this research file. Verify current action metadata and model docs if time has passed, then inspect the Codex action `with` block near the changelog generator step.

--- a/.spektacular/specs/20260503134624-pin-codex-action-nano-model.md
+++ b/.spektacular/specs/20260503134624-pin-codex-action-nano-model.md
@@ -1,0 +1,43 @@
+# Feature: Pin Codex Action Nano Model
+
+## Overview
+
+The automated changelog generator should use a pinned, cost-efficient Codex model instead of relying on whichever default model the action chooses at runtime. This makes maintainer-triggered changelog autofixes more predictable and cheaper while preserving the existing pull request quality workflow.
+
+## Requirements
+
+- [ ] **Pinned model**
+  The changelog autofix automation must explicitly select the nano GPT-5 model.
+- [ ] **Existing behavior preserved**
+  Pull request changelog checks and generated changelog commits must continue to behave as they do today.
+- [ ] **No source-code scope**
+  The change must not alter Rust code, generated artifacts, or release-note content.
+
+## Constraints
+
+- Must use an OpenAI model identifier supported by the Codex GitHub Action.
+- Must keep the current action version and authentication mechanism unchanged.
+- Must follow the repository's Spektacular documentation workflow.
+
+## Acceptance Criteria
+
+- [ ] **Action has explicit model**
+  The Codex changelog generation step includes a `model` input with the supported nano GPT-5 model identifier.
+- [ ] **Workflow scope unchanged**
+  The workflow still checks Rust code changes for release-note evidence and only runs autofix when the existing label and same-repository conditions are met.
+- [ ] **No unrelated files changed**
+  The implementation changes only the workflow configuration plus required Spektacular artifacts.
+
+## Technical Approach
+
+Update the `openai/codex-action@v1` step in the workflow quality automation to pass `model: gpt-5-nano`. Keep all existing prompt, sandbox, permissions, and commit behavior intact. The OpenAI model documentation lists `gpt-5-nano` as the GPT-5 nano alias; no `gpt-5.5-nano` alias is documented.
+
+## Success Metrics
+
+Maintainer-triggered changelog autofix jobs show the configured model input in the action logs and no longer depend on the Codex CLI default model.
+
+## Non-Goals
+
+- Changing the Codex action version.
+- Adding fallback behavior for missing OpenAI secrets.
+- Modifying the generated changelog prompt.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to the Weavster project will be documented in this file.
 
 This project follows a Spektacular-driven documentation workflow where approved specs and plans contribute to this master file.
 
+## 20260503134624-pin-codex-action-nano-model
+
+Maintainer-triggered changelog autofix jobs now explicitly use the GPT-5 nano model instead of relying on the Codex CLI default. This makes generated changelog updates more predictable and cost-efficient while preserving the existing pull request quality workflow and maintainer controls.
+
 ## 20260502165842-workflow-quality-spektacular-alignment
 
 Pull request quality checks now recognize the current Spektacular documentation workflow. Code changes can satisfy the release-note gate with a root changelog update or Spektacular spec/plan artifacts, and contributors no longer receive instructions for retired workflow changelog or Gemini autofix processes. Same-repository PRs can use a maintainer-applied `codex-autofix` label to generate a root changelog entry with Codex when release-note evidence is missing.


### PR DESCRIPTION
## Summary
- pin the Codex changelog autofix step to gpt-5-nano
- add Spektacular spec/plan artifacts for the workflow-only change
- add a root changelog entry for the change

## Verification
- git diff --check
- Ruby YAML/action-input check verified model, secret, sandbox, prompt, label guard, and same-repository guard
- no Rust/source/changelog behavior diffs beyond the release note