### PR TITLE
chore(cli): add cli:link script for global local install

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Added
 
+- `cli:link` root script that builds `@weavster/cli` and links `weavster` globally
+  for local use in any folder.
 - M2 config validation: `v0alpha1` project schema at `spec/schemas/project.schema.json`.
 - `@weavster/cli` package with the `weavster validate` command (commander + Ajv + yaml),
   emitting path-aware error messages.

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "docs:build": "pnpm --filter website build",
     "docs:serve": "pnpm --filter website serve",
     "cli:build": "pnpm --filter @weavster/cli build",
+    "cli:link": "pnpm --filter @weavster/cli build && cd cli && pnpm link --global",
     "test": "pnpm --filter @weavster/cli test",
     "format": "prettier --write .",
     "format:check": "prettier --check ."


### PR DESCRIPTION
## Summary
- Add root `cli:link` script: builds `@weavster/cli` and links the `weavster` binary globally for local use in any folder.

## Usage
```
pnpm cli:link        # build + global link (rerun after CLI source changes)
weavster validate path/to/weavster.yaml
```
Requires `pnpm setup` once (sets `PNPM_HOME`).

## Test plan
- `pnpm cli:link` then `weavster validate spec/examples/project/valid.weavster.yaml` from an unrelated folder → passes.
- Invalid sample → exit 1 with path-aware error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)