### PR TITLE
docs: serve site from docs.weavster.dev

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Changed
 
+- Serve the docs site from the `docs.weavster.dev` custom domain (`CNAME` + `url`/`baseUrl`).
 - Moved planning docs from `mvp/` to `docs/` to match the plan's repo shape.
 - Clarified tool-repo vs user-project split in `MVP_PLAN.md`: defined the `weavster init` user-project layout once, separated tool-test fixtures from user-project fixtures, and pinned `examples/golden-path/` as the reference `init` output.
 - Patched M9 in `MVP_TASKS.md` to generate the golden-path example via `weavster init` and treat it as the `init` output contract.

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ them locally, test them with fixtures, and run them through a modular engine.
 
 - Repository scaffold and folder structure.
 - Docusaurus documentation site in [`website/`](website/) with placeholder pages and
-  CI to build on PRs and deploy to GitHub Pages on merge.
+  CI to build on PRs and deploy to [docs.weavster.dev](https://docs.weavster.dev) on merge.
 - pnpm workspace at the repo root.
 - Contribution rules ([`CONTRIBUTING.md`](CONTRIBUTING.md)) and PR template.
 - Editor/formatter config (`.editorconfig`, Prettier).

--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -13,9 +13,9 @@ const config: Config = {
     v4: true,
   },
 
-  // Production URL for GitHub Pages.
-  url: 'https://weavster-dev.github.io',
-  baseUrl: '/weavster/',
+  // Production URL (custom domain served via GitHub Pages).
+  url: 'https://docs.weavster.dev',
+  baseUrl: '/',
 
   organizationName: 'weavster-dev',
   projectName: 'weavster',

--- a/website/static/CNAME
+++ b/website/static/CNAME
@@ -1,0 +1,1 @@
+docs.weavster.dev


### PR DESCRIPTION
## What changed

Points the docs site at the `docs.weavster.dev` custom domain: `url` → `https://docs.weavster.dev`, `baseUrl` → `/`, and a static `CNAME` so GitHub Pages preserves the domain on each deploy.

## Verification

- `pnpm docs:build` passes; `website/build/CNAME` contains `docs.weavster.dev`.

## Repo setting

- Settings → Pages: custom domain `docs.weavster.dev` (you've set this) and DNS `CNAME docs → weavster-dev.github.io`. Keep "Enforce HTTPS" on once the cert provisions.

## Checklist

- [x] One concept per PR
- [x] Diff reviewed file by file

## Docs

- [x] README + CHANGELOG updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)