### PR TITLE
M0 follow-up: record milestone labels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - `CHANGELOG.md` and a CLAUDE.md rule to update it with every commit.
 - `README.md` describing the current state of the project.
 - CLAUDE.md rule to keep `README.md` matching actual (not future) state.
+- GitHub milestone labels M0–M9 matching the MVP plan.
 
 ### Changed
 

--- a/docs/MVP_TASKS.md
+++ b/docs/MVP_TASKS.md
@@ -44,7 +44,7 @@ Use this on every meaningful task before merge.
 - [x] Commit this `MVP_TASKS.md` file.
 - [x] Add `CONTRIBUTING.md` with small-PR and testing rules.
 - [x] Add PR template with docs and test checklist.
-- [ ] Add issue labels or project board columns matching milestones.
+- [x] Add issue labels or project board columns matching milestones. _(labels M0–M9 on GitHub)_
 
 ### Personal control
 


### PR DESCRIPTION
## What changed

Restores M0 bookkeeping dropped in the #44 squash merge: checks the "issue labels" task and adds the changelog entry. The M0–M9 labels already exist on GitHub.

## Milestone / task

M0 — Planning artifacts: "Add issue labels or project board columns matching milestones."

## Checklist

- [x] One concept per PR
- [ ] Tests — N/A (docs/bookkeeping only)
- [x] Diff reviewed file by file

## Docs

- [x] Docs updated (task list + changelog)

🤖 Generated with [Claude Code](https://claude.com/claude-code)