### PR TITLE
M4: canonical document model (@weavster/core)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,8 @@ jobs:
 
       - run: pnpm install --frozen-lockfile
 
+      - run: pnpm --filter @weavster/core build
+
       - run: pnpm cli:build
 
       - run: pnpm test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Added
 
+- M4 canonical document model in the new `@weavster/core` package: a format-agnostic
+  node tree (`scalar`/`object`/`array`) with a `Document` wrapper carrying source format
+  and validation messages, `fromValue`/`toValue` normalization, and dotted-path access
+  helpers (`parsePath`/`formatPath`/`get`/`getValue`). Concepts page documents it.
 - M3 fixture test harness: `weavster test` runs a project's `fixtures/<case>/`
   (`input.json` vs `expected.json`), compares output, and prints a readable diff on
   mismatch. The flow is an identity passthrough until the transform engine lands.

--- a/README.md
+++ b/README.md
@@ -21,13 +21,17 @@ them locally, test them with fixtures, and run them through a modular engine.
   lands, so a fixture passes when `expected.json` matches `input.json`.
 - A reference user project at [`examples/golden-path/`](examples/golden-path/) exercised
   by `validate` and `test`.
+- `@weavster/core`: the canonical document model — a format-agnostic node tree
+  (`scalar`/`object`/`array`) with `fromValue`/`toValue` normalization and dotted-path
+  access helpers (`get`/`getValue`). See [Concepts](https://docs.weavster.dev/concepts).
 - Contribution rules ([`CONTRIBUTING.md`](CONTRIBUTING.md)) and PR template.
 - Editor/formatter config (`.editorconfig`, Prettier).
 - Dev log ([`notes/DEV_LOG.md`](notes/DEV_LOG.md)) and changelog
   ([`CHANGELOG.md`](CHANGELOG.md)).
 
-The transform engine and format packs are not implemented yet; `validate` and `test`
-exist of the planned CLI commands.
+Format packs and the transform engine are not implemented yet; `validate` and `test`
+exist of the planned CLI commands, and `@weavster/core` provides the model they will
+build on.
 
 ## Local development
 
@@ -37,7 +41,7 @@ Requires Node 22+ and pnpm.
 pnpm install        # install workspace dependencies
 pnpm docs:start     # run the docs site locally
 pnpm docs:build     # production build of the docs site
-pnpm test           # run the CLI test suite
+pnpm test           # run all package test suites (core + cli)
 pnpm format         # format with Prettier
 
 # run a command against a project during development

--- a/core/package.json
+++ b/core/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "@weavster/core",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "test": "vitest run"
+  },
+  "devDependencies": {
+    "@types/node": "^22.10.5",
+    "typescript": "^5.7.3",
+    "vitest": "^3.0.5"
+  }
+}

--- a/core/src/index.ts
+++ b/core/src/index.ts
@@ -1,0 +1,2 @@
+export * from './model.js';
+export * from './path.js';

--- a/core/src/model.ts
+++ b/core/src/model.ts
@@ -1,0 +1,106 @@
+/**
+ * Canonical document model.
+ *
+ * Every input format (JSON, XML, ...) is normalized into this one shape so that
+ * transforms operate on a single representation instead of format-specific
+ * objects. A `Node` is a tagged union of the three structural kinds; a
+ * `Document` wraps a root node with metadata about where it came from.
+ */
+
+/** Leaf values the model preserves from raw input. */
+export type Scalar = string | number | boolean | null;
+
+export interface ScalarNode {
+  kind: 'scalar';
+  value: Scalar;
+}
+
+export interface ObjectNode {
+  kind: 'object';
+  /** Insertion order is preserved; it carries element order for ordered formats. */
+  fields: Record<string, Node>;
+}
+
+export interface ArrayNode {
+  kind: 'array';
+  items: Node[];
+}
+
+export type Node = ScalarNode | ObjectNode | ArrayNode;
+
+export type SourceFormat = 'json' | 'xml' | 'unknown';
+
+export interface ValidationMessage {
+  /** Dotted path to the offending node, or empty for document-level messages. */
+  path: string;
+  message: string;
+}
+
+export interface DocumentMeta {
+  sourceFormat: SourceFormat;
+  errors: ValidationMessage[];
+}
+
+export interface Document {
+  root: Node;
+  meta: DocumentMeta;
+}
+
+export function isScalar(node: Node): node is ScalarNode {
+  return node.kind === 'scalar';
+}
+
+export function isObject(node: Node): node is ObjectNode {
+  return node.kind === 'object';
+}
+
+export function isArray(node: Node): node is ArrayNode {
+  return node.kind === 'array';
+}
+
+export function document(root: Node, meta: Partial<DocumentMeta> = {}): Document {
+  return {
+    root,
+    meta: { sourceFormat: meta.sourceFormat ?? 'unknown', errors: meta.errors ?? [] },
+  };
+}
+
+/**
+ * Normalize a native JS value into a canonical node.
+ *
+ * This is the model's intake boundary: format packs turn text into JS values,
+ * then hand the value here. `undefined` is treated as a null scalar.
+ */
+export function fromValue(value: unknown): Node {
+  if (Array.isArray(value)) {
+    return { kind: 'array', items: value.map(fromValue) };
+  }
+  if (value !== null && typeof value === 'object') {
+    const fields: Record<string, Node> = {};
+    for (const [key, child] of Object.entries(value as Record<string, unknown>)) {
+      fields[key] = fromValue(child);
+    }
+    return { kind: 'object', fields };
+  }
+  if (value === undefined) {
+    return { kind: 'scalar', value: null };
+  }
+  return { kind: 'scalar', value: value as Scalar };
+}
+
+/** Convert a canonical node back into a native JS value. */
+export function toValue(node: Node): unknown {
+  switch (node.kind) {
+    case 'scalar':
+      return node.value;
+    case 'array':
+      return node.items.map(toValue);
+    case 'object': {
+      const out: Record<string, unknown> = {};
+      for (const [key, child] of Object.entries(node.fields)) {
+        out[key] = toValue(child);
+      }
+      return out;
+    }
+  }
+}

--- a/core/src/path.ts
+++ b/core/src/path.ts
@@ -1,0 +1,67 @@
+/**
+ * Path addressing for the canonical model.
+ *
+ * The canonical form of a path is a segment array: string segments address
+ * object fields, number segments address array indices. The string form is
+ * dotted with bracketed indices — `lines[0].sku` ⇄ `['lines', 0, 'sku']` —
+ * and is what the transform DSL will accept from authors.
+ */
+import { type Document, type Node, toValue } from './model.js';
+
+export type Segment = string | number;
+
+const TOKEN = /\[(\d+)\]|([^.[\]]+)/g;
+
+/** Parse a dotted/bracketed path string into segments. `''` is the root. */
+export function parsePath(path: string): Segment[] {
+  if (path === '') return [];
+  const segments: Segment[] = [];
+  for (const match of path.matchAll(TOKEN)) {
+    const [, index, key] = match;
+    segments.push(index !== undefined ? Number(index) : key);
+  }
+  return segments;
+}
+
+/** Render segments back into a dotted/bracketed path string. */
+export function formatPath(segments: Segment[]): string {
+  let out = '';
+  for (const segment of segments) {
+    if (typeof segment === 'number') {
+      out += `[${segment}]`;
+    } else {
+      out += out === '' ? segment : `.${segment}`;
+    }
+  }
+  return out;
+}
+
+function rootOf(target: Document | Node): Node {
+  return 'root' in target ? target.root : target;
+}
+
+/** Resolve a path to its node, or `undefined` if any segment is absent. */
+export function get(target: Document | Node, path: string | Segment[]): Node | undefined {
+  const segments = typeof path === 'string' ? parsePath(path) : path;
+  let current: Node = rootOf(target);
+  for (const segment of segments) {
+    if (typeof segment === 'number') {
+      if (current.kind !== 'array' || segment < 0 || segment >= current.items.length) {
+        return undefined;
+      }
+      current = current.items[segment];
+    } else {
+      if (current.kind !== 'object' || !(segment in current.fields)) {
+        return undefined;
+      }
+      current = current.fields[segment];
+    }
+  }
+  return current;
+}
+
+/** Resolve a path to a native JS value, or `undefined` if absent. */
+export function getValue(target: Document | Node, path: string | Segment[]): unknown {
+  const node = get(target, path);
+  return node === undefined ? undefined : toValue(node);
+}

--- a/core/test/model.test.ts
+++ b/core/test/model.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from 'vitest';
+import { document, fromValue, isArray, isObject, isScalar, toValue } from '../src/model.js';
+
+describe('fromValue', () => {
+  it('normalizes scalars', () => {
+    expect(fromValue('hi')).toEqual({ kind: 'scalar', value: 'hi' });
+    expect(fromValue(3)).toEqual({ kind: 'scalar', value: 3 });
+    expect(fromValue(true)).toEqual({ kind: 'scalar', value: true });
+    expect(fromValue(null)).toEqual({ kind: 'scalar', value: null });
+  });
+
+  it('treats undefined as a null scalar', () => {
+    expect(fromValue(undefined)).toEqual({ kind: 'scalar', value: null });
+  });
+
+  it('normalizes nested objects and arrays', () => {
+    const node = fromValue({ a: 1, b: [{ c: 'x' }] });
+    expect(node).toEqual({
+      kind: 'object',
+      fields: {
+        a: { kind: 'scalar', value: 1 },
+        b: {
+          kind: 'array',
+          items: [{ kind: 'object', fields: { c: { kind: 'scalar', value: 'x' } } }],
+        },
+      },
+    });
+  });
+
+  it('preserves object key insertion order', () => {
+    const node = fromValue({ z: 1, a: 2, m: 3 });
+    expect(isObject(node) && Object.keys(node.fields)).toEqual(['z', 'a', 'm']);
+  });
+});
+
+describe('toValue', () => {
+  it('round-trips arbitrary nested values', () => {
+    const value = { id: 'A-1', lines: [{ sku: 'W', qty: 3 }], active: false, note: null };
+    expect(toValue(fromValue(value))).toEqual(value);
+  });
+});
+
+describe('guards', () => {
+  it('discriminate node kinds', () => {
+    expect(isScalar(fromValue(1))).toBe(true);
+    expect(isObject(fromValue({}))).toBe(true);
+    expect(isArray(fromValue([]))).toBe(true);
+  });
+});
+
+describe('document', () => {
+  it('defaults metadata', () => {
+    const doc = document(fromValue({}));
+    expect(doc.meta).toEqual({ sourceFormat: 'unknown', errors: [] });
+  });
+
+  it('carries source format and errors', () => {
+    const doc = document(fromValue({}), {
+      sourceFormat: 'json',
+      errors: [{ path: 'a', message: 'bad' }],
+    });
+    expect(doc.meta.sourceFormat).toBe('json');
+    expect(doc.meta.errors).toEqual([{ path: 'a', message: 'bad' }]);
+  });
+});

--- a/core/test/path.test.ts
+++ b/core/test/path.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from 'vitest';
+import { document, fromValue } from '../src/model.js';
+import { formatPath, get, getValue, parsePath } from '../src/path.js';
+
+describe('parsePath', () => {
+  it('parses the root as empty', () => {
+    expect(parsePath('')).toEqual([]);
+  });
+
+  it('parses dotted keys and bracket indices', () => {
+    expect(parsePath('lines[0].sku')).toEqual(['lines', 0, 'sku']);
+    expect(parsePath('a.b.c')).toEqual(['a', 'b', 'c']);
+    expect(parsePath('matrix[1][2]')).toEqual(['matrix', 1, 2]);
+  });
+
+  it('keeps a numeric object key as a string', () => {
+    expect(parsePath('counts.0')).toEqual(['counts', '0']);
+  });
+});
+
+describe('formatPath', () => {
+  it('is the inverse of parsePath', () => {
+    for (const path of ['lines[0].sku', 'a.b.c', 'matrix[1][2]', 'counts.0']) {
+      expect(formatPath(parsePath(path))).toBe(path);
+    }
+  });
+});
+
+describe('get', () => {
+  const doc = document(fromValue({ orderId: 'A-1', lines: [{ sku: 'W', qty: 3 }, { sku: 'G' }] }));
+
+  it('resolves a nested object field', () => {
+    expect(get(doc, 'orderId')).toEqual({ kind: 'scalar', value: 'A-1' });
+  });
+
+  it('resolves through an array index', () => {
+    expect(getValue(doc, 'lines[1].sku')).toBe('G');
+  });
+
+  it('accepts a segment array directly', () => {
+    expect(getValue(doc, ['lines', 0, 'qty'])).toBe(3);
+  });
+
+  it('returns undefined for a missing field', () => {
+    expect(get(doc, 'missing')).toBeUndefined();
+    expect(get(doc, 'lines[0].missing')).toBeUndefined();
+  });
+
+  it('returns undefined for an out-of-range index', () => {
+    expect(get(doc, 'lines[5]')).toBeUndefined();
+  });
+
+  it('returns undefined when indexing a non-array or keying a non-object', () => {
+    expect(get(doc, 'orderId[0]')).toBeUndefined();
+    expect(get(doc, 'orderId.x')).toBeUndefined();
+  });
+
+  it('resolves the same path regardless of how the document was built', () => {
+    // The model is format-agnostic: a document a future JSON pack would build and
+    // one a future XML pack would build resolve a shared path identically.
+    const fromJsonLike = document(fromValue({ item: { id: 7 } }), { sourceFormat: 'json' });
+    const fromXmlLike = document(fromValue({ item: { id: 7 } }), { sourceFormat: 'xml' });
+    expect(getValue(fromJsonLike, 'item.id')).toBe(getValue(fromXmlLike, 'item.id'));
+  });
+});

--- a/core/tsconfig.json
+++ b/core/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "rootDir": "src",
+    "outDir": "dist",
+    "strict": true,
+    "types": ["node"],
+    "declaration": true,
+    "sourceMap": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true
+  },
+  "include": ["src"]
+}

--- a/docs/MVP_TASKS.md
+++ b/docs/MVP_TASKS.md
@@ -129,24 +129,24 @@ Use this on every meaningful task before merge.
 
 ### Model design
 
-- [ ] Define internal normalized node structure.
-- [ ] Define path addressing rules.
-- [ ] Define metadata fields for source format and validation messages.
-- [ ] Decide what information is preserved from raw input.
+- [x] Define internal normalized node structure. _(tagged union `scalar`/`object`/`array`)_
+- [x] Define path addressing rules. _(segment array canonical; dotted + bracket string form)_
+- [x] Define metadata fields for source format and validation messages. _(`DocumentMeta`)_
+- [x] Decide what information is preserved from raw input. _(scalars, object keys + order, arrays)_
 
 ### Implementation
 
-- [ ] Add canonical model types.
-- [ ] Add path access helpers.
-- [ ] Add tests for nested objects, arrays, and path lookups.
-- [ ] Add tests showing the same transform target can work across formats later.
+- [x] Add canonical model types. _(`@weavster/core` `model.ts`)_
+- [x] Add path access helpers. _(`parsePath`/`formatPath`/`get`/`getValue`)_
+- [x] Add tests for nested objects, arrays, and path lookups.
+- [x] Add tests showing the same transform target can work across formats later.
 
 ### Docs and understanding
 
-- [ ] Write canonical model concept page.
-- [ ] Add one diagram or table explaining the model.
-- [ ] Trace one input document manually through normalization.
-- [ ] Add a dev log entry explaining why this model exists.
+- [x] Write canonical model concept page.
+- [x] Add one diagram or table explaining the model. _(node-kind table + normalization tree)_
+- [x] Trace one input document manually through normalization. _(Concepts page + DEV_LOG)_
+- [x] Add a dev log entry explaining why this model exists. _(see DEV_LOG M4 entry)_
 
 ## Milestone 5 — JSON format pack
 

--- a/notes/DEV_LOG.md
+++ b/notes/DEV_LOG.md
@@ -13,6 +13,27 @@ Newest entries on top. One entry per merged slice.
 
 ---
 
+## 2026-06-03 — M4 canonical document model
+
+- What changed: Created the `@weavster/core` package holding the canonical model.
+  `core/src/model.ts` defines `Node` as a tagged union of `scalar`/`object`/`array`, a
+  `Document` wrapping a root node with `{ sourceFormat, errors }` metadata, type guards,
+  and `fromValue`/`toValue` to normalize native JS values to/from nodes.
+  `core/src/path.ts` defines path addressing: segment arrays are canonical (strings =
+  object fields, numbers = array indices), with `parsePath`/`formatPath` for the dotted +
+  bracket string form (`lines[0].sku`) and `get`/`getValue` to resolve a path to a node or
+  value. Added the package to the pnpm workspace, switched root `test` to `pnpm -r test`,
+  added a core build step to CI, and wrote the Concepts page.
+- What I learned: The model is the seam that lets one transform serve many formats — by
+  the time a transform runs, format is gone and only nodes remain (M5 JSON / M6 XML both
+  target the same three kinds). Decisions: a tagged union (not native values + sidecar
+  metadata) makes XML attributes/text/order representable later without reshaping; the
+  dotted+bracket path syntax keeps a numeric object key (`counts.0`, string) distinct from
+  an array index (`counts[0]`, number). `fromValue`/`toValue` are the model's intake
+  boundary; format packs own only text⇄value, the model owns value⇄node. vitest runs TS
+  without typechecking, so CI builds core with `tsc` to catch type errors.
+- What is next: M5 — JSON format pack (parse/serialize, map into the canonical model).
+
 ## 2026-06-03 — M3 fixture test harness
 
 - What changed: Added `weavster test [path]`. `cli/src/fixtures.ts` scans a project's

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "docs:serve": "pnpm --filter website serve",
     "cli:build": "pnpm --filter @weavster/cli build",
     "cli:link": "pnpm --filter @weavster/cli build && cd cli && pnpm link --global",
-    "test": "pnpm --filter @weavster/cli test",
+    "test": "pnpm -r test",
     "format": "prettier --write .",
     "format:check": "prettier --check ."
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -37,6 +37,18 @@ importers:
         specifier: ^3.0.5
         version: 3.2.6(@types/debug@4.1.13)(@types/node@22.19.19)(jiti@1.21.7)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
 
+  core:
+    devDependencies:
+      '@types/node':
+        specifier: ^22.10.5
+        version: 22.19.19
+      typescript:
+        specifier: ^5.7.3
+        version: 5.9.3
+      vitest:
+        specifier: ^3.0.5
+        version: 3.2.6(@types/debug@4.1.13)(@types/node@22.19.19)(jiti@1.21.7)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
+
   website:
     dependencies:
       '@docusaurus/core':

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,4 @@
 packages:
+  - core
   - cli
   - website

--- a/website/docs/concepts.md
+++ b/website/docs/concepts.md
@@ -7,6 +7,64 @@ title: Concepts
 
 Core ideas: config-first authoring, the canonical document model, format packs, and transforms.
 
-:::note
-Placeholder page. Content lands with the milestone that builds this feature.
-:::
+## The canonical document model
+
+Weavster never transforms raw JSON or XML directly. Every input is first **normalized**
+into one internal shape — the canonical document model — and transforms operate on that.
+This is why a single transform can later target inputs that arrived as JSON _or_ XML: by
+the time a transform runs, the format is gone and only the canonical model remains.
+
+### Nodes
+
+A `Node` is a tagged union of three structural kinds:
+
+| Kind     | Shape                        | Represents                                    |
+| -------- | ---------------------------- | --------------------------------------------- |
+| `scalar` | `{ kind: 'scalar', value }`  | a leaf: string, number, boolean, or null      |
+| `object` | `{ kind: 'object', fields }` | a keyed map; key insertion order is preserved |
+| `array`  | `{ kind: 'array', items }`   | an ordered list                               |
+
+A `Document` wraps a root node with metadata:
+
+```ts
+interface Document {
+  root: Node;
+  meta: {
+    sourceFormat: 'json' | 'xml' | 'unknown';
+    errors: { path: string; message: string }[];
+  };
+}
+```
+
+`sourceFormat` records where the document came from; `errors` collects validation
+messages keyed by path. The structural kinds stay the same no matter the source format —
+a future XML pack maps elements to objects, attributes to fields, and repeated elements
+to arrays, all targeting the same three kinds.
+
+### Normalization
+
+Format packs turn text into native JS values; the model's `fromValue` then turns a value
+into nodes, and `toValue` reverses it. Tracing `{ "orderId": "A-1", "lines": [{ "sku": "W" }] }`:
+
+```text
+object
+├─ orderId: scalar "A-1"
+└─ lines:   array
+            └─ [0]: object
+                    └─ sku: scalar "W"
+```
+
+### Paths
+
+Nodes are addressed by **path**. The canonical form is a segment array (string segments
+address object fields, numbers address array indices); the string form is dotted with
+bracketed indices:
+
+```text
+lines[0].sku   ⇄   ['lines', 0, 'sku']
+```
+
+`get` resolves a path to a node (or `undefined` if any segment is absent) and `getValue`
+resolves it to a native value. A numeric object key stays a string (`counts.0`), while an
+array index uses brackets (`counts[0]`), so the two never collide. This path syntax is
+what the transform DSL will accept from authors.


### PR DESCRIPTION
## Summary
- New `@weavster/core` package: the format-agnostic canonical model every input normalizes into and transforms operate on.
- **model.ts** — `Node` tagged union (`scalar`/`object`/`array`), `Document` wrapper with `{ sourceFormat, errors }` metadata, type guards, `fromValue`/`toValue` normalization.
- **path.ts** — path addressing. Segment arrays are canonical (strings = object fields, numbers = array indices); dotted+bracket string form (`lines[0].sku`) via `parsePath`/`formatPath`; `get`/`getValue` resolve a path to a node/value.
- Wired into pnpm workspace; root `test` → `pnpm -r test`; CI builds core (vitest does not typecheck); Concepts page documents the model.

## Design decisions
- **Tagged union** over native-value + sidecar metadata: makes XML attributes/text/order representable later (M6) without reshaping.
- **Dotted+bracket paths**: a numeric object key (`counts.0`, string) stays distinct from an array index (`counts[0]`, number).
- `fromValue`/`toValue` are the model's intake boundary — format packs own text⇄value, the model owns value⇄node.

## Test plan
- `pnpm test` → core 19 (8 model, 11 path) + cli 11, all pass.
- `pnpm --filter @weavster/core build` and `pnpm cli:build` clean.
- `pnpm docs:build` succeeds (Concepts MDX renders).

## MVP tasks
- Closes Milestone 4 in `docs/MVP_TASKS.md`. Next: M5 JSON format pack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)