### PR TITLE
Remove ignored run flags and align docs

### DIFF
--- a/.spektacular/plans/20260504125300-runtime-docs-alignment-followup/context.md
+++ b/.spektacular/plans/20260504125300-runtime-docs-alignment-followup/context.md
@@ -1,0 +1,95 @@
+# Context: 20260504125300-runtime-docs-alignment-followup
+
+## Current State Analysis
+
+The CLI currently exposes `run --flow` and `run --once` even though the runtime command ignores both values. `crates/weavster-cli/src/main.rs:76` defines the `Run` subcommand, `crates/weavster-cli/src/main.rs:78` defines `flow`, `crates/weavster-cli/src/main.rs:82` defines `once`, and `crates/weavster-cli/src/commands/run.rs:12` accepts `_flow` and `_once` parameters that are intentionally unused.
+
+The test command is project-aware in the docs but not in the implementation. `crates/weavster-cli/src/main.rs:229` dispatches `Commands::Test` without passing `cli.config`, while `crates/weavster-cli/src/commands/test.rs:13` hardcodes `weavster.yaml` and `crates/weavster-cli/src/commands/test.rs:22` discovers `tests/` relative to the current working directory.
+
+The README and docs site still teach removed or misleading run modes. `README.md:43`, `docs/docs/index.md:39`, and `docs/docs/getting-started/first-flow.md:74` show `weavster run --once`; `docs/docs/cli/commands.md:55` and `docs/docs/cli/commands.md:57` show `run --once` and `run --flow`; `README.md:170` says those flags are accepted.
+
+Current runtime limits are more specific than the docs state. `docs/docs/configuration/project.md:47` marks `runtime.local.data_dir` current, but `crates/weavster-cli/src/commands/run.rs:66` hardcodes `.weavster/data/local.db`. `crates/weavster-runtime/src/engine.rs:90` reduces conditional outputs to connector references and `crates/weavster-runtime/src/engine.rs:151` broadcasts each result to every output. `crates/weavster-codegen/src/generator.rs:126` only emits lookup tables already present in IR artifacts, while `crates/weavster-codegen/src/parser.rs:115` parses lookup transforms without loading artifacts. `crates/weavster-codegen/src/generator.rs:168` builds a fresh output map, and transform generators such as map and coalesce read from the original source record.
+
+Internal Rust documentation overstates unfinished runtime capabilities. `crates/weavster-runtime/src/lib.rs:8` lists job queue management as a runtime feature, while `crates/weavster-runtime/src/jobs.rs:57` still has the apalis job handler as a TODO.
+
+The docs site uses npm in CI and has an npm lockfile, but its local README still shows yarn commands. `docs/package.json:5` defines npm scripts, `docs/package-lock.json` is present, `.github/workflows/docs.yml:49` installs with `npm ci`, and `docs/README.md:8` starts with `yarn`.
+
+## Per-Phase Technical Notes
+
+### Phase 1.1: Remove misleading run flags and honor test config
+
+- `crates/weavster-cli/src/main.rs:76` — remove the `flow` and `once` fields from `Commands::Run`, leaving only `profile`.
+- `crates/weavster-cli/src/main.rs:197` — update run dispatch to call `commands::run::run(&cli.config, profile.as_deref())`.
+- `crates/weavster-cli/src/main.rs:229` — update test dispatch to call `commands::test::run(&cli.config, pattern.as_deref(), profile.as_deref())`.
+- `crates/weavster-cli/src/commands/run.rs:12` — simplify the runtime command signature to remove the unused `_flow` and `_once` parameters.
+- `crates/weavster-cli/src/commands/test.rs:13` — change the command signature to accept `config_path`.
+- `crates/weavster-cli/src/commands/test.rs:16` — load config from `config_path` instead of a hardcoded `weavster.yaml`.
+- `crates/weavster-cli/src/commands/test.rs:22` — discover tests from `config.base_path.join("tests")`.
+- `crates/weavster-cli/src/commands/test.rs:39` — after parsing a `TestDefinition`, normalize relative `input` and `expected_output` paths against `config.base_path` before pushing the test.
+- `crates/weavster-cli/tests/cli_test.rs:4` — rename the starter-project test away from `run_once` and run the generated project without `--once`.
+- `crates/weavster-cli/tests/cli_test.rs` — add regression assertions that `weavster run --once` and `weavster run --flow example_flow` fail argument parsing.
+- `crates/weavster-cli/tests/cli_test.rs` — add or extend an integration test that creates a project, writes a YAML test and expected JSONL fixture with project-relative paths, and verifies `weavster --config <project> test` succeeds from outside that project.
+
+**Complexity**: Medium
+**Token estimate**: ~18k
+**Agent strategy**: Single agent, sequential execution. The write set is small and coupled enough that parallel edits would add merge overhead without saving much time.
+
+### Phase 2.1: Align docs and status language
+
+- `README.md:43` — replace `weavster run --once` with `weavster run`.
+- `README.md:150` — clarify that lookup transforms are not end-to-end usable through normal CLI compilation until lookup data is loaded into generated artifacts.
+- `README.md:152` — clarify that conditional outputs are parsed but runtime delivery currently sends each successful record to all configured outputs.
+- `README.md:170` — remove the claim that `run --flow` and `run --once` are accepted; replace it with a limit that `weavster run` has no one-shot or per-flow mode flags.
+- `docs/docs/index.md:39` — replace `weavster run --once` with `weavster run`.
+- `docs/docs/getting-started/first-flow.md:74` — replace `weavster run --once` with `weavster run`.
+- `docs/docs/getting-started/first-flow.md:90` — remove the statement that `--once` is accepted and describe the current run command as processing available input records and exiting.
+- `docs/docs/cli/commands.md:14` — remove "limited option semantics" from the run command status.
+- `docs/docs/cli/commands.md:55` — remove `run --once` and `run --flow` examples; keep `run` and profile usage.
+- `docs/docs/cli/commands.md:62` — remove `--once` and `--flow` from the run options table.
+- `docs/docs/cli/commands.md:110` — document `weavster test` as the one-shot validation command and note that the global config option selects the project.
+- `docs/docs/configuration/project.md:47` — change `runtime.local.data_dir` from current runtime behavior to parsed/config-only status.
+- `docs/docs/configuration/project.md:58` — state that the current CLI runtime uses `.weavster/data/local.db` and does not use `runtime.local.data_dir` to choose the SQLite path.
+- `docs/docs/configuration/flows.md:47` — keep the starter transform ordering language but point detailed chaining caveats to the transforms page.
+- `docs/docs/configuration/flows.md:80` — state that conditional output `when` expressions are parsed but not enforced by current runtime delivery.
+- `docs/docs/concepts/transforms.md:19` — sharpen lookup status to say artifact loading is not wired into normal CLI codegen.
+- `docs/docs/concepts/transforms.md:104` — keep filter and conditional routing caveats explicit.
+- `docs/docs/concepts/transforms.md:108` — clarify direct interpreter versus generated runtime chaining limits so users know current starter transforms are the reliable path.
+- `crates/weavster-runtime/src/lib.rs:8` — replace the job queue management feature claim with implemented runtime capabilities.
+- `crates/weavster-runtime/src/jobs.rs:1` — describe the module as job data models or future queue integration rather than implemented apalis jobs.
+- `docs/README.md:8` — replace yarn instructions with npm commands matching the lockfile and docs CI.
+- `CHANGELOG.md:7` — add a Spektacular entry for this current-state alignment.
+
+**Complexity**: Medium
+**Token estimate**: ~20k
+**Agent strategy**: Single agent, sequential execution. Documentation edits should be reviewed together to keep status wording consistent across README and docs pages.
+
+## Testing Strategy
+
+Phase 1.1 needs CLI integration regression coverage. The essential checks are that the generated starter project still produces the expected JSONL output with `weavster run`, removed flags fail parsing, and the test command works when the project is selected through the global config option.
+
+Phase 2.1 needs documentation and rustdoc verification. Targeted scans should confirm removed run flags are gone from README/docs instructions, while docs build/typecheck and Rust docs catch Markdown, TypeScript, and generated documentation regressions.
+
+## Project References
+
+- `.spektacular/specs/20260504125300-runtime-docs-alignment-followup.md` — approved scope, requirements, non-goals, and acceptance criteria for this follow-up.
+- `.spektacular/plans/20260428024252-docs-current-vs-planned-alignment/plan.md` — established the current/partial/config-only/placeholder/planned status taxonomy.
+- `.spektacular/plans/20260502160602-sqlite-local-runtime-docs-cleanup/plan.md` — established the local SQLite state documentation baseline and compatibility-preserving cleanup approach.
+- `AGENTS.md` — requires Spektacular planning before implementation and docs updates for behavior/interface changes.
+
+## Token Management Strategy
+
+| Tier | Token Budget | Agent Strategy |
+|------|-------------|----------------|
+| Low | ~10k | Single agent, sequential |
+| Medium | ~25k | 2-3 parallel agents |
+| High | ~50k+ | Parallel analysis, sequential integration |
+
+This work is medium by breadth but not by algorithmic risk. Keep it single-agent unless implementation discovers unexpectedly broad test fixture changes.
+
+## Migration Notes
+
+Existing scripts or users that pass `weavster run --once` or `weavster run --flow` must stop passing those flags. The supported replacement for the generated local file-flow path is `weavster run`; explicit one-shot validation should use `weavster test`.
+
+## Performance Considerations
+
+No runtime performance changes are planned. Test command path normalization is filesystem path handling only and should not affect flow execution performance.

--- a/.spektacular/plans/20260504125300-runtime-docs-alignment-followup/plan.md
+++ b/.spektacular/plans/20260504125300-runtime-docs-alignment-followup/plan.md
@@ -1,0 +1,159 @@
+# Plan: 20260504125300-runtime-docs-alignment-followup
+
+<!-- Metadata -->
+<!-- Created: 2026-05-04T13:06:48Z -->
+<!-- Commit: afb7e63 -->
+<!-- Branch: main -->
+<!-- Repository: https://github.com/weavster-dev/weavster.git -->
+
+## Overview
+
+This plan aligns Weavster's CLI and documentation with the current implemented file-flow runtime. It removes ignored run-mode flags, makes one-shot test execution use the configured project, and updates README/docs/rustdoc language so users can distinguish current behavior from planned trigger-driven work.
+
+## Architecture & Design Decisions
+
+The chosen direction is a behavior-backed current-state cleanup. The CLI should stop exposing `run` options that do not change runtime behavior, and documentation should stop teaching those options as usable workflow controls. This keeps the surface honest without building new trigger, watcher, routing, connector, or lookup features in this pass.
+
+The only behavior correction is that `weavster test` should honor the same global project config selection used by the other project-aware commands. Test discovery and relative fixture paths should resolve from the selected project so a non-default config path actually changes the project under test.
+
+The key trade-off is scope control. We are rejecting a docs-only patch because it would leave ignored CLI options in place, but also rejecting implementation of planned runtime features because the goal is to reset the baseline before building them. See `research.md#alternatives-considered-and-rejected` for the rejected options and evidence.
+
+## Component Breakdown
+
+- **CLI command contract** owns the public command and option surface. It should expose only supported `run` options and route global config consistently into project-aware commands.
+- **Test runner project context** owns discovery of YAML tests and fixture paths. It should execute tests against the project selected by the CLI config option rather than the process working directory.
+- **Documentation baseline** owns README, docs-site pages, and generated Rust documentation claims. It should describe current file-flow behavior, test execution, and known limits without implying planned runtime features are available.
+- **Regression verification** owns proof that removed flags fail, current sample runs still work, config-selected tests work, and docs no longer contain stale run-mode instructions.
+
+## Data Structures & Interfaces
+
+No new serialized data structures are introduced. Existing project, flow, connector, and test YAML shapes remain compatible.
+
+Two internal CLI command interfaces change:
+
+```rust
+commands::run::run(config_path, profile)
+commands::test::run(config_path, pattern, profile)
+```
+
+`TestDefinition` keeps the same YAML contract. The CLI test command normalizes relative `input` and `expected_output` paths against the selected project before handing definitions to the existing test executor.
+
+## Implementation Detail
+
+The implementation follows the existing Clap command structure and avoids new modules or abstractions. Removing the `run` fields from the command enum lets Clap reject `--once` and `--flow` automatically, which is the simplest contract for unsupported flags.
+
+The test command keeps the current compile-and-execute flow but loads configuration from the global CLI config path and discovers tests from the loaded project's base path. This mirrors the rest of the CLI's project-aware behavior and keeps path resolution explicit for test fixtures.
+
+Documentation updates keep the existing status taxonomy and page structure. The pass changes inaccurate claims and examples, adds precise caveats for current runtime limits, and updates docs-site setup commands to match the npm lockfile and CI workflow.
+
+## Dependencies
+
+- **`weavster-cli`** provides the command surface, project config routing, runtime command, and test command; it needs small behavior and integration-test updates.
+- **`weavster-core` testing types and executor** provide the existing YAML test model and WASM-backed comparison path; no public test schema changes are needed.
+- **`weavster-codegen` and `weavster-runtime`** provide evidence for transform, lookup, conditional output, and file-only runtime limits; no feature implementation changes are needed.
+- **Docs-site toolchain** uses npm scripts and an npm lockfile; docs setup instructions should match that existing dependency boundary.
+- **Prior current-vs-planned docs plans** provide the status taxonomy and SQLite local-state baseline this follow-up preserves.
+
+## Testing Approach
+
+Testing focuses on CLI contract and project-selection regression. Integration tests should prove the generated file-flow project still runs without removed flags, rejected run flags fail argument parsing, and the test command loads the selected project and relative fixtures.
+
+Documentation verification uses targeted scans plus the normal docs build/typecheck path. Rust formatting, tests, clippy, and rustdoc remain the broader regression guard because this pass touches both CLI behavior and generated API documentation.
+
+## Milestones & Phases
+
+### Milestone 1: CLI matches supported run and test behavior
+
+**What changes**: Users can no longer pass run flags that are ignored, and tests run against the project they selected. The generated file-flow runtime path remains available through `weavster run`, while explicit one-shot validation belongs to `weavster test`.
+
+#### - [x] Phase 1.1: Remove misleading run flags and honor test config
+
+This phase removes unsupported manual run-mode options from the CLI and updates the command wiring around runtime and test execution. It also makes YAML tests discover and read fixtures from the selected project so the global config option behaves consistently. The runtime's current file-flow behavior remains unchanged except that ignored `run` options become invalid.
+
+*Technical detail:* [context.md#phase-11-remove-misleading-run-flags-and-honor-test-config](./context.md#phase-11-remove-misleading-run-flags-and-honor-test-config)
+
+**Acceptance criteria**:
+
+- [x] Runtime execution still works for the generated starter project using the supported `run` command.
+- [x] The run command no longer lists or accepts one-shot or per-flow runtime options.
+- [x] YAML tests run against the project selected through the global config option.
+- [x] Relative test fixture paths resolve from the selected project.
+- [x] No new trigger, watcher, routing, connector, or lookup runtime behavior is introduced.
+
+### Milestone 2: Documentation describes the current baseline
+
+**What changes**: The README, docs site, and Rust API docs stop directing users toward unsupported run flags or overstated runtime features. Current behavior is described as file-based runtime execution plus explicit test execution, while partial features remain visible as limits rather than working guarantees.
+
+#### - [x] Phase 2.1: Align docs and status language
+
+This phase removes stale run-mode examples from user-facing docs and replaces them with current commands. It sharpens the documented limits around runtime state config, conditional outputs, lookup transforms, generated transform chaining, and job queue wording. It also updates docs-site contributor commands to match the package manager actually used by the repository.
+
+*Technical detail:* [context.md#phase-21-align-docs-and-status-language](./context.md#phase-21-align-docs-and-status-language)
+
+**Acceptance criteria**:
+
+- [x] README and docs-site examples no longer teach removed run flags.
+- [x] One-shot validation is documented as test execution rather than a run mode.
+- [x] Current runtime limits are visible for local state path selection, conditional output delivery, lookup artifacts, and generated transform chaining.
+- [x] Rust documentation no longer describes unimplemented job queue management as an available runtime feature.
+- [x] Docs-site setup instructions use the package manager and scripts already present in the docs project.
+- [x] The changelog records the current-state alignment.
+
+## Open Questions
+
+There are no open questions. The scope is current-state alignment only, and the user has already excluded planned trigger-driven runtime behavior from this pass.
+
+## Out of Scope
+
+- Implementing file watchers, event triggers, continuous polling, or trigger-driven runtime startup.
+- Implementing per-flow runtime filtering for `weavster run`.
+- Implementing conditional routing, output filtering, lookup artifact loading, transform-chaining fixes, or non-file connector runtime execution.
+- Changing `runtime.local.data_dir` semantics or moving the runtime SQLite database path.
+- Changing package signing, registry push/pull, placeholder management commands, CI coverage thresholds, or docs-site tooling dependencies.
+
+## Changelog
+
+### FINAL SUMMARY
+
+This plan delivered the current-state cleanup requested for Weavster's run/test/docs baseline. The CLI no longer accepts ignored `run` flags, `weavster test` now honors the selected project config, and README/docs/rustdoc wording now reflects the implemented file-flow runtime and known partial features.
+
+**Total phases**: 2/2 completed
+
+**Notable deviations from the plan**: The CLI test positional argument help was corrected from "Test file or pattern" to "Test name filter" because implementation filters by test name, not by file glob.
+
+### 2026-05-04 — Phase 1.1: Remove misleading run flags and honor test config
+
+**What was done**: Removed the unsupported `run --once` and `run --flow` CLI options so they now fail argument parsing instead of being silently ignored. Updated `weavster test` to load the selected project from the global config option, discover that project's tests directory, and resolve relative test fixtures from the project root.
+
+**Deviations**: The test command help text was also corrected from "Test file or pattern" to "Test name filter" after analysis confirmed the implementation filters test names only.
+
+**Files changed**:
+- `crates/weavster-cli/src/main.rs`
+- `crates/weavster-cli/src/commands/run.rs`
+- `crates/weavster-cli/src/commands/test.rs`
+- `crates/weavster-cli/tests/cli_test.rs`
+- `.spektacular/plans/20260504125300-runtime-docs-alignment-followup/plan.md`
+
+**Discoveries**: `TestDefinition` fixture paths are consumed directly by the core test executor, so CLI-side normalization is the smallest fix that preserves the existing test schema.
+
+### 2026-05-04 — Phase 2.1: Align docs and status language
+
+**What was done**: Updated README and docs-site examples to use `weavster run` without unsupported run-mode flags and documented `weavster test` as the explicit one-shot validation path. Sharpened status wording for local SQLite path selection, conditional output delivery, lookup artifact loading, generated transform chaining, runtime job docs, and docs-site npm commands.
+
+**Deviations**: None.
+
+**Files changed**:
+- `README.md`
+- `docs/docs/index.md`
+- `docs/docs/getting-started/first-flow.md`
+- `docs/docs/cli/commands.md`
+- `docs/docs/configuration/project.md`
+- `docs/docs/configuration/flows.md`
+- `docs/docs/concepts/transforms.md`
+- `crates/weavster-runtime/src/lib.rs`
+- `crates/weavster-runtime/src/jobs.rs`
+- `docs/README.md`
+- `CHANGELOG.md`
+- `.spektacular/plans/20260504125300-runtime-docs-alignment-followup/plan.md`
+
+**Discoveries**: The docs-site build passes but Docusaurus emits a non-fatal update-check warning because the local update config store under the user's home directory is not writable from the process.

--- a/.spektacular/plans/20260504125300-runtime-docs-alignment-followup/research.md
+++ b/.spektacular/plans/20260504125300-runtime-docs-alignment-followup/research.md
@@ -1,0 +1,109 @@
+# Research: 20260504125300-runtime-docs-alignment-followup
+
+## Alternatives considered and rejected
+
+### Option A: Documentation-only cleanup
+
+This option would remove stale `run --once` and `run --flow` instructions from README/docs while leaving the CLI behavior unchanged.
+
+**Rejected**: The CLI currently defines `run --flow` at `crates/weavster-cli/src/main.rs:78` and `run --once` at `crates/weavster-cli/src/main.rs:82`, but the runtime implementation accepts them as `_flow` and `_once` at `crates/weavster-cli/src/commands/run.rs:14` and `crates/weavster-cli/src/commands/run.rs:15`. Leaving ignored options in the binary would keep the misleading contract alive.
+
+### Option B: Implement event triggers or watch mode now
+
+This option would replace removed run modes with a new event-triggered runtime path or file watcher so `run` starts from events rather than manual flags.
+
+**Rejected**: The spec explicitly limits this pass to current-state alignment and excludes file watching, event triggers, routing, and connector runtime implementation. The current runtime file path is pull-based over available file input records at `crates/weavster-runtime/src/engine.rs:130`, so trigger semantics need their own plan.
+
+### Option C: Implement deeper partial features while documenting them
+
+This option would implement `runtime.local.data_dir`, conditional output routing, lookup artifact loading, or generated transform chaining fixes as part of the cleanup.
+
+**Rejected**: Each item changes runtime behavior beyond the current cleanup scope. The current SQLite path is hardcoded at `crates/weavster-cli/src/commands/run.rs:66`, runtime delivery broadcasts to all outputs at `crates/weavster-runtime/src/engine.rs:151`, lookup transforms are parsed without artifact loading at `crates/weavster-codegen/src/parser.rs:115`, and generated transforms start from a fresh output map at `crates/weavster-codegen/src/generator.rs:168`.
+
+## Chosen approach — evidence
+
+The chosen approach is a narrow CLI contract fix plus documentation alignment. Removing the ignored `run` options makes Clap reject unsupported manual run modes automatically, while keeping `weavster run` available for the current file-flow runtime path.
+
+The test command config fix is included because it is current-state consistency rather than planned runtime behavior. Other project-aware commands pass the global config path into command handlers, but `Commands::Test` currently omits it at `crates/weavster-cli/src/main.rs:229`, and the test command hardcodes `weavster.yaml` at `crates/weavster-cli/src/commands/test.rs:15`.
+
+Docs need updates because the stale CLI surface appears in multiple user-facing entry points: `README.md:43`, `README.md:170`, `docs/docs/index.md:39`, `docs/docs/getting-started/first-flow.md:74`, and `docs/docs/cli/commands.md:55`. Additional status wording needs sharpening because current implementation details are narrower than the docs imply.
+
+## Files examined
+
+- `crates/weavster-cli/src/main.rs:76` — `Run` currently exposes `flow`, `once`, and `profile`.
+- `crates/weavster-cli/src/main.rs:197` — run dispatch passes ignored flags into the command handler.
+- `crates/weavster-cli/src/main.rs:229` — test dispatch does not pass the global config path.
+- `crates/weavster-cli/src/commands/run.rs:12` — runtime command signature accepts unused `_flow` and `_once` parameters.
+- `crates/weavster-cli/src/commands/run.rs:66` — local SQLite state path is hardcoded to `.weavster/data/local.db`.
+- `crates/weavster-cli/src/commands/test.rs:13` — test command signature lacks a config path.
+- `crates/weavster-cli/src/commands/test.rs:15` — test command hardcodes `weavster.yaml`.
+- `crates/weavster-cli/src/commands/test.rs:22` — test discovery is relative to the process working directory.
+- `crates/weavster-cli/tests/cli_test.rs:4` — current CLI integration test is named around `run --once`.
+- `crates/weavster-core/src/config.rs:485` — config loader accepts either a project directory or a `weavster.yaml` path and computes `base_path`.
+- `crates/weavster-core/src/testing/models.rs:6` — `TestDefinition` has stable YAML fields for name, flow, input, expected output, and assertions.
+- `crates/weavster-core/src/testing/executor.rs:91` — unit test execution reads input fixtures from `TestDefinition.input`.
+- `crates/weavster-core/src/testing/executor.rs:104` — expected fixtures are read from `TestDefinition.expected_output`.
+- `crates/weavster-runtime/src/engine.rs:90` — conditional outputs are reduced to connector references.
+- `crates/weavster-runtime/src/engine.rs:151` — runtime pushes each successful result to every output connector.
+- `crates/weavster-runtime/src/engine.rs:214` — input connector runtime support is file-only.
+- `crates/weavster-runtime/src/engine.rs:224` — output connector runtime support is file-only.
+- `crates/weavster-runtime/src/lib.rs:8` — rustdoc currently claims job queue management as an implemented feature.
+- `crates/weavster-runtime/src/jobs.rs:57` — apalis job handler remains a TODO.
+- `crates/weavster-codegen/src/generator.rs:126` — static lookup tables are emitted only from existing IR artifacts.
+- `crates/weavster-codegen/src/generator.rs:168` — generated transform code starts with a fresh output map.
+- `crates/weavster-codegen/src/generator.rs:247` — generated map transforms read from the original source record.
+- `crates/weavster-codegen/src/generator.rs:351` — generated lookup transforms reference static tables by lookup table name.
+- `crates/weavster-codegen/src/generator.rs:385` — generated filter transform is a pass-through placeholder.
+- `crates/weavster-codegen/src/generator.rs:401` — generated coalesce transforms read from the original source record.
+- `crates/weavster-codegen/src/parser.rs:115` — lookup transform parsing does not load lookup artifacts.
+- `README.md:43` — quick start still instructs `weavster run --once`.
+- `README.md:150` — lookup status is too vague about end-to-end limitations.
+- `README.md:170` — known limitations still say `run --flow` and `run --once` are accepted.
+- `docs/docs/index.md:39` — docs landing quick start still uses `weavster run --once`.
+- `docs/docs/getting-started/first-flow.md:74` — first-flow guide still uses `weavster run --once`.
+- `docs/docs/getting-started/first-flow.md:90` — first-flow current limits still says `--once` is accepted.
+- `docs/docs/cli/commands.md:55` — CLI docs still list `weavster run --once`.
+- `docs/docs/cli/commands.md:57` — CLI docs still list `weavster run --flow example_flow`.
+- `docs/docs/configuration/project.md:47` — `runtime.local.data_dir` is documented as current runtime behavior.
+- `docs/docs/configuration/flows.md:80` — conditional output enforcement is described as partial but not explicit enough.
+- `docs/docs/concepts/transforms.md:108` — transform chaining is documented broadly without generated-runtime caveats.
+- `docs/README.md:8` — docs-site README uses yarn even though the repo has an npm lockfile.
+- `.github/workflows/docs.yml:49` — docs CI installs with npm.
+- `docs/package.json:5` — docs project exposes npm scripts.
+- `CHANGELOG.md:7` — latest Spektacular entries are timestamped and should receive this cleanup entry.
+
+## External references
+
+None. The current codebase, docs, and prior Spektacular artifacts are sufficient for this cleanup.
+
+## Prior plans / specs consulted
+
+- `.spektacular/specs/20260504125300-runtime-docs-alignment-followup.md` — defines the current-state alignment scope, explicit non-goals, and acceptance criteria.
+- `.spektacular/plans/20260428024252-docs-current-vs-planned-alignment/plan.md` — establishes the status taxonomy used across README and docs-site pages.
+- `.spektacular/plans/20260428024252-docs-current-vs-planned-alignment/research.md` — provides prior source-backed evidence for file-only runtime and partial transform behavior.
+- `.spektacular/plans/20260502160602-sqlite-local-runtime-docs-cleanup/plan.md` — confirms the compatibility-preserving approach for local runtime docs.
+- `.spektacular/plans/20260502160602-sqlite-local-runtime-docs-cleanup/research.md` — confirms SQLite local-state wording and preserving config compatibility as prior decisions.
+
+## Open assumptions
+
+No open assumptions. If implementation reveals that a removed run flag is consumed somewhere outside the inspected CLI path, stop and re-evaluate before changing runtime behavior.
+
+## Rehydration cues
+
+Re-read the active spec and plan:
+
+```bash
+nl -ba .spektacular/specs/20260504125300-runtime-docs-alignment-followup.md
+nl -ba .spektacular/plans/20260504125300-runtime-docs-alignment-followup/plan.md
+nl -ba .spektacular/plans/20260504125300-runtime-docs-alignment-followup/context.md
+```
+
+Regenerate the main source evidence:
+
+```bash
+rg -n "run --once|run --flow|--once|--flow|data_dir|conditional|lookup|job queue|yarn" README.md docs crates CHANGELOG.md
+nl -ba crates/weavster-cli/src/main.rs
+nl -ba crates/weavster-cli/src/commands/run.rs
+nl -ba crates/weavster-cli/src/commands/test.rs
+nl -ba crates/weavster-cli/tests/cli_test.rs
+```

--- a/.spektacular/specs/20260504125300-runtime-docs-alignment-followup.md
+++ b/.spektacular/specs/20260504125300-runtime-docs-alignment-followup.md
@@ -1,0 +1,153 @@
+# Feature: 20260504125300-runtime-docs-alignment-followup
+
+<!--
+  OVERVIEW
+  A concise 2-3 sentence summary of the feature. Answer three questions:
+    1. What is being built?
+    2. What problem does it solve?
+    3. Who benefits and why does it matter?
+  Avoid implementation details — this should be readable by any stakeholder.
+-->
+## Overview
+
+Weavster will align its command behavior and documentation around the current file-based runtime and explicit on-demand test execution. This removes misleading manual flow-run options and corrects remaining documentation drift so users and contributors understand which features work today, which are intentionally future-facing, and how the first proof of concept should behave.
+
+
+
+<!--
+  REQUIREMENTS
+  Specific, testable behaviours the feature must deliver.
+  Format: bold title on the checkbox line, detail indented below.
+  Rules:
+    - Use active voice: "Users can...", "The system must..."
+    - Each requirement should be independently verifiable
+    - Focus on WHAT, not HOW — avoid prescribing implementation
+    - Keep each item atomic — one behaviour per line
+-->
+## Requirements
+
+- [ ] **Users can distinguish current runtime behavior from planned trigger behavior**
+  The product presents current file-based runtime behavior accurately while keeping trigger-driven execution clearly marked as future-facing.
+- [ ] **Users can run tests as explicit one-shot commands**
+  Users can execute tests on demand without treating normal flow execution as a one-message or one-flow test shortcut.
+- [ ] **The run command does not expose unsupported manual run modes**
+  The run command no longer advertises or accepts flow selection or one-message execution options.
+- [ ] **Users can trust documented runtime state configuration**
+  Documentation must not claim that parsed runtime state settings are honored when the current runtime ignores them.
+- [ ] **Users can understand conditional output behavior**
+  Documentation must clearly state whether conditional output expressions affect runtime delivery today.
+- [ ] **Users can understand transform chaining behavior**
+  Documentation must distinguish sequential interpreter behavior from generated runtime behavior when they differ.
+- [ ] **Users can understand lookup support limits**
+  Documentation must not imply lookup transforms are usable end-to-end until lookup data is loaded into generated runtime artifacts.
+- [ ] **Users can rely on documented test command configuration**
+  Test execution must resolve project configuration consistently with documented command usage.
+- [ ] **Developers can rely on internal docs matching implemented runtime features**
+  Internal API documentation must not describe unimplemented job queue behavior as available.
+- [ ] **Docs contributors can use the documented docs-site toolchain**
+  Documentation-site setup instructions must match the package manager and lockfile used by the repository.
+
+
+
+<!--
+  CONSTRAINTS
+  Hard boundaries the solution must operate within. These are non-negotiable.
+  Examples:
+    - Must integrate with the existing authentication system
+    - Cannot introduce breaking changes to the public API
+    - Must support the current minimum supported runtime versions
+  Leave blank if there are no constraints.
+-->
+## Constraints
+
+- Must align documentation and command behavior to the current implemented state, not planned future behavior.
+- Must not implement new file-watching, event-trigger, routing, or connector runtime features in this pass.
+- Must not mention the external product comparison model in the spec, README, docs, or generated documentation.
+- Must not change runtime execution semantics except for removing previously accepted run options that were ignored.
+- Must preserve the workspace's hexagonal architecture and keep edits scoped to CLI surface, documentation, tests, and internal docs.
+
+<!--
+  ACCEPTANCE CRITERIA
+  The specific, binary conditions that define "done".
+  Format: bold title on the checkbox line, verifiable detail indented below.
+  Each criterion must be:
+    - Independently verifiable (pass/fail, not subjective)
+    - Traceable back to a requirement above
+    - Testable by someone who didn't write the code
+-->
+## Acceptance Criteria
+
+- [ ] **Run help omits unsupported options**
+  `weavster run --help` does not show flow-selection or one-message options.
+- [ ] **Unsupported run options are rejected**
+  Running `weavster run --flow example_flow` or `weavster run --once` fails argument parsing instead of silently accepting ignored options.
+- [ ] **Run documentation matches current behavior**
+  README and docs-site command references describe `weavster run` as running configured flows with current file-based behavior and do not instruct users to use flow-selection or one-message options.
+- [ ] **Testing documentation owns one-shot execution**
+  README and docs-site references direct users to `weavster test` for explicit on-demand verification instead of presenting normal runtime execution as a one-shot test shortcut.
+- [ ] **Current runtime limits are accurately labeled**
+  README and docs-site pages clearly label file connector execution as current, non-file connector execution as not current, conditional outputs as ignored or not enforced by runtime delivery, lookup transforms as not end-to-end usable, and generated transform chaining limitations where relevant.
+- [ ] **Runtime state config documentation is accurate**
+  README and docs-site configuration pages do not claim that parsed local data directory settings control the current CLI runtime database path unless implementation support exists.
+- [ ] **Test command honors documented project configuration**
+  Running tests with a non-default project configuration path loads that project rather than always looking in the current directory.
+- [ ] **Internal documentation does not overstate job support**
+  Generated Rust documentation no longer describes job queue management as an implemented runtime feature.
+- [ ] **Docs-site setup instructions match the repository**
+  The docs-site README uses the repository's current package-manager workflow and lockfile.
+- [ ] **Verification passes**
+  Formatting, tests, clippy, Rust documentation, and docs-site build/typecheck pass, except for any locally unavailable optional coverage tooling explicitly noted in the final report.
+
+
+<!--
+  TECHNICAL APPROACH
+  High-level technical direction to guide the planning agent. Include:
+    - Key architectural decisions already made
+    - Preferred patterns or technologies if known
+    - Integration points with existing systems
+    - Known risks or areas of uncertainty
+  Leave blank if you want the planner to propose the approach.
+-->
+## Technical Approach
+
+- Remove the run command's flow-selection and one-message options from the CLI parser and run command plumbing, then update integration tests and command documentation to match.
+- Do not implement file-watching or event-trigger execution in this pass. Present trigger-driven execution as planned direction only, clearly separated from current behavior.
+- Keep current file-based runtime processing unchanged except for no longer accepting ignored run options.
+- Fix the test command's project configuration mismatch by passing the selected configuration path through the CLI to test execution.
+- Align README and docs-site content around current behavior: file connector execution is current, non-file runtime I/O is not current, conditional output predicates are not enforced during delivery, lookup transforms are not end-to-end usable, generated transform behavior has chaining limits, and local runtime state currently uses the hardcoded SQLite path.
+- Update internal Rust documentation so it describes implemented runtime features and does not advertise unfinished job queue management.
+- Update the docs-site README to use the package-manager workflow represented by the repository lockfile.
+- Preserve existing documentation structure and avoid broad redesign.
+
+
+<!--
+  SUCCESS METRICS
+  How you will know the feature is working well after delivery. Be specific:
+    - Quantitative: "p99 latency < 200ms", "error rate < 0.1%"
+    - Behavioural: "users complete the flow without support intervention"
+  Leave blank if not applicable.
+-->
+## Success Metrics
+
+- `weavster run --help` no longer shows ignored options.
+- A reviewer can read the README and docs-site command pages without finding instructions to use removed run options.
+- A reviewer can classify every documented major runtime feature as current, partial, config-only, placeholder, or planned without reading source code.
+- A new contributor can use the documented docs-site setup commands with the checked-in lockfile.
+- CI-equivalent local verification passes after the alignment changes, except for optional coverage tooling when unavailable locally.
+
+<!--
+  NON-GOALS
+  Explicitly state what this spec does NOT cover. This is as important as
+  the requirements — it prevents scope creep and sets clear expectations.
+  Examples:
+    - "Mobile support is out of scope (tracked in #456)"
+    - "Internationalisation will be addressed in a follow-up spec"
+  Leave blank if there are no explicit exclusions to call out.
+-->
+## Non-Goals
+
+- Implementing file watching, new-file triggers, continuous event processing, or any other trigger runtime behavior.
+- Implementing or changing Kafka, PostgreSQL, HTTP, Bridge, conditional routing, lookup artifact loading, package signing, or registry publishing behavior.
+- Adding back manual runtime flow selection or one-message runtime execution under another option name.
+- Redesigning the documentation site, changing branding, or reorganizing the documentation information architecture beyond factual alignment.
+- Changing CI coverage thresholds or introducing new coverage tooling requirements.

--- a/.spektacular/state.json
+++ b/.spektacular/state.json
@@ -12,9 +12,9 @@
     "update_repo_changelog",
     "finished"
   ],
-  "created_at": "2026-05-02T16:10:15.920219Z",
-  "updated_at": "2026-05-02T16:15:56.97707Z",
+  "created_at": "2026-05-04T13:09:47.847701Z",
+  "updated_at": "2026-05-04T13:32:06.173339Z",
   "data": {
-    "name": "20260502160602-sqlite-local-runtime-docs-cleanup"
+    "name": "20260504125300-runtime-docs-alignment-followup"
   }
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to the Weavster project will be documented in this file.
 
 This project follows a Spektacular-driven documentation workflow where approved specs and plans contribute to this master file.
 
+## 20260504125300-runtime-docs-alignment-followup
+
+Removed ignored `weavster run --once` and `weavster run --flow` options from the CLI and updated README/docs to stop teaching those unsupported modes. The test command now honors the global config path for project discovery and relative fixtures, and docs now label current runtime limits around SQLite state path selection, conditional outputs, lookup artifacts, and generated transform chaining more precisely.
+
 ## 20260503150000-codegen-string-allocs
 
 - Performance: optimize string allocations in codegen. The Rust code generator now uses `std::fmt::Write` and `write!` directly on the target `String` buffers, reducing temporary allocations in `crates/weavster-codegen/src/generator.rs` (including the coalesce transform).

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ cargo install --path crates/weavster-cli
 ```bash
 weavster init my-project
 cd my-project
-weavster run --once
+weavster run
 ```
 
 The generated project includes:
@@ -147,9 +147,9 @@ output:
 | `coalesce` | Partial | Parsed, interpreted, and code-generated; not in the starter flow |
 | `regex` | Partial | Parsed and code-generated; not supported by the direct interpreter |
 | `template` | Partial | Parsed and code-generated; not supported by the direct interpreter |
-| `lookup` | Partial | Parsed and code-generated; lookup artifact loading is limited |
+| `lookup` | Partial | Parsed and code-generated, but lookup data is not loaded into generated artifacts in the normal CLI path |
 | `filter` | Partial | Parsed, but generated runtime behavior is currently pass-through/incomplete |
-| Conditional outputs | Partial | Parsed, but expression handling is not enforced end-to-end |
+| Conditional outputs | Partial | Parsed, but current runtime delivery sends each successful record to all configured outputs |
 
 ### Configuration
 
@@ -167,7 +167,7 @@ output:
 
 - Runtime connector execution is file-only today.
 - Local state uses SQLite, not embedded PostgreSQL.
-- `run --flow` and `run --once` are accepted by the CLI, but flow filtering and continuous mode semantics are still limited.
+- `weavster run` has no one-shot or per-flow mode flags; use `weavster test` for explicit one-shot flow checks.
 - `status`, `flow`, and `connector` management commands are placeholders.
 - `validate` does not yet validate all flows, connector references, or expressions.
 - Packaging does not yet produce a complete OCI registry workflow, and signing is not implemented.

--- a/crates/weavster-cli/src/commands/run.rs
+++ b/crates/weavster-cli/src/commands/run.rs
@@ -9,12 +9,7 @@ use weavster_runtime::Runtime;
 use weavster_runtime::state::{PostgresStateStore, SqliteStateStore, StateStore};
 
 /// Run the Weavster runtime
-pub async fn run(
-    config_path: &str,
-    _flow: Option<&str>,
-    _once: bool,
-    profile: Option<&str>,
-) -> Result<()> {
+pub async fn run(config_path: &str, profile: Option<&str>) -> Result<()> {
     tracing::info!("Loading configuration from {}", config_path);
 
     let config =

--- a/crates/weavster-cli/src/commands/test.rs
+++ b/crates/weavster-cli/src/commands/test.rs
@@ -2,6 +2,7 @@
 
 use anyhow::{Context, Result, anyhow};
 use std::collections::HashMap;
+use std::path::{Path, PathBuf};
 use std::time::Instant;
 use walkdir::WalkDir;
 
@@ -10,18 +11,17 @@ use weavster_core::config::Config;
 use weavster_core::testing::{TestDefinition, TestExecutor, TestMode};
 
 /// Run tests
-pub async fn run(pattern: Option<&str>, profile: Option<&str>) -> Result<()> {
+pub async fn run(config_path: &str, pattern: Option<&str>, profile: Option<&str>) -> Result<()> {
     // 0. Load configuration
-    let config_path = "weavster.yaml";
     let config = Config::load_with_profile(config_path, profile)
         .context("Failed to load configuration for testing")?;
 
     // 1. Discover test YAMLs in `tests/` directory
     let mut tests: Vec<TestDefinition> = Vec::new();
 
-    let tests_dir = std::path::Path::new("tests");
+    let tests_dir = config.base_path.join("tests");
     if tests_dir.exists() && tests_dir.is_dir() {
-        for entry_res in WalkDir::new(tests_dir) {
+        for entry_res in WalkDir::new(&tests_dir) {
             let entry = match entry_res {
                 Ok(e) => e,
                 Err(e) => {
@@ -36,8 +36,9 @@ pub async fn run(pattern: Option<&str>, profile: Option<&str>) -> Result<()> {
             {
                 let content = std::fs::read_to_string(entry.path())
                     .with_context(|| format!("Failed to read test file: {:?}", entry.path()))?;
-                let test_def: TestDefinition = serde_yaml::from_str(&content)
+                let mut test_def: TestDefinition = serde_yaml::from_str(&content)
                     .with_context(|| format!("Failed to parse test YAML: {:?}", entry.path()))?;
+                normalize_test_paths(&mut test_def, &config.base_path);
                 tests.push(test_def);
             }
         }
@@ -135,4 +136,20 @@ pub async fn run(pattern: Option<&str>, profile: Option<&str>) -> Result<()> {
     }
 
     Ok(())
+}
+
+fn normalize_test_paths(test: &mut TestDefinition, base_path: &Path) {
+    let input = resolve_project_path(base_path, &test.input);
+    let expected_output = resolve_project_path(base_path, &test.expected_output);
+
+    test.input = input;
+    test.expected_output = expected_output;
+}
+
+fn resolve_project_path(base_path: &Path, path: &Path) -> PathBuf {
+    if path.is_absolute() {
+        path.to_path_buf()
+    } else {
+        base_path.join(path)
+    }
 }

--- a/crates/weavster-cli/src/main.rs
+++ b/crates/weavster-cli/src/main.rs
@@ -75,14 +75,6 @@ enum Commands {
 
     /// Run the Weavster runtime
     Run {
-        /// Run a specific flow only
-        #[arg(short, long)]
-        flow: Option<String>,
-
-        /// Process one message and exit
-        #[arg(long)]
-        once: bool,
-
         /// Configuration profile to use (e.g., dev, prod)
         #[arg(short, long)]
         profile: Option<String>,
@@ -112,7 +104,7 @@ enum Commands {
 
     /// Run tests
     Test {
-        /// Test file or pattern
+        /// Test name filter
         pattern: Option<String>,
 
         /// Configuration profile to use (e.g., dev, prod)
@@ -194,12 +186,8 @@ async fn main() -> Result<()> {
             commands::package::run(&cli.config, sign, output.as_deref(), profile.as_deref())
                 .await?;
         }
-        Commands::Run {
-            flow,
-            once,
-            profile,
-        } => {
-            commands::run::run(&cli.config, flow.as_deref(), once, profile.as_deref()).await?;
+        Commands::Run { profile } => {
+            commands::run::run(&cli.config, profile.as_deref()).await?;
         }
         Commands::Validate { profile } => {
             commands::validate::run(&cli.config, profile.as_deref()).await?;
@@ -227,7 +215,7 @@ async fn main() -> Result<()> {
             }
         },
         Commands::Test { pattern, profile } => {
-            commands::test::run(pattern.as_deref(), profile.as_deref()).await?;
+            commands::test::run(&cli.config, pattern.as_deref(), profile.as_deref()).await?;
         }
     }
 

--- a/crates/weavster-cli/tests/cli_test.rs
+++ b/crates/weavster-cli/tests/cli_test.rs
@@ -1,7 +1,9 @@
 use assert_cmd::cargo::cargo_bin_cmd;
+use predicates::prelude::*;
+use std::fs;
 
 #[test]
-fn test_init_and_run_once() {
+fn test_init_and_run() {
     let dir = tempfile::tempdir().unwrap();
 
     // Init project
@@ -28,9 +30,9 @@ fn test_init_and_run_once() {
         "generated weavster.yaml should omit runtime.local.port"
     );
 
-    // Run --once
+    // Run the generated project
     cargo_bin_cmd!("weavster")
-        .args(["--config", dir.path().to_str().unwrap(), "run", "--once"])
+        .args(["--config", dir.path().to_str().unwrap(), "run"])
         .assert()
         .success();
 
@@ -59,9 +61,115 @@ fn test_init_and_run_once() {
     assert_eq!(lines[1]["full_name"], "Bob Smith");
     assert_eq!(lines[1]["email"], "bob@example.com");
     assert_eq!(lines[1]["processed"], true);
+    assert!(lines[1].get("name").is_none(), "name should be dropped");
+    assert!(lines[1].get("age").is_none(), "age should be dropped");
 
     // Third record: Carol
     assert_eq!(lines[2]["full_name"], "Carol Williams");
     assert_eq!(lines[2]["email"], "carol@example.com");
     assert_eq!(lines[2]["processed"], true);
+    assert!(lines[2].get("name").is_none(), "name should be dropped");
+    assert!(lines[2].get("age").is_none(), "age should be dropped");
+}
+
+#[test]
+fn test_run_rejects_removed_flags() {
+    let dir = tempfile::tempdir().unwrap();
+
+    cargo_bin_cmd!("weavster")
+        .args(["init", dir.path().to_str().unwrap()])
+        .assert()
+        .success();
+
+    let unexpected_argument = predicate::str::contains("unexpected argument");
+
+    cargo_bin_cmd!("weavster")
+        .args(["--config", dir.path().to_str().unwrap(), "run", "--once"])
+        .assert()
+        .failure()
+        .stderr(
+            unexpected_argument
+                .clone()
+                .and(predicate::str::contains("--once")),
+        );
+
+    cargo_bin_cmd!("weavster")
+        .args([
+            "--config",
+            dir.path().to_str().unwrap(),
+            "run",
+            "--flow",
+            "example_flow",
+        ])
+        .assert()
+        .failure()
+        .stderr(unexpected_argument.and(predicate::str::contains("--flow")));
+}
+
+#[test]
+fn test_test_command_uses_config_project_for_relative_fixtures() {
+    let dir = tempfile::tempdir().unwrap();
+
+    cargo_bin_cmd!("weavster")
+        .args(["init", dir.path().to_str().unwrap()])
+        .assert()
+        .success();
+
+    let expected_output_path = dir.path().join("tests/expected_output.jsonl");
+    fs::write(
+        &expected_output_path,
+        r#"{"full_name":"Alice Johnson","email":"alice@example.com","processed":true}
+{"full_name":"Bob Smith","email":"bob@example.com","processed":true}
+{"full_name":"Carol Williams","email":"carol@example.com","processed":true}
+"#,
+    )
+    .unwrap();
+
+    let test_path = dir.path().join("tests/example_flow.yaml");
+    fs::write(
+        &test_path,
+        r#"name: starter flow transforms sample records
+flow: example_flow
+input: data/input.jsonl
+expected_output: tests/expected_output.jsonl
+assertions:
+  - type: record_count
+    count: 3
+  - type: field_exists
+    field: full_name
+  - type: field_exists
+    field: email
+  - type: field_exists
+    field: processed
+  - type: field_value
+    field: processed
+    equals: true
+  - type: field_not_exists
+    field: name
+  - type: field_not_exists
+    field: age
+"#,
+    )
+    .unwrap();
+
+    assert!(test_path.exists(), "YAML test fixture should exist");
+    assert!(
+        expected_output_path.exists(),
+        "expected output fixture should exist"
+    );
+
+    let repo_root = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .and_then(std::path::Path::parent)
+        .expect("crate should be inside the workspace");
+
+    cargo_bin_cmd!("weavster")
+        .current_dir(repo_root)
+        .args(["--config", dir.path().to_str().unwrap(), "test"])
+        .assert()
+        .success()
+        .stdout(
+            predicate::str::contains("✓ starter flow transforms sample records")
+                .and(predicate::str::contains("1 passed, 0 failed")),
+        );
 }

--- a/crates/weavster-cli/tests/cli_test.rs
+++ b/crates/weavster-cli/tests/cli_test.rs
@@ -1,9 +1,13 @@
 use assert_cmd::cargo::cargo_bin_cmd;
 use predicates::prelude::*;
 use std::fs;
+use std::sync::Mutex;
+
+static WASM_COMPILE_LOCK: Mutex<()> = Mutex::new(());
 
 #[test]
 fn test_init_and_run() {
+    let _guard = WASM_COMPILE_LOCK.lock().unwrap();
     let dir = tempfile::tempdir().unwrap();
 
     // Init project
@@ -108,6 +112,7 @@ fn test_run_rejects_removed_flags() {
 
 #[test]
 fn test_test_command_uses_config_project_for_relative_fixtures() {
+    let _guard = WASM_COMPILE_LOCK.lock().unwrap();
     let dir = tempfile::tempdir().unwrap();
 
     cargo_bin_cmd!("weavster")

--- a/crates/weavster-runtime/src/jobs.rs
+++ b/crates/weavster-runtime/src/jobs.rs
@@ -1,4 +1,4 @@
-//! Job definitions for apalis
+//! Job data models for future queue integration
 
 use serde::{Deserialize, Serialize};
 

--- a/crates/weavster-runtime/src/lib.rs
+++ b/crates/weavster-runtime/src/lib.rs
@@ -5,9 +5,9 @@
 //!
 //! # Features
 //!
-//! - Job queue management via apalis
-//! - Flow execution engine
-//! - Connector lifecycle management
+//! - WASM-backed flow execution engine
+//! - File connector input/output runtime
+//! - SQLite and Postgres state store implementations
 //!
 //! # Usage
 //!

--- a/docs/README.md
+++ b/docs/README.md
@@ -5,13 +5,13 @@ This website is built using [Docusaurus](https://docusaurus.io/), a modern stati
 ## Installation
 
 ```bash
-yarn
+npm ci
 ```
 
 ## Local Development
 
 ```bash
-yarn start
+npm run start
 ```
 
 This command starts a local development server and opens up a browser window. Most changes are reflected live without having to restart the server.
@@ -19,7 +19,7 @@ This command starts a local development server and opens up a browser window. Mo
 ## Build
 
 ```bash
-yarn build
+npm run build
 ```
 
 This command generates static content into the `build` directory and can be served using any static contents hosting service.
@@ -29,13 +29,13 @@ This command generates static content into the `build` directory and can be serv
 Using SSH:
 
 ```bash
-USE_SSH=true yarn deploy
+USE_SSH=true npm run deploy
 ```
 
 Not using SSH:
 
 ```bash
-GIT_USER=<Your GitHub username> yarn deploy
+GIT_USER=<Your GitHub username> npm run deploy
 ```
 
 If you are using GitHub pages for hosting, this command is a convenient way to build the website and push to the `gh-pages` branch.

--- a/docs/docs/cli/commands.md
+++ b/docs/docs/cli/commands.md
@@ -11,7 +11,7 @@ The CLI currently exposes implemented, partial, placeholder, and planned surface
 | Command | Status | Notes |
 | --- | --- | --- |
 | `weavster init` | Current | Creates a starter project |
-| `weavster run` | Current | Runs the file-based flow path, with limited option semantics |
+| `weavster run` | Current | Runs the file-based flow path |
 | `weavster compile` | Current | Compiles flows to WASM artifacts |
 | `weavster test` | Partial | Runs YAML-defined flow tests through compiled WASM where available |
 | `weavster validate` | Partial | Loads project config; deeper validation is still TODO |
@@ -52,18 +52,17 @@ Creates `weavster.yaml`, `flows/example_flow.yaml`, `connectors/file.yaml`, `tes
 Run the runtime.
 
 ```bash
-weavster run --once
+weavster run
 weavster run --profile production
-weavster run --flow example_flow
 ```
 
 Options:
 
 | Option | Status | Notes |
 | --- | --- | --- |
-| `--once` | Partial | Accepted by the CLI; current file flow already runs over available input records and exits |
-| `--flow <name>` | Partial | Accepted by the CLI; flow filtering semantics are limited |
 | `--profile <name>` | Current | Loads an inline profile from `weavster.yaml` |
+
+There are no current one-shot or per-flow options for `weavster run`.
 
 ## `weavster compile`
 
@@ -115,9 +114,10 @@ Run YAML-defined tests from a project `tests/` directory.
 weavster test
 weavster test example
 weavster test --profile development
+weavster --config ./my-project test
 ```
 
-Test execution is partial and centered on compiled WASM flow checks.
+Test execution is partial and centered on compiled WASM flow checks. Use `weavster test` for explicit one-shot flow validation; the global `--config` option selects which project supplies tests and relative fixtures.
 
 ## Placeholder Commands
 

--- a/docs/docs/concepts/transforms.md
+++ b/docs/docs/concepts/transforms.md
@@ -16,7 +16,7 @@ Transforms manipulate JSON records as they move through a flow. Support varies b
 | `coalesce` | Partial | Parsed, interpreted, and code-generated; not in the starter flow |
 | `regex` | Partial | Parsed and code-generated; not supported by the direct interpreter |
 | `template` | Partial | Parsed and code-generated; not supported by the direct interpreter |
-| `lookup` | Partial | Parsed and code-generated; lookup artifact loading is limited |
+| `lookup` | Partial | Parsed and code-generated, but lookup data is not loaded into generated artifacts in the normal CLI path |
 | `filter` | Partial | Parsed, but generated runtime behavior is currently pass-through/incomplete |
 
 ## Current Starter Transforms
@@ -105,7 +105,7 @@ Filter expression support is incomplete in the generated runtime path. Do not re
 
 ## Chaining Transforms
 
-Transforms execute in order. Keep starter flows to current transforms unless you are intentionally testing partial behavior.
+The direct interpreter applies transforms in order. In the generated runtime path, several transform generators still read from the original input record rather than the current accumulated output, so keep starter flows to the validated `map`, `drop`, and `add_fields` pattern unless you are intentionally testing partial behavior.
 
 ```yaml
 transforms:

--- a/docs/docs/configuration/flows.md
+++ b/docs/docs/configuration/flows.md
@@ -44,7 +44,7 @@ The reference format is `filename.key`. `file.input` maps to the `input` entry i
 
 ## Transforms
 
-Transforms are applied in order. The current starter path uses `map`, `drop`, and `add_fields`.
+Transforms are applied in order by the direct interpreter. The current generated starter path uses `map`, `drop`, and `add_fields`; see [Transforms](../concepts/transforms) for generated-runtime chaining limits.
 
 ```yaml
 transforms:
@@ -77,7 +77,7 @@ outputs:
     when: "total > 1000"
 ```
 
-Conditional output expression enforcement is partial today and should not be treated as a complete routing feature.
+Conditional output `when` expressions are parsed, but current runtime delivery does not enforce them. Successful records are sent to all resolved output connectors, so this syntax should not be treated as a routing feature yet.
 
 ## Flow-Level Options
 

--- a/docs/docs/configuration/project.md
+++ b/docs/docs/configuration/project.md
@@ -44,7 +44,7 @@ macros_dir: macros
 | `name` | Current | Project name |
 | `version` | Current | Project version, defaults to `0.1.0` |
 | `runtime.mode` | Config-only | Parsed from config, but it does not currently select the runtime backend |
-| `runtime.local.data_dir` | Current | Local runtime data directory |
+| `runtime.local.data_dir` | Config-only | Parsed from config; current CLI runtime state still uses the default SQLite path |
 | `runtime.local.port` | Compatibility-only | Legacy field accepted by config parsing; not used by SQLite local state and not included in new starter projects |
 | `runtime.remote.postgres_url` | Config-only | Parsed from config; current CLI runtime selects Postgres state only from the `WEAVSTER_PG_URL` environment variable |
 | `runtime.remote.redis_url` | Planned | Modeled in config; distributed Redis runtime is not implemented |
@@ -55,7 +55,7 @@ macros_dir: macros
 
 ## Runtime State
 
-Local runtime state currently defaults to SQLite at `.weavster/data/local.db`.
+Local runtime state currently uses SQLite at `.weavster/data/local.db`. The `runtime.local.data_dir` field is parsed for compatibility, but the current CLI runtime does not use it to choose the SQLite database path.
 
 Postgres state is available when `WEAVSTER_PG_URL` is set in the environment. Setting only `runtime.mode: remote` or `runtime.remote.postgres_url` in `weavster.yaml` does not currently switch the CLI runtime away from the local SQLite path. The `remote` config shape exists, but remote/distributed runtime behavior is not complete.
 

--- a/docs/docs/getting-started/first-flow.md
+++ b/docs/docs/getting-started/first-flow.md
@@ -71,7 +71,7 @@ output:
 ## Run the Flow
 
 ```bash
-weavster run --once
+weavster run
 ```
 
 Weavster will:
@@ -87,7 +87,7 @@ Weavster will:
 
 - The end-to-end runtime path currently supports file connectors only.
 - Local state uses SQLite, not embedded PostgreSQL.
-- `--once` is accepted by the CLI, but current file processing already runs over available input records and exits.
+- `weavster run` processes available file input records and exits. Use `weavster test` for explicit one-shot flow checks.
 
 ## Next Steps
 

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -36,7 +36,7 @@ cargo install --path crates/weavster-cli
 
 weavster init my-project
 cd my-project
-weavster run --once
+weavster run
 ```
 
 ## Core Concepts


### PR DESCRIPTION
## Summary
- remove unsupported `weavster run --once` and `weavster run --flow` flags
- make `weavster test` honor global `--config` and project-relative fixtures
- align README/docs/rustdoc/changelog with the current file-flow runtime baseline
- add Spektacular spec and implementation plan artifacts

## Verification
- `cargo fmt --check`
- `cargo test --all-features`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features`
- `npm run build`
- `npm run typecheck`

Note: docs build passed with a non-fatal Docusaurus update-check warning about local config-store permissions.