### PR TITLE
M7 (slice 3): conditional logic (when)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Added
 
+- M7 (slice 3) conditional op `when` in `@weavster/core`: a `cond` predicate (`path` tested
+  with `equals` or `exists`) runs nested `then`/`else` sub-step lists. The pipeline recurses,
+  so `when` can nest and nested errors carry the `when` context. Extends `flow.schema.json`
+  and the Transform DSL docs.
 - M7 (slice 2) transform helper ops in `@weavster/core`: `concat` (join `parts` of paths
   and literals with an optional `sep`), `str` (`upper`/`lower`/`trim`), and `date`
   (`toIso`). Extends `flow.schema.json` and the Transform DSL docs.

--- a/README.md
+++ b/README.md
@@ -31,8 +31,8 @@ them locally, test them with fixtures, and run them through a modular engine.
   [Format Packs](https://docs.weavster.dev/formats).
 - Transform engine (`@weavster/core` `applyFlow`): runs an op-keyed step list as a
   mutate-in-place pipeline over the canonical model. Operations: `map`, `rename`, `default`,
-  `concat`, `str` (upper/lower/trim), `date` (toIso), with step-scoped errors. See
-  [Transform DSL](https://docs.weavster.dev/dsl).
+  `concat`, `str` (upper/lower/trim), `date` (toIso), and `when` (conditional then/else), with
+  step-scoped errors. See [Transform DSL](https://docs.weavster.dev/dsl).
 - Contribution rules ([`CONTRIBUTING.md`](CONTRIBUTING.md)) and PR template.
 - Editor/formatter config (`.editorconfig`, Prettier).
 - Dev log ([`notes/DEV_LOG.md`](notes/DEV_LOG.md)) and changelog

--- a/core/src/transform.ts
+++ b/core/src/transform.ts
@@ -58,6 +58,25 @@ interface ConcatPart {
   value?: unknown;
 }
 
+/** A `when` predicate: a path tested with `equals` (literal) or `exists` (boolean). */
+interface Cond {
+  path?: unknown;
+  equals?: unknown;
+  exists?: unknown;
+}
+
+/** Evaluate a `when` condition against the working document. */
+function evalCond(working: Document, cond: Cond | undefined): boolean {
+  if (typeof cond?.path !== 'string') throw new TransformError('"cond.path" must be a path string');
+  const node = get(working, cond.path);
+  if ('exists' in cond) return (node !== undefined) === Boolean(cond.exists);
+  if ('equals' in cond) {
+    if (node === undefined || !isScalar(node)) return false;
+    return node.value === cond.equals;
+  }
+  throw new TransformError('"cond" needs an "equals" or "exists"');
+}
+
 const OPS: Record<string, OpFn> = {
   /** Copy the value at `from` to `to`. */
   map(working, step) {
@@ -122,16 +141,23 @@ const OPS: Record<string, OpFn> = {
     if (Number.isNaN(date.getTime())) throw new TransformError(`cannot parse date "${input}"`);
     set(working, to, scalarNode(date.toISOString()));
   },
+
+  /** Run `then` when `cond` holds, otherwise `else` (if present). */
+  when(working, step) {
+    if (!Array.isArray(step.then)) throw new TransformError('"then" must be a list of steps');
+    if (step.else !== undefined && !Array.isArray(step.else)) {
+      throw new TransformError('"else" must be a list of steps');
+    }
+    const branch = evalCond(working, step.cond as Cond | undefined)
+      ? (step.then as Step[])
+      : ((step.else as Step[] | undefined) ?? []);
+    runSteps(working, branch);
+  },
 };
 
-/** Run a flow against a document, returning a new transformed document. */
-export function applyFlow(doc: Document, flow: Flow): Document {
-  const working: Document = {
-    root: structuredClone(doc.root),
-    meta: { ...doc.meta, errors: [...doc.meta.errors] },
-  };
-
-  flow.steps.forEach((step, index) => {
+/** Run a list of steps against the working document. Recurses for nested branches. */
+function runSteps(working: Document, steps: Step[]): void {
+  steps.forEach((step, index) => {
     const op = OPS[step.op];
     if (op === undefined) throw new TransformError(`step ${index}: unknown op "${step.op}"`);
     try {
@@ -141,6 +167,14 @@ export function applyFlow(doc: Document, flow: Flow): Document {
       throw new TransformError(`step ${index} (${step.op}): ${message}`);
     }
   });
+}
 
+/** Run a flow against a document, returning a new transformed document. */
+export function applyFlow(doc: Document, flow: Flow): Document {
+  const working: Document = {
+    root: structuredClone(doc.root),
+    meta: { ...doc.meta, errors: [...doc.meta.errors] },
+  };
+  runSteps(working, flow.steps);
   return working;
 }

--- a/core/test/transform.test.ts
+++ b/core/test/transform.test.ts
@@ -122,6 +122,96 @@ describe('date', () => {
   });
 });
 
+describe('when', () => {
+  it('runs the then branch when equals matches', () => {
+    expect(
+      run({ status: 'new' }, [
+        {
+          op: 'when',
+          cond: { path: 'status', equals: 'new' },
+          then: [{ op: 'default', at: 'priority', value: 'high' }],
+        },
+      ]),
+    ).toEqual({ status: 'new', priority: 'high' });
+  });
+
+  it('runs the else branch when the condition is false', () => {
+    expect(
+      run({ status: 'done' }, [
+        {
+          op: 'when',
+          cond: { path: 'status', equals: 'new' },
+          then: [{ op: 'default', at: 'priority', value: 'high' }],
+          else: [{ op: 'default', at: 'priority', value: 'low' }],
+        },
+      ]),
+    ).toEqual({ status: 'done', priority: 'low' });
+  });
+
+  it('does nothing when false and there is no else', () => {
+    expect(
+      run({ status: 'done' }, [
+        {
+          op: 'when',
+          cond: { path: 'status', equals: 'new' },
+          then: [{ op: 'default', at: 'priority', value: 'high' }],
+        },
+      ]),
+    ).toEqual({ status: 'done' });
+  });
+
+  it('tests presence with exists', () => {
+    expect(
+      run({}, [
+        {
+          op: 'when',
+          cond: { path: 'x', exists: false },
+          then: [{ op: 'default', at: 'x', value: 1 }],
+        },
+      ]),
+    ).toEqual({ x: 1 });
+    expect(
+      run({ x: 9 }, [
+        {
+          op: 'when',
+          cond: { path: 'x', exists: true },
+          then: [{ op: 'default', at: 'seen', value: true }],
+        },
+      ]),
+    ).toEqual({ x: 9, seen: true });
+  });
+
+  it('treats equals against a missing or non-scalar value as false', () => {
+    expect(
+      run({}, [
+        {
+          op: 'when',
+          cond: { path: 'k', equals: 'v' },
+          then: [{ op: 'default', at: 'hit', value: 1 }],
+        },
+      ]),
+    ).toEqual({});
+  });
+
+  it('reports nested step errors with the when context', () => {
+    expect(() =>
+      run({ a: 1 }, [
+        {
+          op: 'when',
+          cond: { path: 'a', equals: 1 },
+          then: [{ op: 'map', from: 'missing', to: 'y' }],
+        },
+      ]),
+    ).toThrow(/step 0 \(when\): step 0 \(map\).*missing/);
+  });
+
+  it('errors on a malformed condition', () => {
+    expect(() => run({}, [{ op: 'when', cond: { path: 'a' }, then: [] }])).toThrow(
+      /equals.*exists/,
+    );
+  });
+});
+
 describe('applyFlow', () => {
   it('runs steps in order as a pipeline', () => {
     const flow: Flow = {

--- a/docs/MVP_TASKS.md
+++ b/docs/MVP_TASKS.md
@@ -200,9 +200,9 @@ helpers, (3) conditionals, (4) wire golden-path + DSL reference._
 - [x] Implement `rename` or equivalent field remap primitive. _(slice 1)_
 - [x] Implement `default`. _(slice 1)_
 - [x] Implement `concat`. _(slice 2)_
-- [ ] Implement conditional logic. _(slice 3)_
+- [x] Implement conditional logic. _(slice 3: `when` with equals/exists, then/else)_
 - [x] Implement minimal string/date helpers. _(slice 2: `str` upper/lower/trim, `date` toIso)_
-- [ ] Add tests for each operation and at least one combined pipeline. _(slices 1–2 done; conditional in slice 3)_
+- [x] Add tests for each operation and at least one combined pipeline.
 
 ### Docs and understanding
 

--- a/notes/DEV_LOG.md
+++ b/notes/DEV_LOG.md
@@ -13,6 +13,25 @@ Newest entries on top. One entry per merged slice.
 
 ---
 
+## 2026-06-05 — M7 slice 3: conditional logic
+
+- What changed: Added the `when` op. `cond` is a single predicate — a `path` tested with
+  `equals` (literal match) or `exists` (boolean presence). `then` runs when it holds, `else`
+  (optional) otherwise. To support nested branches, the engine's step loop was extracted into
+  `runSteps(working, steps)`, which `applyFlow` and `when` both call; branches are full
+  sub-pipelines. Extended `flow.schema.json` (recursive `then`/`else` via `$ref` to the step
+  def), the valid sample, the DSL docs, and added `when` tests.
+- What I learned: Recursion fell out cleanly once the per-step try/catch lived in `runSteps`
+  rather than `applyFlow` — a failure inside a branch throws a `TransformError` tagged with its
+  own index, and the enclosing `when` step re-wraps it, so the message nests:
+  `step 0 (when): step 0 (map): no value at "missing"`. Predicate semantics chosen for
+  least surprise: `equals` against a missing path or a non-scalar is simply false (not an
+  error), so authors branch on shape without guarding first; only a malformed `cond` (no
+  `equals`/`exists`) throws. Kept the predicate to one comparison — AND is nesting, NOT is the
+  `else` branch — to avoid growing a boolean expression language this slice.
+- What is next: M7 slice 4 — wire flows into the cli (load `flows/`, run via the fixture
+  harness) and finish the golden-path + DSL reference.
+
 ## 2026-06-04 — M7 slice 2: concat + string/date helpers
 
 - What changed: Added three ops to the engine. `concat` joins a `parts` list — each part a

--- a/spec/examples/flow/valid.flow.yaml
+++ b/spec/examples/flow/valid.flow.yaml
@@ -21,3 +21,15 @@ steps:
   - op: default
     at: status
     value: new
+  - op: when
+    cond:
+      path: status
+      equals: new
+    then:
+      - op: default
+        at: priority
+        value: high
+    else:
+      - op: default
+        at: priority
+        value: normal

--- a/spec/schemas/flow.schema.json
+++ b/spec/schemas/flow.schema.json
@@ -96,6 +96,27 @@
             "from": { "$ref": "#/$defs/path" },
             "to": { "$ref": "#/$defs/path" }
           }
+        },
+        {
+          "description": "Run `then` when `cond` holds, otherwise `else`.",
+          "additionalProperties": false,
+          "required": ["op", "cond", "then"],
+          "properties": {
+            "op": { "const": "when" },
+            "cond": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": ["path"],
+              "properties": {
+                "path": { "$ref": "#/$defs/path" },
+                "equals": {},
+                "exists": { "type": "boolean" }
+              },
+              "oneOf": [{ "required": ["equals"] }, { "required": ["exists"] }]
+            },
+            "then": { "type": "array", "items": { "$ref": "#/$defs/step" } },
+            "else": { "type": "array", "items": { "$ref": "#/$defs/step" } }
+          }
         }
       ]
     }

--- a/website/docs/dsl.md
+++ b/website/docs/dsl.md
@@ -99,6 +99,31 @@ as a date and writes it back as an ISO-8601 UTC string; an unparseable value is 
   from: createdAt # '2026-06-04' -> '2026-06-04T00:00:00.000Z'
 ```
 
+### `when`
+
+Run a nested list of steps conditionally. `cond` is a single predicate — a `path` tested
+with either `equals` (matches a literal) or `exists` (`true`/`false` for presence). Steps in
+`then` run when the condition holds; `else` (optional) runs otherwise. Branches are full
+sub-pipelines, so `when` can nest.
+
+```yaml
+- op: when
+  cond:
+    path: status
+    equals: new
+  then:
+    - op: default
+      at: priority
+      value: high
+  else:
+    - op: default
+      at: priority
+      value: normal
+```
+
+A missing path, or a value that is not a scalar, makes `equals` false. Combine conditions by
+nesting `when` inside `then`; negate by using `else`.
+
 ## Errors
 
 A step that references a missing source path, or that targets an impossible location (for


### PR DESCRIPTION
Third of the stacked M7 slices (engine ✅ → helpers ✅ → **conditionals** → cli+golden-path).

## Summary
- New `when` op: `cond` is a single predicate — a `path` tested with `equals` (literal match) or `exists` (boolean presence). `then` runs when it holds; `else` (optional) otherwise.
- Branches are full sub-pipelines. The step loop is extracted into `runSteps(working, steps)` (shared by `applyFlow` and `when`), so `when` nests and nested errors carry context: `step 0 (when): step 0 (map): no value at "missing"`.
- Extends `flow.schema.json` (recursive `then`/`else` via `$ref`), the valid sample, the DSL docs, and adds `when` tests.

## Semantics
- `equals` against a missing path or non-scalar is **false** (not an error) — branch on shape without guarding first.
- Only a malformed `cond` (no `equals`/`exists`) throws.
- Kept to one comparison: AND = nesting, NOT = `else`. No boolean-expression language this slice.

## Test plan
- `pnpm test` → core 72 (+7) + cli 11, all pass.
- Flow schema re-checked against samples (valid passes; invalids rejected).
- `pnpm --filter @weavster/core build` / `pnpm cli:build` / `pnpm docs:build` clean.

## MVP tasks
- Checks conditional logic + the combined-pipeline coverage. Remaining: slice 4 — wire flows into the cli (load `flows/`, run via the fixture harness) + golden-path + DSL reference wrap-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)