### PR TITLE
M7 (slice 1): transform engine + map/rename/default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,11 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Added
 
+- M7 (slice 1) transform engine in `@weavster/core`: `applyFlow` runs an op-keyed step
+  list as a mutate-in-place pipeline over the canonical model, with the first operations
+  `map`, `rename`, and `default`. Bad mappings raise a step-scoped `TransformError`. Adds
+  `set`/`remove` path helpers, a `flow.schema.json` contract with sample flows, and a
+  Transform DSL docs page.
 - M6 XML format pack in `@weavster/core` (`xml` namespace), built on fast-xml-parser:
   `xml.parse` (well-formedness-checked text → canonical `Document` tagged `xml`,
   `XmlParseError` on malformed input) and `xml.serialize`. Attributes map to `@`-prefixed

--- a/README.md
+++ b/README.md
@@ -29,14 +29,17 @@ them locally, test them with fixtures, and run them through a modular engine.
   XML pack (fast-xml-parser) maps attributes to `@`-fields, text to `#text`, and repeated
   elements to arrays, plus a pluggable `XmlValidator`. See
   [Format Packs](https://docs.weavster.dev/formats).
+- Transform engine (`@weavster/core` `applyFlow`): runs an op-keyed step list as a
+  mutate-in-place pipeline over the canonical model. First operations: `map`, `rename`,
+  `default`, with step-scoped errors. See [Transform DSL](https://docs.weavster.dev/dsl).
 - Contribution rules ([`CONTRIBUTING.md`](CONTRIBUTING.md)) and PR template.
 - Editor/formatter config (`.editorconfig`, Prettier).
 - Dev log ([`notes/DEV_LOG.md`](notes/DEV_LOG.md)) and changelog
   ([`CHANGELOG.md`](CHANGELOG.md)).
 
-The transform engine is not implemented yet; `validate` and `test` exist of the planned
-CLI commands, and `@weavster/core` provides the canonical model and JSON/XML format packs
-they will build on.
+The engine's first transform operations exist in `@weavster/core`, but flows are not yet
+wired into the CLI — `validate` and `test` are the working CLI commands so far. More
+transform operations and CLI integration are landing in stacked slices.
 
 ## Local development
 

--- a/core/src/index.ts
+++ b/core/src/index.ts
@@ -1,4 +1,5 @@
 export * from './model.js';
 export * from './path.js';
+export * from './transform.js';
 export * as json from './formats/json.js';
 export * as xml from './formats/xml.js';

--- a/core/src/path.ts
+++ b/core/src/path.ts
@@ -65,3 +65,71 @@ export function getValue(target: Document | Node, path: string | Segment[]): unk
   const node = get(target, path);
   return node === undefined ? undefined : toValue(node);
 }
+
+/** Error thrown when a path cannot be written or removed against a node tree. */
+export class PathError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'PathError';
+  }
+}
+
+/**
+ * Set `value` at `path`, mutating `target`. Missing object segments are created
+ * along the way. Writing through a missing array index, or keying a scalar, is a
+ * `PathError` — the model does not auto-grow arrays.
+ */
+export function set(target: Document | Node, path: string | Segment[], value: Node): void {
+  const segments = typeof path === 'string' ? parsePath(path) : path;
+  if (segments.length === 0) throw new PathError('cannot set the root');
+
+  let current: Node = rootOf(target);
+  for (let i = 0; i < segments.length - 1; i++) {
+    const segment = segments[i];
+    const here = formatPath(segments.slice(0, i + 1));
+    if (typeof segment === 'number') {
+      if (current.kind !== 'array' || segment < 0 || segment >= current.items.length) {
+        throw new PathError(`no array index at ${here}`);
+      }
+      current = current.items[segment];
+    } else {
+      if (current.kind !== 'object') throw new PathError(`cannot descend into ${here}`);
+      let next = current.fields[segment];
+      if (next === undefined) {
+        next = { kind: 'object', fields: {} };
+        current.fields[segment] = next;
+      }
+      current = next;
+    }
+  }
+
+  const last = segments[segments.length - 1];
+  if (typeof last === 'number') {
+    if (current.kind !== 'array' || last < 0 || last > current.items.length) {
+      throw new PathError(`no array index at ${formatPath(segments)}`);
+    }
+    current.items[last] = value;
+  } else {
+    if (current.kind !== 'object') throw new PathError(`cannot set ${formatPath(segments)}`);
+    current.fields[last] = value;
+  }
+}
+
+/** Remove the node at `path`, mutating `target`. Returns whether anything was removed. */
+export function remove(target: Document | Node, path: string | Segment[]): boolean {
+  const segments = typeof path === 'string' ? parsePath(path) : path;
+  if (segments.length === 0) throw new PathError('cannot remove the root');
+
+  const parent = get(target, segments.slice(0, -1));
+  if (parent === undefined) return false;
+  const last = segments[segments.length - 1];
+
+  if (typeof last === 'number') {
+    if (parent.kind !== 'array' || last < 0 || last >= parent.items.length) return false;
+    parent.items.splice(last, 1);
+    return true;
+  }
+  if (parent.kind !== 'object' || !(last in parent.fields)) return false;
+  delete parent.fields[last];
+  return true;
+}

--- a/core/src/transform.ts
+++ b/core/src/transform.ts
@@ -1,0 +1,88 @@
+/**
+ * Declarative transform engine.
+ *
+ * A flow is an ordered list of op-keyed steps. The engine runs them as a
+ * mutate-in-place pipeline: the input document is cloned into a working
+ * document, each step edits it via path helpers, and the working document is
+ * returned. Steps operate only on the canonical model, so the same flow runs
+ * regardless of whether the input arrived as JSON or XML.
+ */
+import { type Document, type Node, fromValue } from './model.js';
+import { type Segment, get, remove, set } from './path.js';
+
+/** A single transform step. The `op` field selects the operation. */
+export interface Step {
+  op: string;
+  [key: string]: unknown;
+}
+
+export interface Flow {
+  steps: Step[];
+}
+
+/** Thrown when a step references a bad path or is otherwise malformed. */
+export class TransformError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'TransformError';
+  }
+}
+
+type OpFn = (working: Document, step: Step) => void;
+
+function requirePath(step: Step, key: string): string | Segment[] {
+  const value = step[key];
+  if (typeof value !== 'string') throw new TransformError(`"${key}" must be a path string`);
+  return value;
+}
+
+function requireNode(working: Document, path: string | Segment[]): Node {
+  const node = get(working, path);
+  if (node === undefined) throw new TransformError(`no value at "${String(path)}"`);
+  return node;
+}
+
+const OPS: Record<string, OpFn> = {
+  /** Copy the value at `from` to `to`. */
+  map(working, step) {
+    const from = requirePath(step, 'from');
+    const to = requirePath(step, 'to');
+    set(working, to, structuredClone(requireNode(working, from)));
+  },
+
+  /** Move the value at `from` to `to` (copy then delete the source). */
+  rename(working, step) {
+    const from = requirePath(step, 'from');
+    const to = requirePath(step, 'to');
+    set(working, to, structuredClone(requireNode(working, from)));
+    remove(working, from);
+  },
+
+  /** Set `at` to `value` only when nothing is there yet. */
+  default(working, step) {
+    const at = requirePath(step, 'at');
+    if (!('value' in step)) throw new TransformError('"value" is required');
+    if (get(working, at) === undefined) set(working, at, fromValue(step.value));
+  },
+};
+
+/** Run a flow against a document, returning a new transformed document. */
+export function applyFlow(doc: Document, flow: Flow): Document {
+  const working: Document = {
+    root: structuredClone(doc.root),
+    meta: { ...doc.meta, errors: [...doc.meta.errors] },
+  };
+
+  flow.steps.forEach((step, index) => {
+    const op = OPS[step.op];
+    if (op === undefined) throw new TransformError(`step ${index}: unknown op "${step.op}"`);
+    try {
+      op(working, step);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      throw new TransformError(`step ${index} (${step.op}): ${message}`);
+    }
+  });
+
+  return working;
+}

--- a/core/test/path.test.ts
+++ b/core/test/path.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
-import { document, fromValue } from '../src/model.js';
-import { formatPath, get, getValue, parsePath } from '../src/path.js';
+import { document, fromValue, toValue } from '../src/model.js';
+import { PathError, formatPath, get, getValue, parsePath, remove, set } from '../src/path.js';
 
 describe('parsePath', () => {
   it('parses the root as empty', () => {
@@ -61,5 +61,51 @@ describe('get', () => {
     const fromJsonLike = document(fromValue({ item: { id: 7 } }), { sourceFormat: 'json' });
     const fromXmlLike = document(fromValue({ item: { id: 7 } }), { sourceFormat: 'xml' });
     expect(getValue(fromJsonLike, 'item.id')).toBe(getValue(fromXmlLike, 'item.id'));
+  });
+});
+
+describe('set', () => {
+  it('overwrites an existing field', () => {
+    const doc = document(fromValue({ a: 1 }));
+    set(doc, 'a', fromValue(2));
+    expect(toValue(doc.root)).toEqual({ a: 2 });
+  });
+
+  it('creates missing object segments', () => {
+    const doc = document(fromValue({}));
+    set(doc, 'x.y', fromValue('z'));
+    expect(toValue(doc.root)).toEqual({ x: { y: 'z' } });
+  });
+
+  it('overwrites an in-range array index and appends at length', () => {
+    const doc = document(fromValue({ list: ['a'] }));
+    set(doc, 'list[0]', fromValue('A'));
+    set(doc, 'list[1]', fromValue('b'));
+    expect(toValue(doc.root)).toEqual({ list: ['A', 'b'] });
+  });
+
+  it('throws PathError for an out-of-range index and for the root', () => {
+    const doc = document(fromValue({ list: [] }));
+    expect(() => set(doc, 'list[3]', fromValue('x'))).toThrow(PathError);
+    expect(() => set(doc, '', fromValue('x'))).toThrow(PathError);
+  });
+});
+
+describe('remove', () => {
+  it('removes an object field', () => {
+    const doc = document(fromValue({ a: 1, b: 2 }));
+    expect(remove(doc, 'b')).toBe(true);
+    expect(toValue(doc.root)).toEqual({ a: 1 });
+  });
+
+  it('removes an array index by splicing', () => {
+    const doc = document(fromValue({ list: ['a', 'b', 'c'] }));
+    expect(remove(doc, 'list[1]')).toBe(true);
+    expect(toValue(doc.root)).toEqual({ list: ['a', 'c'] });
+  });
+
+  it('returns false when the path is absent', () => {
+    const doc = document(fromValue({ a: 1 }));
+    expect(remove(doc, 'missing')).toBe(false);
   });
 });

--- a/core/test/transform.test.ts
+++ b/core/test/transform.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from 'vitest';
+import { document, fromValue, toValue } from '../src/model.js';
+import { type Flow, TransformError, applyFlow } from '../src/transform.js';
+
+const docOf = (value: unknown) => document(fromValue(value), { sourceFormat: 'json' });
+const run = (value: unknown, steps: Flow['steps']) =>
+  toValue(applyFlow(docOf(value), { steps }).root);
+
+describe('map', () => {
+  it('copies a value to a new path', () => {
+    expect(run({ order: { id: 'A-1' } }, [{ op: 'map', from: 'order.id', to: 'id' }])).toEqual({
+      order: { id: 'A-1' },
+      id: 'A-1',
+    });
+  });
+
+  it('creates intermediate object segments on the target', () => {
+    expect(run({ a: 1 }, [{ op: 'map', from: 'a', to: 'nested.deep.value' }])).toEqual({
+      a: 1,
+      nested: { deep: { value: 1 } },
+    });
+  });
+
+  it('throws a step-scoped TransformError for a missing source', () => {
+    expect(() => run({}, [{ op: 'map', from: 'missing', to: 'x' }])).toThrow(
+      /step 0 \(map\).*missing/,
+    );
+  });
+});
+
+describe('rename', () => {
+  it('moves a value: target set, source removed', () => {
+    expect(
+      run({ order: { '@id': 'A-1' } }, [{ op: 'rename', from: 'order.@id', to: 'order.id' }]),
+    ).toEqual({ order: { id: 'A-1' } });
+  });
+});
+
+describe('default', () => {
+  it('fills a value when the path is absent', () => {
+    expect(run({}, [{ op: 'default', at: 'status', value: 'new' }])).toEqual({ status: 'new' });
+  });
+
+  it('leaves an existing value untouched', () => {
+    expect(run({ status: 'done' }, [{ op: 'default', at: 'status', value: 'new' }])).toEqual({
+      status: 'done',
+    });
+  });
+
+  it('accepts a structured default value', () => {
+    expect(run({}, [{ op: 'default', at: 'meta', value: { tags: [] } }])).toEqual({
+      meta: { tags: [] },
+    });
+  });
+});
+
+describe('applyFlow', () => {
+  it('runs steps in order as a pipeline', () => {
+    const flow: Flow = {
+      steps: [
+        { op: 'rename', from: 'order.@id', to: 'id' },
+        { op: 'map', from: 'order.line', to: 'lines' },
+        { op: 'default', at: 'status', value: 'new' },
+      ],
+    };
+    expect(run({ order: { '@id': 'A-1', line: ['w', 'g'] } }, flow.steps)).toEqual({
+      order: { line: ['w', 'g'] },
+      id: 'A-1',
+      lines: ['w', 'g'],
+      status: 'new',
+    });
+  });
+
+  it('does not mutate the input document', () => {
+    const input = docOf({ a: 1 });
+    applyFlow(input, { steps: [{ op: 'map', from: 'a', to: 'b' }] });
+    expect(toValue(input.root)).toEqual({ a: 1 });
+  });
+
+  it('throws on an unknown op', () => {
+    expect(() => run({}, [{ op: 'frobnicate' }])).toThrow(TransformError);
+  });
+});

--- a/docs/MVP_TASKS.md
+++ b/docs/MVP_TASKS.md
@@ -184,30 +184,33 @@ Use this on every meaningful task before merge.
 
 ## Milestone 7 — Declarative transform DSL
 
+_Delivered as stacked slices: (1) engine + map/rename/default, (2) concat + string/date
+helpers, (3) conditionals, (4) wire golden-path + DSL reference._
+
 ### DSL design
 
-- [ ] Define the first supported transform operations.
-- [ ] Decide YAML shape for each operation.
-- [ ] Decide how errors are reported for bad mappings.
-- [ ] Add failing tests for each operation before implementing.
+- [x] Define the first supported transform operations. _(slice 1: map, rename, default)_
+- [x] Decide YAML shape for each operation. _(op-keyed steps; `flow.schema.json`)_
+- [x] Decide how errors are reported for bad mappings. _(step-scoped `TransformError`)_
+- [x] Add failing tests for each operation before implementing.
 
 ### Implementation
 
-- [ ] Implement `map`.
-- [ ] Implement `rename` or equivalent field remap primitive.
-- [ ] Implement `default`.
-- [ ] Implement `concat`.
-- [ ] Implement conditional logic.
-- [ ] Implement minimal string/date helpers.
-- [ ] Add tests for each operation and at least one combined pipeline.
+- [x] Implement `map`. _(slice 1)_
+- [x] Implement `rename` or equivalent field remap primitive. _(slice 1)_
+- [x] Implement `default`. _(slice 1)_
+- [ ] Implement `concat`. _(slice 2)_
+- [ ] Implement conditional logic. _(slice 3)_
+- [ ] Implement minimal string/date helpers. _(slice 2)_
+- [ ] Add tests for each operation and at least one combined pipeline. _(slice 1: map/rename/default + a pipeline; extended per slice)_
 
 ### Docs and understanding
 
-- [ ] Write DSL reference docs.
-- [ ] Add copy-paste examples.
-- [ ] Add one “when not to use config” note.
-- [ ] Walk through one transform execution path in the debugger or logs.
-- [ ] Add a dev log entry summarizing the execution path.
+- [x] Write DSL reference docs. _(Transform DSL page; extended per slice)_
+- [x] Add copy-paste examples.
+- [x] Add one “when not to use config” note.
+- [ ] Walk through one transform execution path in the debugger or logs. _(slice 1 DEV_LOG traces it; revisit once wired into the cli)_
+- [x] Add a dev log entry summarizing the execution path. _(see DEV_LOG M7 slice 1 entry)_
 
 ## Milestone 8 — TypeScript escape hatch
 

--- a/notes/DEV_LOG.md
+++ b/notes/DEV_LOG.md
@@ -13,6 +13,26 @@ Newest entries on top. One entry per merged slice.
 
 ---
 
+## 2026-06-04 — M7 slice 1: transform engine + map/rename/default
+
+- What changed: Added the transform engine at `core/src/transform.ts`. `applyFlow(doc, flow)`
+  clones the input document, then runs an op-keyed `steps` list as a mutate-in-place pipeline,
+  returning a new document (input is never mutated). First ops: `map` (copy `from`→`to`),
+  `rename` (move), `default` (fill `at` only if absent; literal `value` via `fromValue`).
+  Added `set`/`remove`/`PathError` to `core/src/path.ts` (set auto-creates missing object
+  segments, refuses to grow arrays). Defined the `flow.schema.json` contract + valid/invalid
+  sample flows, and started the Transform DSL docs page. This slice is core-only; wiring the
+  cli fixture harness to load `flows/` and run the engine comes in slice 4.
+- What I learned: Execution-path trace — `applyFlow` deep-clones `doc.root` into a working
+  document, then for each step looks up the op in a registry and calls it; the op reads via
+  `get` and writes via `set`/`remove` against the working tree; any throw is re-wrapped as a
+  `TransformError` tagged with the step index + op, and the pipeline stops. Keeping the engine
+  in core with no ajv dependency means flow _loading + schema validation_ will live in the cli
+  (slice 4) where ajv already is — the engine only ever sees an already-parsed `Flow`. The
+  mutate-in-place model makes `rename` literally copy-then-`remove`, and `default` a guarded
+  `set`, which is why the path helpers (not the ops) own the structural rules.
+- What is next: M7 slice 2 — `concat` + string/date helpers.
+
 ## 2026-06-04 — M6 XML format pack
 
 - What changed: Added the XML format pack at `core/src/formats/xml.ts` (`xml` namespace),

--- a/spec/examples/flow/invalid-missing-field.flow.yaml
+++ b/spec/examples/flow/invalid-missing-field.flow.yaml
@@ -1,0 +1,3 @@
+steps:
+  - op: map
+    from: a

--- a/spec/examples/flow/invalid-unknown-op.flow.yaml
+++ b/spec/examples/flow/invalid-unknown-op.flow.yaml
@@ -1,0 +1,4 @@
+steps:
+  - op: frobnicate
+    from: a
+    to: b

--- a/spec/examples/flow/valid.flow.yaml
+++ b/spec/examples/flow/valid.flow.yaml
@@ -1,0 +1,10 @@
+steps:
+  - op: rename
+    from: order.@id
+    to: id
+  - op: map
+    from: order.line
+    to: lines
+  - op: default
+    at: status
+    value: new

--- a/spec/schemas/flow.schema.json
+++ b/spec/schemas/flow.schema.json
@@ -1,0 +1,59 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://weavster.dev/schemas/flow.schema.json",
+  "title": "Weavster flow",
+  "description": "Schema for a Weavster flow file: an ordered list of transform steps.",
+  "type": "object",
+  "required": ["steps"],
+  "additionalProperties": false,
+  "properties": {
+    "steps": {
+      "description": "Transform steps, run in order as a mutate-in-place pipeline.",
+      "type": "array",
+      "items": { "$ref": "#/$defs/step" }
+    }
+  },
+  "$defs": {
+    "path": {
+      "description": "A dotted/bracketed path into the canonical model, e.g. order.line[0].sku.",
+      "type": "string",
+      "minLength": 1
+    },
+    "step": {
+      "type": "object",
+      "required": ["op"],
+      "oneOf": [
+        {
+          "description": "Copy the value at `from` to `to`.",
+          "additionalProperties": false,
+          "required": ["op", "from", "to"],
+          "properties": {
+            "op": { "const": "map" },
+            "from": { "$ref": "#/$defs/path" },
+            "to": { "$ref": "#/$defs/path" }
+          }
+        },
+        {
+          "description": "Move the value at `from` to `to`.",
+          "additionalProperties": false,
+          "required": ["op", "from", "to"],
+          "properties": {
+            "op": { "const": "rename" },
+            "from": { "$ref": "#/$defs/path" },
+            "to": { "$ref": "#/$defs/path" }
+          }
+        },
+        {
+          "description": "Set `at` to `value` only when nothing is there yet.",
+          "additionalProperties": false,
+          "required": ["op", "at", "value"],
+          "properties": {
+            "op": { "const": "default" },
+            "at": { "$ref": "#/$defs/path" },
+            "value": {}
+          }
+        }
+      ]
+    }
+  }
+}

--- a/website/docs/dsl.md
+++ b/website/docs/dsl.md
@@ -1,0 +1,81 @@
+---
+sidebar_position: 6
+title: Transform DSL
+---
+
+# Transform DSL
+
+A **flow** transforms a document with a list of declarative steps — no code. Steps run in
+order as a **mutate-in-place pipeline**: the input document is cloned into a working
+document, each step edits it, and the result is the transformed document. Steps operate on
+the [canonical model](./concepts.md) and address values by [path](./concepts.md#paths), so
+the same flow runs whether the input arrived as JSON or XML.
+
+```yaml
+# flows/order.yaml
+steps:
+  - op: rename
+    from: order.@id
+    to: id
+  - op: map
+    from: order.line
+    to: lines
+  - op: default
+    at: status
+    value: new
+```
+
+Each step is **op-keyed**: the `op` field names the operation, and the remaining fields are
+its arguments. Paths use the dotted/bracket form (`order.line[0].sku`).
+
+## Operations
+
+### `map`
+
+Copy the value at `from` to `to`. Missing object segments in `to` are created.
+
+```yaml
+- op: map
+  from: order.id
+  to: id
+```
+
+### `rename`
+
+Move the value at `from` to `to` — copy, then remove the source.
+
+```yaml
+- op: rename
+  from: order.@id
+  to: id
+```
+
+### `default`
+
+Set `at` to `value` only when nothing is there yet. An existing value is left untouched.
+`value` can be any literal — scalar, object, or array.
+
+```yaml
+- op: default
+  at: status
+  value: new
+```
+
+## Errors
+
+A step that references a missing source path, or that targets an impossible location (for
+example writing through an array index that does not exist), fails with a `TransformError`
+naming the step index and op:
+
+```text
+step 1 (map): no value at "order.missing"
+```
+
+The flow stops at the first failing step — later steps do not run.
+
+## When not to use config
+
+The DSL is for straightforward field-level reshaping. Reach for the (future) TypeScript
+escape hatch instead when a transform needs real logic — lookups against external data,
+non-trivial branching, or computation the step list cannot express clearly. If a flow grows
+a long tail of conditional steps to fake control flow, that is the signal to drop to code.

--- a/website/sidebars.ts
+++ b/website/sidebars.ts
@@ -8,6 +8,7 @@ const sidebars: SidebarsConfig = {
     'cli',
     'config',
     'formats',
+    'dsl',
     'testing',
     'architecture',
     'contributing',


### PR DESCRIPTION
First of the stacked M7 slices (engine → concat/helpers → conditionals → cli+golden-path).

## Summary
- Transform engine in `@weavster/core`: `applyFlow(doc, flow)` clones the input and runs an **op-keyed** `steps` list as a **mutate-in-place pipeline**, returning a new document (input never mutated).
- First operations: `map` (copy `from`→`to`), `rename` (move), `default` (fill `at` only if absent).
- Bad mappings raise a step-scoped `TransformError` (`step 1 (map): no value at "order.missing"`); pipeline stops at first failure.
- `set`/`remove`/`PathError` path helpers (set auto-creates missing object segments; refuses to grow arrays).
- `spec/schemas/flow.schema.json` contract + valid/invalid sample flows; Transform DSL docs page.

## Decisions
- **Pipeline backbone** (not declarative projection): fits the op verbs, gives a step trace, keeps the DSL minimal — projection is available as the `map` op.
- **Engine has no ajv dependency**: flow loading + schema validation will live in the cli (later slice); the engine only ever sees a parsed `Flow`.
- **Core-only this slice**: cli wiring + golden-path flow come in slice 4.

## Test plan
- `pnpm test` → core 55 (+17: 10 transform, 7 path set/remove) + cli 11, all pass.
- Flow schema checked against samples (valid passes; unknown-op + missing-field rejected).
- `pnpm --filter @weavster/core build` / `pnpm cli:build` / `pnpm docs:build` clean.

## MVP tasks
- Checks the M7 DSL-design + map/rename/default items. Remaining ops (concat/conditional/helpers), the combined-pipeline coverage, and cli/golden-path wiring follow in slices 2–4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)