### PR TITLE
M6: XML format pack

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,12 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Added
 
+- M6 XML format pack in `@weavster/core` (`xml` namespace), built on fast-xml-parser:
+  `xml.parse` (well-formedness-checked text → canonical `Document` tagged `xml`,
+  `XmlParseError` on malformed input) and `xml.serialize`. Attributes map to `@`-prefixed
+  fields, element text to `#text`, repeated elements to arrays; leaf values stay strings.
+  Includes a pluggable `XmlValidator` interface (default `wellFormedValidator`, room for
+  XSD), round-trip tests, and Format Packs docs with a JSON/XML comparison and limitations.
 - M5 JSON format pack in `@weavster/core` (`json` namespace): `json.parse` (text →
   canonical `Document` tagged `json`, `JsonParseError` on invalid input) and
   `json.serialize` (document/node → 2-space JSON with trailing newline). Stable

--- a/README.md
+++ b/README.md
@@ -24,17 +24,19 @@ them locally, test them with fixtures, and run them through a modular engine.
 - `@weavster/core`: the canonical document model — a format-agnostic node tree
   (`scalar`/`object`/`array`) with `fromValue`/`toValue` normalization and dotted-path
   access helpers (`get`/`getValue`). See [Concepts](https://docs.weavster.dev/concepts).
-- JSON format pack (`@weavster/core` `json` namespace): `json.parse`/`json.serialize`
-  between JSON text and the canonical model, with stable round-tripping. See
+- JSON and XML format packs (`@weavster/core` `json` / `xml` namespaces):
+  `parse`/`serialize` between text and the canonical model with stable round-tripping. The
+  XML pack (fast-xml-parser) maps attributes to `@`-fields, text to `#text`, and repeated
+  elements to arrays, plus a pluggable `XmlValidator`. See
   [Format Packs](https://docs.weavster.dev/formats).
 - Contribution rules ([`CONTRIBUTING.md`](CONTRIBUTING.md)) and PR template.
 - Editor/formatter config (`.editorconfig`, Prettier).
 - Dev log ([`notes/DEV_LOG.md`](notes/DEV_LOG.md)) and changelog
   ([`CHANGELOG.md`](CHANGELOG.md)).
 
-The XML format pack and the transform engine are not implemented yet; `validate` and
-`test` exist of the planned CLI commands, and `@weavster/core` provides the model and
-JSON pack they will build on.
+The transform engine is not implemented yet; `validate` and `test` exist of the planned
+CLI commands, and `@weavster/core` provides the canonical model and JSON/XML format packs
+they will build on.
 
 ## Local development
 

--- a/core/package.json
+++ b/core/package.json
@@ -16,5 +16,8 @@
     "@types/node": "^22.10.5",
     "typescript": "^5.7.3",
     "vitest": "^3.0.5"
+  },
+  "dependencies": {
+    "fast-xml-parser": "^5.8.0"
   }
 }

--- a/core/src/formats/xml.ts
+++ b/core/src/formats/xml.ts
@@ -1,0 +1,95 @@
+/**
+ * XML format pack.
+ *
+ * Like the JSON pack, this owns only the text⇄value boundary; the canonical
+ * model owns value⇄node. XML is mapped with a flat convention so that XML
+ * specifics never leak into transforms or paths:
+ *
+ * - attributes become `@`-prefixed fields (`order.@id`)
+ * - element text becomes a `#text` field (`note.#text`)
+ * - repeated elements become an array; a single element stays an object
+ * - leaf values stay strings — XML is untyped, so no number/boolean coercion
+ *
+ * Known limitations: the single-vs-repeated ambiguity means one `<line/>`
+ * round-trips as an object, not a one-element array; namespace prefixes are
+ * kept verbatim as part of the key (no resolution); the XML declaration and
+ * comments are dropped; `serialize` expects a single-root-element object, the
+ * shape `parse` produces.
+ */
+import { XMLBuilder, XMLParser, XMLValidator } from 'fast-xml-parser';
+import {
+  type Document,
+  type Node,
+  type ValidationMessage,
+  document,
+  fromValue,
+  toValue,
+} from '../model.js';
+
+const ATTR_PREFIX = '@';
+const TEXT_NODE = '#text';
+
+const parser = new XMLParser({
+  ignoreAttributes: false,
+  attributeNamePrefix: ATTR_PREFIX,
+  textNodeName: TEXT_NODE,
+  parseTagValue: false,
+  parseAttributeValue: false,
+  trimValues: true,
+  ignoreDeclaration: true,
+});
+
+const builder = new XMLBuilder({
+  ignoreAttributes: false,
+  attributeNamePrefix: ATTR_PREFIX,
+  textNodeName: TEXT_NODE,
+  format: true,
+  indentBy: '  ',
+  suppressEmptyNode: true,
+  // Keep attr="true" intact; the default renders it as a valueless attribute,
+  // which is not well-formed XML and would break the round trip on reparse.
+  suppressBooleanAttributes: false,
+});
+
+/** Thrown when input text is not well-formed XML. */
+export class XmlParseError extends Error {
+  constructor(message: string, options?: { cause?: unknown }) {
+    super(message, options);
+    this.name = 'XmlParseError';
+  }
+}
+
+/**
+ * A pluggable XML validator. The default checks well-formedness; an XSD-backed
+ * validator can implement this interface later without changing the pack.
+ */
+export interface XmlValidator {
+  validate(text: string): ValidationMessage[];
+}
+
+/** Default validator: reports well-formedness errors, empty when valid. */
+export const wellFormedValidator: XmlValidator = {
+  validate(text: string): ValidationMessage[] {
+    const result = XMLValidator.validate(text);
+    if (result === true) return [];
+    const { line, col, msg } = result.err;
+    return [{ path: '', message: `line ${line}:${col}: ${msg}` }];
+  },
+};
+
+/** Parse XML text into a canonical document. Throws on malformed input. */
+export function parse(text: string, validator: XmlValidator = wellFormedValidator): Document {
+  const errors = validator.validate(text);
+  if (errors.length > 0) {
+    throw new XmlParseError(`invalid XML: ${errors.map((e) => e.message).join('; ')}`);
+  }
+  const value = parser.parse(text) as unknown;
+  return document(fromValue(value), { sourceFormat: 'xml' });
+}
+
+/** Serialize a document or node to XML text (2-space indent, trailing newline). */
+export function serialize(target: Document | Node): string {
+  const node = 'root' in target ? target.root : target;
+  const text = builder.build(toValue(node)) as string;
+  return text.endsWith('\n') ? text : `${text}\n`;
+}

--- a/core/src/index.ts
+++ b/core/src/index.ts
@@ -1,3 +1,4 @@
 export * from './model.js';
 export * from './path.js';
 export * as json from './formats/json.js';
+export * as xml from './formats/xml.js';

--- a/core/test/xml.test.ts
+++ b/core/test/xml.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from 'vitest';
+import { toValue } from '../src/model.js';
+import {
+  XmlParseError,
+  type XmlValidator,
+  parse,
+  serialize,
+  wellFormedValidator,
+} from '../src/formats/xml.js';
+
+describe('parse', () => {
+  it('tags the document as xml', () => {
+    expect(parse('<a>x</a>').meta.sourceFormat).toBe('xml');
+  });
+
+  it('maps a text-only element to a string', () => {
+    expect(toValue(parse('<order><note>hi</note></order>').root)).toEqual({
+      order: { note: 'hi' },
+    });
+  });
+
+  it('maps attributes to @-prefixed fields and mixed text to #text', () => {
+    expect(
+      toValue(parse('<order id="A-1"><customer vip="true">acme</customer></order>').root),
+    ).toEqual({
+      order: {
+        '@id': 'A-1',
+        customer: { '#text': 'acme', '@vip': 'true' },
+      },
+    });
+  });
+
+  it('maps repeated elements to an array', () => {
+    expect(toValue(parse('<order><line>w</line><line>g</line></order>').root)).toEqual({
+      order: { line: ['w', 'g'] },
+    });
+  });
+
+  it('keeps leaf values as strings (no number/boolean coercion)', () => {
+    expect(toValue(parse('<order><qty>3</qty><paid>true</paid></order>').root)).toEqual({
+      order: { qty: '3', paid: 'true' },
+    });
+  });
+
+  it('throws XmlParseError on malformed XML', () => {
+    expect(() => parse('<a><b></a>')).toThrow(XmlParseError);
+  });
+});
+
+describe('serialize', () => {
+  it('renders indented XML with a trailing newline', () => {
+    expect(serialize(parse('<order id="A-1"><line>w</line></order>'))).toBe(
+      '<order id="A-1">\n  <line>w</line>\n</order>\n',
+    );
+  });
+});
+
+describe('round-trip', () => {
+  it('preserves structure through parse → serialize → parse', () => {
+    const xml =
+      '<order id="A-1"><customer vip="true">acme</customer><line>w</line><line>g</line></order>';
+    const once = parse(xml);
+    const twice = parse(serialize(once));
+    expect(toValue(twice.root)).toEqual(toValue(once.root));
+  });
+
+  it('is stable: serialize is idempotent on its own output', () => {
+    const once = serialize(parse('<order id="A-1"><line>w</line></order>'));
+    expect(serialize(parse(once))).toBe(once);
+  });
+});
+
+describe('wellFormedValidator', () => {
+  it('returns no messages for valid XML', () => {
+    expect(wellFormedValidator.validate('<a>x</a>')).toEqual([]);
+  });
+
+  it('reports a message for malformed XML', () => {
+    const errors = wellFormedValidator.validate('<a><b></a>');
+    expect(errors.length).toBeGreaterThan(0);
+    expect(errors[0].message).toMatch(/line \d+:\d+:/);
+  });
+
+  it('lets a custom validator gate parsing', () => {
+    const rejectAll: XmlValidator = {
+      validate: () => [{ path: '', message: 'rejected by policy' }],
+    };
+    expect(() => parse('<a>x</a>', rejectAll)).toThrow(/rejected by policy/);
+  });
+});

--- a/docs/MVP_TASKS.md
+++ b/docs/MVP_TASKS.md
@@ -168,19 +168,19 @@ Use this on every meaningful task before merge.
 
 ### XML support
 
-- [ ] Create XML format pack structure.
-- [ ] Implement XML parser.
-- [ ] Implement XML serializer.
-- [ ] Map XML into canonical model.
-- [ ] Add validation abstraction for future XSD support.[cite:71][cite:74]
-- [ ] Add round-trip tests.
+- [x] Create XML format pack structure. _(`core/src/formats/xml.ts`, `xml` namespace)_
+- [x] Implement XML parser. _(`xml.parse`, fast-xml-parser, `XmlParseError` on malformed)_
+- [x] Implement XML serializer. _(`xml.serialize`, indented + trailing newline)_
+- [x] Map XML into canonical model. _(`@`/`#text` convention, repeated → array, string leaves)_
+- [x] Add validation abstraction for future XSD support. _(`XmlValidator` + `wellFormedValidator`)_
+- [x] Add round-trip tests.
 
 ### Docs and understanding
 
-- [ ] Write XML format pack docs.
-- [ ] Document current XML limitations.
-- [ ] Compare one JSON example and one XML example side by side in the docs.
-- [ ] Add a dev log entry on where XML handling differs from JSON.
+- [x] Write XML format pack docs. _(Format Packs page, XML section)_
+- [x] Document current XML limitations. _(Limitations subsection)_
+- [x] Compare one JSON example and one XML example side by side in the docs.
+- [x] Add a dev log entry on where XML handling differs from JSON. _(see DEV_LOG M6 entry)_
 
 ## Milestone 7 — Declarative transform DSL
 

--- a/notes/DEV_LOG.md
+++ b/notes/DEV_LOG.md
@@ -13,6 +13,26 @@ Newest entries on top. One entry per merged slice.
 
 ---
 
+## 2026-06-04 — M6 XML format pack
+
+- What changed: Added the XML format pack at `core/src/formats/xml.ts` (`xml` namespace),
+  built on fast-xml-parser. `xml.parse(text, validator?)` runs a validator, then maps via
+  `fromValue` to a `Document` tagged `sourceFormat: 'xml'`. Convention: attributes → `@`-prefixed
+  fields, element text → `#text`, repeated elements → arrays, single elements → objects, and
+  leaf values stay strings (no coercion). `xml.serialize` renders indented XML with a trailing
+  newline. Added the `XmlValidator` interface with a default `wellFormedValidator` (seam for XSD
+  later), 12 tests, and extended the Format Packs docs with a JSON/XML comparison + limitations.
+- What I learned: XML→object mapping is where format quirks try to leak in, so the pack
+  flattens them into ordinary fields the model already understands — a transform addressing
+  `line[0]` cannot tell JSON from XML. Where XML genuinely differs from JSON: leaves are
+  untyped (everything is a string), and a single element is ambiguous between object and
+  one-element array (documented limitation). A concrete round-trip trap: the XMLBuilder
+  default `suppressBooleanAttributes: true` renders `vip="true"` as a valueless `vip`, which
+  is not well-formed XML and fails on reparse — set it to `false`. Validation is a pluggable
+  interface so XSD support can drop in without touching parse/serialize; malformed input
+  throws `XmlParseError`, mirroring the JSON pack.
+- What is next: M7 — declarative transform DSL.
+
 ## 2026-06-04 — M5 JSON format pack
 
 - What changed: Added the JSON format pack at `core/src/formats/json.ts`, exported as the

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -38,6 +38,10 @@ importers:
         version: 3.2.6(@types/debug@4.1.13)(@types/node@22.19.19)(jiti@1.21.7)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
 
   core:
+    dependencies:
+      fast-xml-parser:
+        specifier: ^5.8.0
+        version: 5.8.0
     devDependencies:
       '@types/node':
         specifier: ^22.10.5
@@ -1786,6 +1790,9 @@ packages:
     resolution: {integrity: sha512-V1JJ1WTRUqHHrOSh597hURcMqVKVGL/ea3kv0gSnEdsEZ0/+VyPghM1lMNGc00z7CIQorSvbKpuJkxvuHbvdbg==}
     engines: {node: '>= 16'}
 
+  '@nodable/entities@2.1.1':
+    resolution: {integrity: sha512-Pig3HxDIoMgjdEH8OCf/dkcTmLFjJRjWuq8jSnklu284/TKOPibSRERmOykiwmyXTtv61mP+44f3GMx0tLAyjg==}
+
   '@nodelib/fs.scandir@2.1.5':
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
     engines: {node: '>= 8'}
@@ -3492,6 +3499,13 @@ packages:
   fast-uri@3.1.2:
     resolution: {integrity: sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==}
 
+  fast-xml-builder@1.2.0:
+    resolution: {integrity: sha512-00aAWieqff+ZJhsXA4g1g7M8k+7AYoMUUHF+/zFb5U6Uv/P0Vl4QZo84/IcufzYalLuEj9928bXN9PbbFzMF0Q==}
+
+  fast-xml-parser@5.8.0:
+    resolution: {integrity: sha512-6bIM7fsJxeo3uXv7OncQYsBAMPJ7V16Slahl/6M98C/i2q+vB1+4a0MtrvYwDFEUrwDSbAmeLDRXsOBwrL7yAg==}
+    hasBin: true
+
   fastq@1.20.1:
     resolution: {integrity: sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==}
 
@@ -4649,6 +4663,10 @@ packages:
     resolution: {integrity: sha512-RjhtfwJOxzcFmNOi6ltcbcu4Iu+FL3zEj83dk4kAS+fVpTxXLO1b38RvJgT/0QwvV/L3aY9TAnyv0EOqW4GoMQ==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
+  path-expression-matcher@1.5.0:
+    resolution: {integrity: sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ==}
+    engines: {node: '>=14.0.0'}
+
   path-is-inside@1.0.2:
     resolution: {integrity: sha512-DUWJr3+ULp4zXmol/SZkFf3JGsS9/SIv+Y3Rt93/UjPpDpklB5f1er4O3POIbUuUJ3FXgqte2Q7SrU6zAqwk8w==}
 
@@ -5613,6 +5631,9 @@ packages:
   strip-literal@3.1.0:
     resolution: {integrity: sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==}
 
+  strnum@2.3.0:
+    resolution: {integrity: sha512-ums3KNd42PGyx5xaoVTO1mjU1bH3NpY4vsrVlnv9PNGqQj8wd7rJ6nEypLrJ7z5vxK5RP0yMLo6J/Gsm62DI5Q==}
+
   style-to-js@1.1.21:
     resolution: {integrity: sha512-RjQetxJrrUJLQPHbLku6U/ocGtzyjbJMP9lCNK7Ag0CNh690nSH8woqWH9u16nMjYBAok+i7JO1NP2pOy8IsPQ==}
 
@@ -6129,6 +6150,10 @@ packages:
   xml-js@1.6.11:
     resolution: {integrity: sha512-7rVi2KMfwfWFl+GpPg6m80IVMWXLRjO+PxTq7V2CDhoGak0wzYzFgUY2m4XJ47OGdXd8eLE8EmwfAmdjw7lC1g==}
     hasBin: true
+
+  xml-naming@0.1.0:
+    resolution: {integrity: sha512-k8KO9hrMyNk6tUWqUfkTEZbezRRpONVOzUTnc97VnCvyj6Tf9lyUR9EDAIeiVLv56jsMcoXEwjW8Kv5yPY52lw==}
+    engines: {node: '>=16.0.0'}
 
   yallist@3.1.1:
     resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
@@ -8850,6 +8875,8 @@ snapshots:
 
   '@noble/hashes@1.4.0': {}
 
+  '@nodable/entities@2.1.1': {}
+
   '@nodelib/fs.scandir@2.1.5':
     dependencies:
       '@nodelib/fs.stat': 2.0.5
@@ -10684,6 +10711,19 @@ snapshots:
 
   fast-uri@3.1.2: {}
 
+  fast-xml-builder@1.2.0:
+    dependencies:
+      path-expression-matcher: 1.5.0
+      xml-naming: 0.1.0
+
+  fast-xml-parser@5.8.0:
+    dependencies:
+      '@nodable/entities': 2.1.1
+      fast-xml-builder: 1.2.0
+      path-expression-matcher: 1.5.0
+      strnum: 2.3.0
+      xml-naming: 0.1.0
+
   fastq@1.20.1:
     dependencies:
       reusify: 1.1.0
@@ -12141,6 +12181,8 @@ snapshots:
 
   path-exists@5.0.0: {}
 
+  path-expression-matcher@1.5.0: {}
+
   path-is-inside@1.0.2: {}
 
   path-key@3.1.1: {}
@@ -13285,6 +13327,8 @@ snapshots:
     dependencies:
       js-tokens: 9.0.1
 
+  strnum@2.3.0: {}
+
   style-to-js@1.1.21:
     dependencies:
       style-to-object: 1.0.14
@@ -13922,6 +13966,8 @@ snapshots:
   xml-js@1.6.11:
     dependencies:
       sax: 1.6.0
+
+  xml-naming@0.1.0: {}
 
   yallist@3.1.1: {}
 

--- a/website/docs/formats.md
+++ b/website/docs/formats.md
@@ -41,3 +41,74 @@ Serializing is stable — `serialize` applied to its own output returns the same
 JSON survives a parse→serialize→parse round trip with its values intact. The
 [golden-path example](https://github.com/weavster-dev/weavster/tree/main/examples/golden-path)
 exercises JSON fixtures end to end via `weavster test`.
+
+## XML
+
+The XML pack lives under the `xml` namespace of `@weavster/core` and is built on
+[fast-xml-parser](https://github.com/NaturalIntelligence/fast-xml-parser). It maps XML
+into the same object/array/scalar model so transforms never see XML-specific shapes:
+
+| XML                  | Canonical                                       | Path             |
+| -------------------- | ----------------------------------------------- | ---------------- |
+| attribute `id="A-1"` | `@`-prefixed field                              | `order.@id`      |
+| element text         | `#text` field (only when mixed with attributes) | `customer.#text` |
+| text-only element    | a string                                        | `order.note`     |
+| repeated elements    | an array                                        | `order.line[0]`  |
+
+```ts
+import { xml, toValue } from '@weavster/core';
+
+const doc = xml.parse('<order id="A-1"><line>w</line><line>g</line></order>');
+doc.meta.sourceFormat; // 'xml'
+toValue(doc.root); // { order: { '@id': 'A-1', line: ['w', 'g'] } }
+
+xml.serialize(doc); // indented XML with a trailing newline
+```
+
+- **`parse(text, validator?)`** validates well-formedness, then maps the document to a
+  canonical `Document` tagged `sourceFormat: 'xml'`. Malformed input throws `XmlParseError`.
+- **`serialize(docOrNode)`** renders the model back to indented XML.
+
+### Validation
+
+`parse` runs an `XmlValidator` first. The default `wellFormedValidator` only checks that
+the input is well-formed XML. The interface is the seam for schema-aware validation later
+(e.g. an XSD-backed validator) without changing the pack:
+
+```ts
+interface XmlValidator {
+  validate(text: string): { path: string; message: string }[]; // empty = valid
+}
+```
+
+### JSON vs XML, side by side
+
+The same order in each format, with its normalized model:
+
+```text
+JSON                                XML
+{ "@id": "A-1",                     <order id="A-1">
+  "line": ["w", "g"] }                <line>w</line>
+                                      <line>g</line>
+                                    </order>
+
+→ { '@id': 'A-1',                   → { order: { '@id': 'A-1',
+    line: ['w', 'g'] }                            line: ['w', 'g'] } }
+```
+
+Within an element the two converge — attributes become `@`-fields and repeated children
+become arrays, exactly the JSON shape. The one structural difference is the root: XML
+always has a single root element, so its content sits one level down under that element's
+name (`order.line[0]`), whereas JSON has no such wrapper (`line[0]`). A transform works on
+either source once it addresses from the right root.
+
+### Limitations
+
+- **Single vs repeated**: one `<line/>` parses as an object, not a one-element array —
+  XML cannot express "always a list", so a lone element is ambiguous.
+- **Leaf typing**: all XML leaves are strings (`<qty>3</qty>` → `"3"`); there is no
+  number/boolean coercion.
+- **Namespaces**: prefixes are kept verbatim in the key (`ns:tag`); they are not resolved.
+- **Dropped on parse**: the XML declaration and comments are not preserved.
+- **Serialize input**: `serialize` expects a single-root-element object — the shape
+  `parse` produces.


### PR DESCRIPTION
## Summary
- XML format pack as a module in `@weavster/core` (`xml` namespace), built on **fast-xml-parser**. Owns only text⇄value; the canonical model owns value⇄node.
- `xml.parse(text, validator?)` → well-formedness check + map to `Document` tagged `sourceFormat: 'xml'`. Convention: attributes → `@`-fields, element text → `#text`, repeated elements → arrays; leaf values stay **strings**. Malformed input throws `XmlParseError`.
- `xml.serialize(docOrNode)` → indented XML + trailing newline; `suppressBooleanAttributes: false` so `attr="true"` round-trips.
- `XmlValidator` interface + default `wellFormedValidator` — the seam for XSD-backed validation later.
- Format Packs docs extended: XML section, JSON/XML side-by-side, limitations.

## Decisions / notes
- `@`/`#text` prefix convention (flat paths; XML specifics don't leak into transforms).
- Single element → object, repeated → array (documented ambiguity); namespaces kept verbatim; XML declaration/comments dropped; `serialize` expects a single-root-element object.
- **Round-trip trap fixed:** XMLBuilder's `suppressBooleanAttributes` default rendered `vip="true"` as valueless `vip` (not well-formed) — set to `false`.

## Test plan
- `pnpm test` → core 38 (+12 xml) + cli 11, all pass.
- `pnpm --filter @weavster/core build` / `pnpm cli:build` clean; `pnpm install --frozen-lockfile` clean.
- `pnpm docs:build` succeeds.

## MVP tasks
- Closes Milestone 6 in `docs/MVP_TASKS.md`. Next: M7 declarative transform DSL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)