### PR TITLE
docs(rfc): v0alpha2 transform DSL design (RFC 0001)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Added
 
+- RFC 0001 (`docs/rfcs/0001-v0alpha2-dsl.md`): design for the v0alpha2 transform DSL — a
+  MongoDB-flavored expression model on a patch-by-default pipeline (`$path` refs, `_op`
+  operators), folding in the M7 cleanup. Draft only; targeted post-M8.
 - M7 (slice 4) flows wired into the CLI: `weavster test` now parses each fixture's input,
   runs it through `flows/<flow>.yaml`, and compares the output (fixtures are grouped by flow
   under `fixtures/<flow>/<case>/`). `weavster validate` now also validates every `flows/*.yaml`

--- a/docs/rfcs/0001-v0alpha2-dsl.md
+++ b/docs/rfcs/0001-v0alpha2-dsl.md
@@ -188,7 +188,17 @@ become the expression namespace, validation noise fixed.
 
 ## Sequencing
 
-1. Finish M8 (TypeScript escape hatch) on the v0alpha1 DSL.
+Agreed order: **M8 → v0alpha2 → M9** (a deliberate reorder of the MVP plan's M8 → M9).
+Rationale: M8 (the TypeScript escape hatch) is largely orthogonal to DSL syntax — it rides on
+the canonical model, and its only touchpoint is the step keyword — so it lands cleanly on
+v0alpha1. M9 (golden-path example, quickstart, full DSL reference) is the most user-facing,
+most-copied surface, so it should be written **once** against the final v0alpha2 syntax rather
+than written on v0alpha1 and redone. The project is pre-release (`v0alpha`), so breaking the
+DSL before M9 is cheap; breaking it after M9 ships examples people copy is not.
+
+1. Finish M8 (TypeScript escape hatch) on the v0alpha1 DSL (only the step keyword needs later
+   migration).
 2. Resolve the open questions on this RFC.
-3. Implement v0alpha2 in core (expression evaluator + structural ops), bump the schema,
-   update the CLI loader, migrate the golden-path flow, rewrite the DSL docs.
+3. Implement v0alpha2 in core (expression evaluator + structural ops), bump the schema, update
+   the CLI loader, and migrate any flows.
+4. Then M9 — write the golden-path example, quickstart, and DSL reference against v0alpha2.

--- a/docs/rfcs/0001-v0alpha2-dsl.md
+++ b/docs/rfcs/0001-v0alpha2-dsl.md
@@ -1,0 +1,194 @@
+# RFC 0001 — v0alpha2 Transform DSL
+
+- Status: **Draft** (design only; no implementation yet)
+- Target: after Milestone 8 (TypeScript escape hatch)
+- Supersedes: the v0alpha1 op-keyed flow DSL (M7)
+- Schema bump: `weavster/v0alpha1` → `weavster/v0alpha2` (breaking)
+
+## Summary
+
+Redesign the transform DSL around a small **expression language** (MongoDB-flavored),
+while keeping the **mutate-in-place pipeline** so small edits stay small. Two sigils:
+`$path` references read from the document, `_op` keys invoke operators (in any position —
+as a step or as a value). Steps default to **patch** semantics (keep everything, change
+only what you name); full reshape is an explicit opt-in.
+
+## Motivation
+
+v0alpha1 (M7) shipped an op-keyed pipeline: `map`, `rename`, `default`, `concat`, `str`,
+`date`, `when`. Building it surfaced real limits:
+
+1. **No composition.** Each op is a flat step. You cannot nest logic (e.g. uppercase the
+   result of a concat) without intermediate fields. No path to reuse/macros.
+2. **Inconsistent target keys** (`at` vs `to`), and `map` is a confusing name (reads like
+   array-map; it actually copies one path to another).
+3. **No unconditional literal set**, no `drop`/`select` — source fields leak into output.
+4. **Noisy validation** — the step schema is a `oneOf` over op variants, so a bad `op`
+   reports every branch's failure.
+
+And one requirement v0alpha1 cannot meet well:
+
+5. **Cheap partial edits.** For segment-heavy formats (e.g. HL7), a change is often "set
+   `MSH-4`, reformat one date, append one patient id" — without re-emitting every segment
+   and field. Pure projection (declare the whole output) is the opposite of this.
+
+## Key decision: patch + reshape, not projection-only
+
+MongoDB already reconciles "powerful expressions" with "cheap partial edits" by having two
+modes. We adopt both:
+
+- **Patch** (`_set` / `_default` / `_unset` / `_rename` / `_append`): keep the whole
+  document, change only the named paths. **This is the default.**
+- **Reshape** (`_select`): output only what you declare (projection). Explicit opt-in.
+
+The backbone stays a **pipeline of steps** (so partial edits compose naturally and a step
+trace remains debuggable). The new power is that **values are expressions**.
+
+## Sigils
+
+| Sigil  | Position     | Meaning                                  | Example              |
+| ------ | ------------ | ---------------------------------------- | -------------------- |
+| `$`    | scalar value | path reference into the working document | `$order.line[0].sku` |
+| `_`    | map key      | operator invocation (step or value)      | `{ _concat: [...] }` |
+| (none) | map key      | literal data / field name                | `status: new`        |
+
+- One rule to remember: **`_` means "run an operator," `$` means "read a path," plain means
+  "literal data."**
+- Escapes: a literal string that must start with `$` → `$$...`, or wrap with `{ _lit: "$x" }`.
+  A literal map that would look like an operator → `{ _lit: { ... } }`.
+- Path references resolve against the **working document** (the state after prior steps),
+  not the original input.
+
+## Structural step operators
+
+Each step is a single `_`-prefixed operator key. Dispatch is on that key (which also gives
+clean validation — see below).
+
+| Step       | Shape                                            | Semantics                                               |
+| ---------- | ------------------------------------------------ | ------------------------------------------------------- |
+| `_set`     | `{ <path>: <expr>, ... }`                        | Patch: set each path to its expr. Keep everything else. |
+| `_default` | `{ <path>: <expr>, ... }`                        | Patch, but only where the path is currently absent.     |
+| `_rename`  | `{ <from>: <to>, ... }`                          | Move each path (copy then remove source).               |
+| `_unset`   | `[<path>, ...]`                                  | Remove paths.                                           |
+| `_append`  | `{ to: <path>, value: <expr> }`                  | Append to an array (grows it).                          |
+| `_select`  | `{ <path>: <expr>, ... }`                        | Reshape: output **only** these paths.                   |
+| `_when`    | `{ cond: <expr>, then: [steps], else: [steps] }` | Run a branch (sub-pipeline) by condition.               |
+
+`_set`, `_default`, and `_rename` take **maps** (many paths per step) for terse patches.
+
+## Value operators (the expression language)
+
+Used anywhere a value is expected — inside `_set`/`_select`/`_append`/`_default` and in
+`_when.cond`. An expression is one of: a literal, a `$path` reference, or a single-key
+`{ _op: args }` map.
+
+| Operator                      | Shape                                             | Result                     |
+| ----------------------------- | ------------------------------------------------- | -------------------------- |
+| reference                     | `$a.b[0]`                                         | the value at that path     |
+| `_concat`                     | `[<expr>, ...]` or `{ parts: [...], sep: <str> }` | joined string              |
+| `_upper` / `_lower` / `_trim` | `<expr>`                                          | transformed string         |
+| `_toIso`                      | `<expr>`                                          | date string → ISO-8601 UTC |
+| `_coalesce`                   | `[<expr>, ...]`                                   | first non-null             |
+| `_eq`                         | `[<expr>, <expr>]`                                | boolean                    |
+| `_exists`                     | `<expr-path>`                                     | boolean (path present)     |
+| `_cond`                       | `{ if: <expr>, then: <expr>, else: <expr> }`      | ternary, as a value        |
+
+Future (not v0alpha2 unless cheap): `_gt`/`_lt`/`_in`, `_and`/`_or`/`_not`, numeric/math ops.
+
+Note this **subsumes** several v0alpha1 ops: `map` is just `_set: { to: $from }`; `concat`,
+`str.*`, `date.*` become value operators; `when`'s condition becomes an `_eq`/`_exists`
+expression. The structural surface shrinks; the composable surface grows.
+
+## Worked example — HL7-style partial edit
+
+Set `MSH-4`, reformat a date in `PID-7`, append a patient id to the repeating `PID-3` —
+leaving every other segment and field untouched:
+
+```yaml
+steps:
+  - _set:
+      MSH-4: SENDING_FAC
+      PID-7: { _toIso: $PID-7 }
+  - _append:
+      to: PID-3
+      value: MRN-12345
+```
+
+(The HL7 format pack itself is out of scope here; this shows the patch ergonomics the DSL
+must support. Segment/field addressing maps onto the canonical model via that pack; the
+existing dotted/bracket path syntax already covers arbitrary keys and array indices.)
+
+## Worked example — reshape
+
+```yaml
+steps:
+  - _select:
+      id: { _upper: $order.@id }
+      name: { _concat: { parts: [$first, $last], sep: ' ' } }
+      priority:
+        _cond:
+          if: { _eq: [$status, new] }
+          then: high
+          else: normal
+```
+
+## Validation
+
+Because each step is a single `_op` key, the schema dispatches on that key (e.g. JSON Schema
+`if`/`then` per operator, or ajv `discriminator`), not a `oneOf` over an `op` constant. A bad
+operator yields one clean message — "unknown operator `_st`" — instead of v0alpha1's
+every-branch explosion. This resolves the M7 validation rough edge for free.
+
+## Errors
+
+Unchanged in spirit: a `TransformError` carries the step index, the operator, and the
+offending path, and nests through `_when` branches. Reference to a missing path inside an
+expression follows the same "missing → error" / "comparison of missing → false" rules as
+v0alpha1.
+
+## v0alpha1 → v0alpha2 migration
+
+| v0alpha1                                          | v0alpha2                                               |
+| ------------------------------------------------- | ------------------------------------------------------ |
+| `op: map { from, to }`                            | `_set: { <to>: $<from> }`                              |
+| `op: rename { from, to }`                         | `_rename: { <from>: <to> }`                            |
+| `op: default { at, value }`                       | `_default: { <at>: <value> }`                          |
+| `op: concat { to, parts, sep }`                   | `_set: { <to>: { _concat: { parts, sep } } }`          |
+| `op: str { fn, from, to }`                        | `_set: { <to>: { _<fn>: $<from> } }`                   |
+| `op: date { fn: toIso, from, to }`                | `_set: { <to>: { _toIso: $<from> } }`                  |
+| `op: when { cond: { path, equals }, then, else }` | `_when: { cond: { _eq: [$<path>, <v>] }, then, else }` |
+| (none) — set a literal always                     | `_set: { <path>: <value> }`                            |
+| (none) — drop a field                             | `_unset: [<path>]`                                     |
+
+Cleanup items from the M7 retro are absorbed: consistent target keys (maps remove `at`/`to`
+split), unconditional set, drop/select, `map` renamed away, grouped string/date functions
+become the expression namespace, validation noise fixed.
+
+## Open questions
+
+1. **Array ops** — is `_append` enough, or do we also need `_insert { to, index, value }`
+   and removal by index? HL7 repeating fields will pressure this.
+2. **Macros / reuse** — named, reusable expressions (e.g. a project-level `fullName`) are the
+   real prize of the expression model. Design the seam in v0alpha2; ship in a later pass?
+3. **`_select` semantics** — strict projection (only named paths) vs. deep-merge over a base.
+   Proposed: strict.
+4. **Literal escapes** — settle `_lit` vs `$$` for values that must start with `$`/look like
+   operators.
+5. **Numeric/logical operators** — how much of `_gt`/`_lt`/`_in`/`_and`/`_or`/`_not` lands in
+   v0alpha2 vs later.
+6. **Flow `apiVersion`** — do flow files declare `apiVersion: weavster/v0alpha2`, or is the
+   version implied by the project?
+
+## Non-goals
+
+- Implementing this now (post-M8).
+- A full Turing-complete expression language — that is what the TypeScript escape hatch (M8)
+  is for. The "when not to use config" guidance still applies.
+- The HL7 format pack itself (separate, later milestone).
+
+## Sequencing
+
+1. Finish M8 (TypeScript escape hatch) on the v0alpha1 DSL.
+2. Resolve the open questions on this RFC.
+3. Implement v0alpha2 in core (expression evaluator + structural ops), bump the schema,
+   update the CLI loader, migrate the golden-path flow, rewrite the DSL docs.

--- a/notes/DEV_LOG.md
+++ b/notes/DEV_LOG.md
@@ -13,6 +13,25 @@ Newest entries on top. One entry per merged slice.
 
 ---
 
+## 2026-06-05 — RFC 0001: v0alpha2 DSL (design)
+
+- What changed: Wrote `docs/rfcs/0001-v0alpha2-dsl.md` capturing the next-gen transform DSL
+  decided in discussion. Core idea: a MongoDB-flavored expression language on a mutate-in-place
+  pipeline. Two sigils — `$path` reads a reference, `_op` invokes an operator (as a step or a
+  value). Patch by default (`_set`/`_default`/`_unset`/`_rename`/`_append` keep the rest of the
+  document); reshape (`_select`) is the explicit opt-in. The M7 cleanup folds in: maps remove the
+  `at`/`to` split, `map` becomes `_set: { to: $from }`, str/date/concat become value operators,
+  and single-key `_op` dispatch fixes the noisy validation.
+- What I learned: The decisive constraint was partial edits — the HL7 case ("set MSH-4, reformat
+  one date, append one PID, leave the rest") rules out pure projection. Mongo's split (`$set`
+  patch vs `$project` reshape) is the resolution, so v0alpha2 is patch-first with reshape opt-in,
+  not projection-first. Expressions-as-values are what unlock composition and future macros (the
+  reuse goal); the structural op surface actually shrinks because transforms move into the
+  expression namespace. Design only — implementation waits until after M8 so the escape hatch
+  lands on the stable v0alpha1 DSL first.
+- What is next: M8 — TypeScript escape hatch (still on v0alpha1); resolve RFC open questions, then
+  implement v0alpha2.
+
 ## 2026-06-05 — M7 slice 4: wire flows into the cli
 
 - What changed: Connected the engine to the CLI (the cli↔core integration deferred since M3).


### PR DESCRIPTION
Design-only RFC capturing the next-gen transform DSL agreed in discussion. **No engine changes**; targeted post-M8.

## What it proposes
- **MongoDB-flavored expression model on a patch-by-default pipeline.**
- **Two sigils:** `$path` reads a reference, `_op` invokes an operator (as a step or as a value).
- **Patch by default** — `_set`/`_default`/`_unset`/`_rename`/`_append` keep the whole document, change only named paths. **Reshape** (`_select`) is the explicit opt-in.
- **Values are expressions** (`_concat`, `_upper`, `_toIso`, `_eq`, `_cond`, …) — the composition/macros prize, and the structural op surface shrinks.

## Why patch-first
The decisive constraint is cheap partial edits. The HL7 case — set `MSH-4`, reformat one date, append one PID, leave every other segment untouched — rules out pure projection. Mongo's split (`$set` patch vs `$project` reshape) is the resolution.

## Folds in the M7 cleanup
Consistent target keys, `map`→`_set: { to: $from }`, `drop`/`set`, str/date/concat become value operators, and single-key `_op` dispatch fixes the noisy validation. Includes a v0alpha1→v0alpha2 migration table and open questions (array ops, macros, escapes, numeric/logical ops).

## Decisions baked in (from discussion)
- Option B (expression model) ✅
- Both sigils (`$` + `_`) ✅
- Patch by default ✅
- Cleanup folded into the v0alpha2 break ✅
- Sequenced post-M8 ✅

File: `docs/rfcs/0001-v0alpha2-dsl.md`. Merge to record the design; refine open questions before implementing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)