### PR TITLE
M7 (slice 2): concat + string/date helpers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Added
 
+- M7 (slice 2) transform helper ops in `@weavster/core`: `concat` (join `parts` of paths
+  and literals with an optional `sep`), `str` (`upper`/`lower`/`trim`), and `date`
+  (`toIso`). Extends `flow.schema.json` and the Transform DSL docs.
 - M7 (slice 1) transform engine in `@weavster/core`: `applyFlow` runs an op-keyed step
   list as a mutate-in-place pipeline over the canonical model, with the first operations
   `map`, `rename`, and `default`. Bad mappings raise a step-scoped `TransformError`. Adds

--- a/README.md
+++ b/README.md
@@ -30,8 +30,9 @@ them locally, test them with fixtures, and run them through a modular engine.
   elements to arrays, plus a pluggable `XmlValidator`. See
   [Format Packs](https://docs.weavster.dev/formats).
 - Transform engine (`@weavster/core` `applyFlow`): runs an op-keyed step list as a
-  mutate-in-place pipeline over the canonical model. First operations: `map`, `rename`,
-  `default`, with step-scoped errors. See [Transform DSL](https://docs.weavster.dev/dsl).
+  mutate-in-place pipeline over the canonical model. Operations: `map`, `rename`, `default`,
+  `concat`, `str` (upper/lower/trim), `date` (toIso), with step-scoped errors. See
+  [Transform DSL](https://docs.weavster.dev/dsl).
 - Contribution rules ([`CONTRIBUTING.md`](CONTRIBUTING.md)) and PR template.
 - Editor/formatter config (`.editorconfig`, Prettier).
 - Dev log ([`notes/DEV_LOG.md`](notes/DEV_LOG.md)) and changelog

--- a/core/src/transform.ts
+++ b/core/src/transform.ts
@@ -7,7 +7,7 @@
  * returned. Steps operate only on the canonical model, so the same flow runs
  * regardless of whether the input arrived as JSON or XML.
  */
-import { type Document, type Node, fromValue } from './model.js';
+import { type Document, type Node, type Scalar, fromValue, isScalar } from './model.js';
 import { type Segment, get, remove, set } from './path.js';
 
 /** A single transform step. The `op` field selects the operation. */
@@ -42,6 +42,22 @@ function requireNode(working: Document, path: string | Segment[]): Node {
   return node;
 }
 
+/** Coerce a scalar node to a string; null becomes empty, structured nodes are an error. */
+function scalarToString(node: Node, context: string): string {
+  if (!isScalar(node)) throw new TransformError(`${context} must be a scalar`);
+  return node.value === null ? '' : String(node.value);
+}
+
+function scalarNode(value: Scalar): Node {
+  return { kind: 'scalar', value };
+}
+
+/** A concat part: a path to read, or a literal value. */
+interface ConcatPart {
+  path?: unknown;
+  value?: unknown;
+}
+
 const OPS: Record<string, OpFn> = {
   /** Copy the value at `from` to `to`. */
   map(working, step) {
@@ -63,6 +79,48 @@ const OPS: Record<string, OpFn> = {
     const at = requirePath(step, 'at');
     if (!('value' in step)) throw new TransformError('"value" is required');
     if (get(working, at) === undefined) set(working, at, fromValue(step.value));
+  },
+
+  /** Join `parts` (each a `path` or literal `value`) into a string at `to`. */
+  concat(working, step) {
+    const to = requirePath(step, 'to');
+    if (!Array.isArray(step.parts)) throw new TransformError('"parts" must be a list');
+    const sep = step.sep === undefined ? '' : String(step.sep);
+    const pieces = (step.parts as ConcatPart[]).map((part, i) => {
+      if (typeof part?.path === 'string') {
+        return scalarToString(requireNode(working, part.path), `parts[${i}] (${part.path})`);
+      }
+      if ('value' in part) return part.value === null ? '' : String(part.value);
+      throw new TransformError(`parts[${i}] must have a "path" or "value"`);
+    });
+    set(working, to, scalarNode(pieces.join(sep)));
+  },
+
+  /** Apply a string function (`upper`/`lower`/`trim`) from `from` to `to` (default `from`). */
+  str(working, step) {
+    const from = requirePath(step, 'from');
+    const to = step.to === undefined ? from : requirePath(step, 'to');
+    const input = scalarToString(requireNode(working, from), `value at "${String(from)}"`);
+    const fns: Record<string, (s: string) => string> = {
+      upper: (s) => s.toUpperCase(),
+      lower: (s) => s.toLowerCase(),
+      trim: (s) => s.trim(),
+    };
+    const fn = fns[String(step.fn)];
+    if (fn === undefined) throw new TransformError(`unknown str fn "${String(step.fn)}"`);
+    set(working, to, scalarNode(fn(input)));
+  },
+
+  /** Apply a date function (`toIso`) from `from` to `to` (default `from`). */
+  date(working, step) {
+    const from = requirePath(step, 'from');
+    const to = step.to === undefined ? from : requirePath(step, 'to');
+    const input = scalarToString(requireNode(working, from), `value at "${String(from)}"`);
+    if (String(step.fn) !== 'toIso')
+      throw new TransformError(`unknown date fn "${String(step.fn)}"`);
+    const date = new Date(input);
+    if (Number.isNaN(date.getTime())) throw new TransformError(`cannot parse date "${input}"`);
+    set(working, to, scalarNode(date.toISOString()));
   },
 };
 

--- a/core/test/transform.test.ts
+++ b/core/test/transform.test.ts
@@ -54,6 +54,74 @@ describe('default', () => {
   });
 });
 
+describe('concat', () => {
+  it('joins paths and literals with a separator', () => {
+    expect(
+      run({ first: 'jane', last: 'doe' }, [
+        { op: 'concat', to: 'name', sep: ' ', parts: [{ path: 'first' }, { path: 'last' }] },
+      ]),
+    ).toMatchObject({ name: 'jane doe' });
+  });
+
+  it('supports literal value parts and defaults the separator to empty', () => {
+    expect(
+      run({ area: '212', num: '5551234' }, [
+        {
+          op: 'concat',
+          to: 'phone',
+          parts: [{ value: '(' }, { path: 'area' }, { value: ') ' }, { path: 'num' }],
+        },
+      ]),
+    ).toMatchObject({ phone: '(212) 5551234' });
+  });
+
+  it('errors on a missing source path', () => {
+    expect(() => run({}, [{ op: 'concat', to: 'x', parts: [{ path: 'nope' }] }])).toThrow(
+      /step 0 \(concat\).*nope/,
+    );
+  });
+
+  it('errors when a part resolves to a non-scalar', () => {
+    expect(() =>
+      run({ obj: { a: 1 } }, [{ op: 'concat', to: 'x', parts: [{ path: 'obj' }] }]),
+    ).toThrow(/must be a scalar/);
+  });
+});
+
+describe('str', () => {
+  it('applies upper/lower/trim', () => {
+    expect(run({ v: 'aB' }, [{ op: 'str', fn: 'upper', from: 'v', to: 'v' }])).toEqual({ v: 'AB' });
+    expect(run({ v: 'aB' }, [{ op: 'str', fn: 'lower', from: 'v', to: 'v' }])).toEqual({ v: 'ab' });
+    expect(run({ v: '  x  ' }, [{ op: 'str', fn: 'trim', from: 'v', to: 'v' }])).toEqual({
+      v: 'x',
+    });
+  });
+
+  it('defaults the target to the source (in place)', () => {
+    expect(run({ code: 'ab' }, [{ op: 'str', fn: 'upper', from: 'code' }])).toEqual({ code: 'AB' });
+  });
+
+  it('errors on an unknown fn', () => {
+    expect(() => run({ v: 'x' }, [{ op: 'str', fn: 'reverse', from: 'v' }])).toThrow(
+      /unknown str fn/,
+    );
+  });
+});
+
+describe('date', () => {
+  it('converts a parseable date string to ISO 8601', () => {
+    expect(run({ ts: '2026-06-04' }, [{ op: 'date', fn: 'toIso', from: 'ts' }])).toEqual({
+      ts: '2026-06-04T00:00:00.000Z',
+    });
+  });
+
+  it('errors on an unparseable date', () => {
+    expect(() => run({ ts: 'not-a-date' }, [{ op: 'date', fn: 'toIso', from: 'ts' }])).toThrow(
+      /cannot parse date/,
+    );
+  });
+});
+
 describe('applyFlow', () => {
   it('runs steps in order as a pipeline', () => {
     const flow: Flow = {
@@ -67,6 +135,24 @@ describe('applyFlow', () => {
       order: { line: ['w', 'g'] },
       id: 'A-1',
       lines: ['w', 'g'],
+      status: 'new',
+    });
+  });
+
+  it('runs a combined pipeline using helper ops', () => {
+    expect(
+      run({ first: 'jane', last: 'DOE', ts: '2026-06-04' }, [
+        { op: 'str', fn: 'lower', from: 'last', to: 'last' },
+        { op: 'concat', to: 'name', sep: ' ', parts: [{ path: 'first' }, { path: 'last' }] },
+        { op: 'date', fn: 'toIso', from: 'ts', to: 'createdAt' },
+        { op: 'default', at: 'status', value: 'new' },
+      ]),
+    ).toEqual({
+      first: 'jane',
+      last: 'doe',
+      ts: '2026-06-04',
+      name: 'jane doe',
+      createdAt: '2026-06-04T00:00:00.000Z',
       status: 'new',
     });
   });

--- a/docs/MVP_TASKS.md
+++ b/docs/MVP_TASKS.md
@@ -199,10 +199,10 @@ helpers, (3) conditionals, (4) wire golden-path + DSL reference._
 - [x] Implement `map`. _(slice 1)_
 - [x] Implement `rename` or equivalent field remap primitive. _(slice 1)_
 - [x] Implement `default`. _(slice 1)_
-- [ ] Implement `concat`. _(slice 2)_
+- [x] Implement `concat`. _(slice 2)_
 - [ ] Implement conditional logic. _(slice 3)_
-- [ ] Implement minimal string/date helpers. _(slice 2)_
-- [ ] Add tests for each operation and at least one combined pipeline. _(slice 1: map/rename/default + a pipeline; extended per slice)_
+- [x] Implement minimal string/date helpers. _(slice 2: `str` upper/lower/trim, `date` toIso)_
+- [ ] Add tests for each operation and at least one combined pipeline. _(slices 1–2 done; conditional in slice 3)_
 
 ### Docs and understanding
 

--- a/notes/DEV_LOG.md
+++ b/notes/DEV_LOG.md
@@ -13,6 +13,24 @@ Newest entries on top. One entry per merged slice.
 
 ---
 
+## 2026-06-04 — M7 slice 2: concat + string/date helpers
+
+- What changed: Added three ops to the engine. `concat` joins a `parts` list — each part a
+  `path` to read or a literal `value` — into a string at `to`, with an optional `sep`. `str`
+  applies `upper`/`lower`/`trim` from `from` to `to` (default `from`, so in-place). `date`
+  applies `toIso`, parsing the source with `new Date(...)` and writing `.toISOString()`.
+  Extended `flow.schema.json` with the three variants + a richer valid sample, the DSL docs,
+  and added a combined-pipeline test using the helpers.
+- What I learned: A real JSON Schema trap — `additionalProperties: false` only sees
+  `properties` declared in the _same_ schema object, not ones nested inside `oneOf`. The first
+  cut put each concat part's `path`/`value` only inside `oneOf` branches, so `false` treated
+  both as unknown and rejected every part. Fix: declare `path` and `value` at the item level,
+  use `oneOf` only to require exactly one. Determinism mattered for `date`: `toIso` is pure
+  given its input (no `now`), so it is safe for fixtures; `new Date('2026-06-04')` yields a
+  fixed UTC instant. Scalar coercion lives in one helper (`scalarToString`) so concat/str/date
+  share the same "null → empty, structured → error" rule.
+- What is next: M7 slice 3 — conditional logic.
+
 ## 2026-06-04 — M7 slice 1: transform engine + map/rename/default
 
 - What changed: Added the transform engine at `core/src/transform.ts`. `applyFlow(doc, flow)`

--- a/spec/examples/flow/valid.flow.yaml
+++ b/spec/examples/flow/valid.flow.yaml
@@ -5,6 +5,19 @@ steps:
   - op: map
     from: order.line
     to: lines
+  - op: str
+    fn: upper
+    from: id
+  - op: concat
+    to: label
+    sep: ' '
+    parts:
+      - value: order
+      - path: id
+  - op: date
+    fn: toIso
+    from: order.createdAt
+    to: createdAt
   - op: default
     at: status
     value: new

--- a/spec/schemas/flow.schema.json
+++ b/spec/schemas/flow.schema.json
@@ -52,6 +52,50 @@
             "at": { "$ref": "#/$defs/path" },
             "value": {}
           }
+        },
+        {
+          "description": "Join `parts` (each a path or literal value) into a string at `to`.",
+          "additionalProperties": false,
+          "required": ["op", "to", "parts"],
+          "properties": {
+            "op": { "const": "concat" },
+            "to": { "$ref": "#/$defs/path" },
+            "sep": { "type": "string" },
+            "parts": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                  "path": { "$ref": "#/$defs/path" },
+                  "value": {}
+                },
+                "oneOf": [{ "required": ["path"] }, { "required": ["value"] }]
+              }
+            }
+          }
+        },
+        {
+          "description": "Apply a string function from `from` to `to` (default `from`).",
+          "additionalProperties": false,
+          "required": ["op", "fn", "from"],
+          "properties": {
+            "op": { "const": "str" },
+            "fn": { "enum": ["upper", "lower", "trim"] },
+            "from": { "$ref": "#/$defs/path" },
+            "to": { "$ref": "#/$defs/path" }
+          }
+        },
+        {
+          "description": "Apply a date function from `from` to `to` (default `from`).",
+          "additionalProperties": false,
+          "required": ["op", "fn", "from"],
+          "properties": {
+            "op": { "const": "date" },
+            "fn": { "enum": ["toIso"] },
+            "from": { "$ref": "#/$defs/path" },
+            "to": { "$ref": "#/$defs/path" }
+          }
         }
       ]
     }

--- a/website/docs/dsl.md
+++ b/website/docs/dsl.md
@@ -61,6 +61,44 @@ Set `at` to `value` only when nothing is there yet. An existing value is left un
   value: new
 ```
 
+### `concat`
+
+Join `parts` into a string at `to`. Each part is either a `path` (read from the document)
+or a literal `value`. An optional `sep` is placed between parts (default empty). Parts must
+resolve to scalars; `null` contributes an empty string.
+
+```yaml
+- op: concat
+  to: fullName
+  sep: ' '
+  parts:
+    - path: first
+    - path: last
+    - value: '!'
+```
+
+### `str`
+
+Apply a string function — `upper`, `lower`, or `trim` — from `from` to `to`. `to` defaults
+to `from`, so omitting it transforms in place.
+
+```yaml
+- op: str
+  fn: upper
+  from: code # writes back to `code`
+```
+
+### `date`
+
+Apply a date function from `from` to `to` (default `from`). `toIso` parses the source value
+as a date and writes it back as an ISO-8601 UTC string; an unparseable value is an error.
+
+```yaml
+- op: date
+  fn: toIso
+  from: createdAt # '2026-06-04' -> '2026-06-04T00:00:00.000Z'
+```
+
 ## Errors
 
 A step that references a missing source path, or that targets an impossible location (for


### PR DESCRIPTION
Second of the stacked M7 slices (engine ✅ → **helpers** → conditionals → cli+golden-path).

## Summary
- Three new transform ops in `@weavster/core`:
  - `concat` — join a `parts` list (each a `path` or literal `value`) into a string at `to`, optional `sep`.
  - `str` — `upper`/`lower`/`trim` from `from` to `to` (default `from`, i.e. in place).
  - `date` — `toIso`, parses the source with `new Date(...)` and writes the ISO-8601 UTC string. **Deterministic (no `now`)** → fixture-safe.
- Extended `flow.schema.json` (+ richer valid sample), Transform DSL docs, and a combined-pipeline test.

## Notes
- Scalar coercion shared via one helper: `null` → empty string, structured node → error.
- **Fixed a JSON Schema bug while extending the schema:** `additionalProperties: false` only sees properties declared in the *same* schema object, not ones nested in `oneOf` — the concat part's `path`/`value` are now declared at item level (verified valid sample passes, invalids still rejected).

## Test plan
- `pnpm test` → core 65 (+10) + cli 11, all pass.
- Flow schema re-checked against samples.
- `pnpm --filter @weavster/core build` / `pnpm cli:build` / `pnpm docs:build` clean.

## MVP tasks
- Checks `concat` + string/date helpers. Remaining: conditional logic (slice 3), then cli/golden-path wiring (slice 4).

🤖 Generated with [Claude Code](https://claude.com/claude-code)