### PR TITLE
M5: JSON format pack

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,11 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Added
 
+- M5 JSON format pack in `@weavster/core` (`json` namespace): `json.parse` (text →
+  canonical `Document` tagged `json`, `JsonParseError` on invalid input) and
+  `json.serialize` (document/node → 2-space JSON with trailing newline). Stable
+  round-trip; a richer nested JSON case added to the golden-path example. Format Packs
+  docs page added.
 - M4 canonical document model in the new `@weavster/core` package: a format-agnostic
   node tree (`scalar`/`object`/`array`) with a `Document` wrapper carrying source format
   and validation messages, `fromValue`/`toValue` normalization, and dotted-path access

--- a/README.md
+++ b/README.md
@@ -24,14 +24,17 @@ them locally, test them with fixtures, and run them through a modular engine.
 - `@weavster/core`: the canonical document model — a format-agnostic node tree
   (`scalar`/`object`/`array`) with `fromValue`/`toValue` normalization and dotted-path
   access helpers (`get`/`getValue`). See [Concepts](https://docs.weavster.dev/concepts).
+- JSON format pack (`@weavster/core` `json` namespace): `json.parse`/`json.serialize`
+  between JSON text and the canonical model, with stable round-tripping. See
+  [Format Packs](https://docs.weavster.dev/formats).
 - Contribution rules ([`CONTRIBUTING.md`](CONTRIBUTING.md)) and PR template.
 - Editor/formatter config (`.editorconfig`, Prettier).
 - Dev log ([`notes/DEV_LOG.md`](notes/DEV_LOG.md)) and changelog
   ([`CHANGELOG.md`](CHANGELOG.md)).
 
-Format packs and the transform engine are not implemented yet; `validate` and `test`
-exist of the planned CLI commands, and `@weavster/core` provides the model they will
-build on.
+The XML format pack and the transform engine are not implemented yet; `validate` and
+`test` exist of the planned CLI commands, and `@weavster/core` provides the model and
+JSON pack they will build on.
 
 ## Local development
 
@@ -57,8 +60,8 @@ pnpm --filter @weavster/cli dev test ./path/to/project
 | `website/`    | Docusaurus docs site (not yet scaffolded)                  |
 | `spec/`       | Config JSON Schemas and example configs                    |
 | `cli/`        | CLI commands                                               |
-| `core/`       | Canonical document model and engine                        |
-| `formats/`    | Format packs (JSON, XML)                                   |
+| `core/`       | Canonical document model, format packs, and engine         |
+| `formats/`    | Reserved for format packs if later extracted from `core/`  |
 | `functions/`  | Built-in transform functions                               |
 | `ts-runtime/` | TypeScript escape hatch for custom transforms              |
 | `tests/`      | Fixtures and integration tests                             |

--- a/core/src/formats/json.ts
+++ b/core/src/formats/json.ts
@@ -1,0 +1,33 @@
+/**
+ * JSON format pack.
+ *
+ * Format packs own the text⇄value boundary; the canonical model owns
+ * value⇄node. So `parse` is `JSON.parse` followed by `fromValue`, and
+ * `serialize` is `toValue` followed by `JSON.stringify`.
+ */
+import { type Document, type Node, document, fromValue, toValue } from '../model.js';
+
+/** Thrown when input text is not valid JSON. */
+export class JsonParseError extends Error {
+  constructor(message: string, options?: { cause?: unknown }) {
+    super(message, options);
+    this.name = 'JsonParseError';
+  }
+}
+
+/** Parse JSON text into a canonical document. */
+export function parse(text: string): Document {
+  let value: unknown;
+  try {
+    value = JSON.parse(text);
+  } catch (err) {
+    throw new JsonParseError(`invalid JSON: ${(err as Error).message}`, { cause: err });
+  }
+  return document(fromValue(value), { sourceFormat: 'json' });
+}
+
+/** Serialize a document or node to JSON text (2-space indent, trailing newline). */
+export function serialize(target: Document | Node): string {
+  const node = 'root' in target ? target.root : target;
+  return `${JSON.stringify(toValue(node), null, 2)}\n`;
+}

--- a/core/src/index.ts
+++ b/core/src/index.ts
@@ -1,2 +1,3 @@
 export * from './model.js';
 export * from './path.js';
+export * as json from './formats/json.js';

--- a/core/test/json.test.ts
+++ b/core/test/json.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from 'vitest';
+import { toValue } from '../src/model.js';
+import { JsonParseError, parse, serialize } from '../src/formats/json.js';
+
+describe('parse', () => {
+  it('parses JSON text into a canonical document tagged json', () => {
+    const doc = parse('{"a": 1, "b": ["x"]}');
+    expect(doc.meta.sourceFormat).toBe('json');
+    expect(doc.root).toEqual({
+      kind: 'object',
+      fields: {
+        a: { kind: 'scalar', value: 1 },
+        b: { kind: 'array', items: [{ kind: 'scalar', value: 'x' }] },
+      },
+    });
+  });
+
+  it('parses top-level scalars and arrays', () => {
+    expect(toValue(parse('42').root)).toBe(42);
+    expect(toValue(parse('null').root)).toBeNull();
+    expect(toValue(parse('[1, 2, 3]').root)).toEqual([1, 2, 3]);
+  });
+
+  it('throws JsonParseError on invalid JSON', () => {
+    expect(() => parse('{not json}')).toThrow(JsonParseError);
+  });
+});
+
+describe('serialize', () => {
+  it('renders 2-space indented JSON with a trailing newline', () => {
+    const out = serialize(parse('{"a":1}'));
+    expect(out).toBe('{\n  "a": 1\n}\n');
+  });
+
+  it('accepts a bare node', () => {
+    expect(serialize(parse('[1,2]').root)).toBe('[\n  1,\n  2\n]\n');
+  });
+});
+
+describe('round-trip', () => {
+  it('preserves values through parse → serialize → parse', () => {
+    const text = serialize(
+      parse('{"orderId":"A-1","lines":[{"sku":"W","qty":3}],"active":false,"note":null}'),
+    );
+    const first = toValue(parse(text).root);
+    const second = toValue(parse(serialize(parse(text))).root);
+    expect(first).toEqual({
+      orderId: 'A-1',
+      lines: [{ sku: 'W', qty: 3 }],
+      active: false,
+      note: null,
+    });
+    expect(second).toEqual(first);
+  });
+
+  it('is stable: serialize is idempotent on its own output', () => {
+    const once = serialize(parse('{"b":2,"a":1}'));
+    expect(serialize(parse(once))).toBe(once);
+  });
+});

--- a/docs/MVP_TASKS.md
+++ b/docs/MVP_TASKS.md
@@ -152,17 +152,17 @@ Use this on every meaningful task before merge.
 
 ### JSON support
 
-- [ ] Create JSON format pack structure.
-- [ ] Implement JSON parser.
-- [ ] Implement JSON serializer.
-- [ ] Map JSON into canonical model.
-- [ ] Add round-trip tests.
+- [x] Create JSON format pack structure. _(`core/src/formats/json.ts`, `json` namespace)_
+- [x] Implement JSON parser. _(`json.parse` → `Document`, `JsonParseError` on bad input)_
+- [x] Implement JSON serializer. _(`json.serialize`, 2-space + trailing newline)_
+- [x] Map JSON into canonical model. _(`fromValue`/`toValue` at the value boundary)_
+- [x] Add round-trip tests.
 
 ### Docs and understanding
 
-- [ ] Write JSON format pack docs.
-- [ ] Add one JSON example to the golden path.
-- [ ] Confirm you understand every step from raw JSON to normalized model to output.
+- [x] Write JSON format pack docs. _(Format Packs page)_
+- [x] Add one JSON example to the golden path. _(`fixtures/nested-order`)_
+- [x] Confirm you understand every step from raw JSON to normalized model to output. _(see DEV_LOG M5 entry)_
 
 ## Milestone 6 — XML format pack
 

--- a/examples/golden-path/fixtures/nested-order/expected.json
+++ b/examples/golden-path/fixtures/nested-order/expected.json
@@ -1,0 +1,9 @@
+{
+  "orderId": "A-1002",
+  "customer": { "id": "acme-co", "vip": true, "note": null },
+  "lines": [
+    { "sku": "WIDGET-1", "qty": 3, "tags": ["a", "b"] },
+    { "sku": "GADGET-9", "qty": 1, "tags": [] }
+  ],
+  "total": 42.5
+}

--- a/examples/golden-path/fixtures/nested-order/input.json
+++ b/examples/golden-path/fixtures/nested-order/input.json
@@ -1,0 +1,9 @@
+{
+  "orderId": "A-1002",
+  "customer": { "id": "acme-co", "vip": true, "note": null },
+  "lines": [
+    { "sku": "WIDGET-1", "qty": 3, "tags": ["a", "b"] },
+    { "sku": "GADGET-9", "qty": 1, "tags": [] }
+  ],
+  "total": 42.5
+}

--- a/notes/DEV_LOG.md
+++ b/notes/DEV_LOG.md
@@ -13,6 +13,24 @@ Newest entries on top. One entry per merged slice.
 
 ---
 
+## 2026-06-04 — M5 JSON format pack
+
+- What changed: Added the JSON format pack at `core/src/formats/json.ts`, exported as the
+  `json` namespace from `@weavster/core`. `json.parse(text)` runs `JSON.parse` then
+  `fromValue` to produce a `Document` tagged `sourceFormat: 'json'`, throwing `JsonParseError`
+  on invalid input. `json.serialize(docOrNode)` runs `toValue` then `JSON.stringify` with a
+  2-space indent and trailing newline. Added round-trip + stability tests, a richer nested
+  JSON case to the golden-path example, and a Format Packs docs page (wired into the sidebar).
+- What I learned: The format pack is deliberately thin — it owns only text⇄value, while the
+  model owns value⇄node (`fromValue`/`toValue`). That split is what lets one transform serve
+  many formats: by the time a transform runs, format is gone. Decisions: the pack lives as a
+  module inside `@weavster/core` (not its own package) to avoid cross-package resolution and
+  build-before-test friction — it can be extracted later if a real need appears. Syntax errors
+  throw (`JsonParseError`); `meta.errors` stays reserved for semantic validation in a later
+  milestone. The cli fixture harness is intentionally NOT rewired to the pack yet — that
+  integration belongs with the engine (M7+), keeping cli↔core decoupled for now.
+- What is next: M6 — XML format pack (parser, serializer, map into the canonical model).
+
 ## 2026-06-03 — M4 canonical document model
 
 - What changed: Created the `@weavster/core` package holding the canonical model.

--- a/website/docs/formats.md
+++ b/website/docs/formats.md
@@ -1,0 +1,43 @@
+---
+sidebar_position: 5
+title: Format Packs
+---
+
+# Format packs
+
+A format pack teaches Weavster how to read and write one wire format. It owns the
+**text⇄value** boundary; the [canonical model](./concepts.md) owns **value⇄node**. So a
+pack is thin: parse text to a native value and hand it to the model, or take a value back
+from the model and render it as text.
+
+```text
+text ──parse──▶ value ──fromValue──▶ Node        (read)
+Node ──toValue──▶ value ──serialize──▶ text       (write)
+```
+
+Because every pack targets the same canonical model, a transform written once applies
+regardless of whether the input arrived as JSON or XML.
+
+## JSON
+
+The JSON pack is the first one, exposed under the `json` namespace of `@weavster/core`.
+
+```ts
+import { json, toValue } from '@weavster/core';
+
+const doc = json.parse('{"orderId":"A-1","lines":[{"sku":"W","qty":3}]}');
+doc.meta.sourceFormat; // 'json'
+toValue(doc.root); // { orderId: 'A-1', lines: [{ sku: 'W', qty: 3 }] }
+
+json.serialize(doc); // 2-space indented JSON with a trailing newline
+```
+
+- **`parse(text)`** runs `JSON.parse`, then normalizes the value into a canonical
+  `Document` tagged `sourceFormat: 'json'`. Invalid input throws `JsonParseError`.
+- **`serialize(docOrNode)`** converts back to a native value and renders it with a
+  2-space indent and a trailing newline.
+
+Serializing is stable — `serialize` applied to its own output returns the same text — so
+JSON survives a parse→serialize→parse round trip with its values intact. The
+[golden-path example](https://github.com/weavster-dev/weavster/tree/main/examples/golden-path)
+exercises JSON fixtures end to end via `weavster test`.

--- a/website/sidebars.ts
+++ b/website/sidebars.ts
@@ -7,6 +7,7 @@ const sidebars: SidebarsConfig = {
     'concepts',
     'cli',
     'config',
+    'formats',
     'testing',
     'architecture',
     'contributing',


### PR DESCRIPTION
## Summary
- JSON format pack as a module in `@weavster/core`, exposed under the `json` namespace. Packs own only **text⇄value**; the canonical model owns **value⇄node**.
- `json.parse(text)` → `JSON.parse` + `fromValue` → `Document` tagged `sourceFormat: 'json'`; throws `JsonParseError` on invalid input.
- `json.serialize(docOrNode)` → `toValue` + `JSON.stringify` (2-space indent, trailing newline); stable across `parse → serialize → parse`.
- Richer nested JSON case added to the golden-path example; Format Packs docs page wired into the sidebar.

## Decisions
- **Pack lives in `@weavster/core`** (not its own package): avoids cross-package resolution + build-before-test friction; extract later if needed.
- **Syntax errors throw** (`JsonParseError`); `meta.errors` reserved for semantic validation (later milestone).
- **cli harness not rewired** to the pack this milestone — that integration belongs with the engine (M7+), keeping cli↔core decoupled.

## Test plan
- `pnpm test` → core 26 (+7 json) + cli 11, all pass.
- `pnpm --filter @weavster/core build` / `pnpm cli:build` clean.
- `pnpm docs:build` succeeds.
- `weavster test examples/golden-path` → 2/2 fixtures passed.

## MVP tasks
- Closes Milestone 5 in `docs/MVP_TASKS.md`. Next: M6 XML format pack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)