### PR TITLE
v0alpha2 (slice 1): expression evaluator + _set/_unset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Added
 
+- v0alpha2 DSL (slice 1, internal): expression evaluator (`core/src/dsl/expr.ts`) with `$path`
+  references, `$$` escape, deep array/object evaluation, and `_lit`; plus a patch-by-default
+  engine (`core/src/dsl/engine.ts`) with the first structural ops `_set` and `_unset`. Not yet
+  wired into the CLI — v0alpha1 still runs flows until the cutover slice.
 - M8 TypeScript escape hatch: a `ts` transform step runs a custom function from the project's
   `functions/<module>.ts`. The contract is pure JSON in / JSON out (WASM-portable); the core
   engine takes injected functions (`applyFlow(doc, flow, { functions })`) and the CLI loads

--- a/core/src/dsl/engine.ts
+++ b/core/src/dsl/engine.ts
@@ -1,0 +1,83 @@
+/**
+ * v0alpha2 transform engine.
+ *
+ * A flow is a pipeline of single-key `_op` steps run against a working document
+ * (a clone of the input). Steps are **patch by default**: `_set` and `_unset`
+ * change only the paths they name and leave the rest of the document intact.
+ * Values are expressions (see `expr.ts`).
+ */
+import { type Document, type Node, fromValue } from '../model.js';
+import { remove, set } from '../path.js';
+import { type Ctx, evalExpr } from './expr.js';
+import { TransformError } from './errors.js';
+
+export { TransformError } from './errors.js';
+
+/** A single transform step: one `_`-prefixed operator key mapped to its argument. */
+export type Step = Record<string, unknown>;
+
+export interface Flow {
+  steps: Step[];
+}
+
+export interface RunOptions {
+  functions?: Record<string, (value: unknown) => unknown>;
+}
+
+type StructuralOp = (working: Document, arg: unknown, ctx: Ctx) => void;
+
+function asRecord(arg: unknown, op: string): Record<string, unknown> {
+  if (arg === null || typeof arg !== 'object' || Array.isArray(arg)) {
+    throw new TransformError(`"${op}" expects a map of paths to values`);
+  }
+  return arg as Record<string, unknown>;
+}
+
+const STRUCTURAL: Record<string, StructuralOp> = {
+  /** Patch: set each path to its evaluated expression. Missing (undefined) values are skipped. */
+  _set(working, arg, ctx) {
+    const entries = Object.entries(asRecord(arg, '_set')).map(
+      ([path, expr]) => [path, evalExpr(expr, ctx)] as const,
+    );
+    for (const [path, value] of entries) {
+      if (value !== undefined) set(working, path, fromValue(value) as Node);
+    }
+  },
+
+  /** Remove each listed path. */
+  _unset(working, arg) {
+    if (!Array.isArray(arg)) throw new TransformError('"_unset" expects a list of paths');
+    for (const path of arg) {
+      if (typeof path !== 'string') throw new TransformError('"_unset" paths must be strings');
+      remove(working, path);
+    }
+  },
+};
+
+function runSteps(working: Document, steps: Step[], ctx: Ctx): void {
+  steps.forEach((step, index) => {
+    const keys = Object.keys(step);
+    if (keys.length !== 1) {
+      throw new TransformError(`step ${index}: a step must have exactly one operator key`);
+    }
+    const op = keys[0];
+    const impl = STRUCTURAL[op];
+    if (impl === undefined) throw new TransformError(`step ${index}: unknown operator "${op}"`);
+    try {
+      impl(working, step[op], ctx);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      throw new TransformError(`step ${index} (${op}): ${message}`);
+    }
+  });
+}
+
+/** Run a flow against a document, returning a new transformed document. */
+export function applyFlow(doc: Document, flow: Flow, _options: RunOptions = {}): Document {
+  const working: Document = {
+    root: structuredClone(doc.root),
+    meta: { ...doc.meta, errors: [...doc.meta.errors] },
+  };
+  runSteps(working, flow.steps, { working });
+  return working;
+}

--- a/core/src/dsl/errors.ts
+++ b/core/src/dsl/errors.ts
@@ -1,0 +1,7 @@
+/** Thrown when a step or expression is malformed or references a bad path. */
+export class TransformError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'TransformError';
+  }
+}

--- a/core/src/dsl/expr.ts
+++ b/core/src/dsl/expr.ts
@@ -1,0 +1,56 @@
+/**
+ * Expression evaluator for the v0alpha2 DSL.
+ *
+ * A value position is an expression: a literal, a `$path` reference, or a
+ * single-key `{ _op: ... }` operator. Plain objects and arrays are evaluated
+ * deeply, so references and operators can be nested anywhere inside a value.
+ *
+ * Sigils: `$path` reads from the working document; `$$x` is the literal `$x`;
+ * a single `_`-prefixed key invokes an operator. `_lit` returns its argument
+ * verbatim (the escape for values that would otherwise look like operators or
+ * path references).
+ */
+import type { Document } from '../model.js';
+import { getValue } from '../path.js';
+import { TransformError } from './errors.js';
+
+export interface Ctx {
+  working: Document;
+}
+
+export type ValueOp = (arg: unknown, ctx: Ctx) => unknown;
+
+/** Value operators (`_concat`, comparisons, …). Populated as the DSL grows. */
+export const VALUE_OPS: Record<string, ValueOp> = {};
+
+function isOperator(keys: string[]): boolean {
+  return keys.length === 1 && keys[0].startsWith('_');
+}
+
+/** Evaluate an expression against the working document, returning a JS value. */
+export function evalExpr(expr: unknown, ctx: Ctx): unknown {
+  if (typeof expr === 'string') {
+    if (expr.startsWith('$$')) return expr.slice(1);
+    if (expr.startsWith('$')) return getValue(ctx.working, expr.slice(1));
+    return expr;
+  }
+
+  if (Array.isArray(expr)) return expr.map((item) => evalExpr(item, ctx));
+
+  if (expr !== null && typeof expr === 'object') {
+    const record = expr as Record<string, unknown>;
+    const keys = Object.keys(record);
+    if (isOperator(keys)) {
+      const op = keys[0];
+      if (op === '_lit') return record._lit;
+      const impl = VALUE_OPS[op];
+      if (impl === undefined) throw new TransformError(`unknown operator "${op}"`);
+      return impl(record[op], ctx);
+    }
+    const out: Record<string, unknown> = {};
+    for (const [key, value] of Object.entries(record)) out[key] = evalExpr(value, ctx);
+    return out;
+  }
+
+  return expr;
+}

--- a/core/test/dsl-engine.test.ts
+++ b/core/test/dsl-engine.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from 'vitest';
+import { document, fromValue, toValue } from '../src/model.js';
+import { type Flow, TransformError, applyFlow } from '../src/dsl/engine.js';
+
+const docOf = (value: unknown) => document(fromValue(value), { sourceFormat: 'json' });
+const run = (value: unknown, steps: Flow['steps']) =>
+  toValue(applyFlow(docOf(value), { steps }).root);
+
+describe('_set', () => {
+  it('patches named paths and keeps the rest of the document', () => {
+    expect(run({ a: 1, b: 2 }, [{ _set: { c: 3 } }])).toEqual({ a: 1, b: 2, c: 3 });
+  });
+
+  it('sets from a $path reference', () => {
+    expect(run({ order: { id: 'A-1' } }, [{ _set: { id: '$order.id' } }])).toEqual({
+      order: { id: 'A-1' },
+      id: 'A-1',
+    });
+  });
+
+  it('creates intermediate object segments', () => {
+    expect(run({}, [{ _set: { 'a.b.c': 1 } }])).toEqual({ a: { b: { c: 1 } } });
+  });
+
+  it('builds a nested value with embedded references', () => {
+    expect(run({ a: 1, b: 2 }, [{ _set: { out: { x: '$a', y: ['$b', 'lit'] } } }])).toEqual({
+      a: 1,
+      b: 2,
+      out: { x: 1, y: [2, 'lit'] },
+    });
+  });
+
+  it('skips a key whose value resolves to undefined (missing reference)', () => {
+    expect(run({ a: 1 }, [{ _set: { b: '$missing' } }])).toEqual({ a: 1 });
+  });
+
+  it('writes an explicit null literal', () => {
+    expect(run({ a: 1 }, [{ _set: { b: null } }])).toEqual({ a: 1, b: null });
+  });
+
+  it('evaluates sibling keys independently (no intra-step ordering)', () => {
+    // `b` reads the original `a`, not a value written earlier in the same step.
+    expect(run({ a: 1 }, [{ _set: { a: 2, b: '$a' } }])).toEqual({ a: 2, b: 1 });
+  });
+});
+
+describe('_unset', () => {
+  it('removes listed paths', () => {
+    expect(run({ a: 1, b: 2, c: 3 }, [{ _unset: ['b', 'c'] }])).toEqual({ a: 1 });
+  });
+});
+
+describe('applyFlow', () => {
+  it('does not mutate the input document', () => {
+    const input = docOf({ a: 1 });
+    applyFlow(input, { steps: [{ _set: { b: 2 } }] });
+    expect(toValue(input.root)).toEqual({ a: 1 });
+  });
+
+  it('throws on a step without exactly one operator key', () => {
+    expect(() => run({}, [{ _set: {}, _unset: [] }])).toThrow(/exactly one operator key/);
+  });
+
+  it('throws on an unknown operator with step context', () => {
+    expect(() => run({}, [{ _frobnicate: 1 }])).toThrow(/step 0: unknown operator "_frobnicate"/);
+  });
+});

--- a/core/test/dsl-expr.test.ts
+++ b/core/test/dsl-expr.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest';
+import { document, fromValue } from '../src/model.js';
+import { TransformError } from '../src/dsl/errors.js';
+import { type Ctx, evalExpr } from '../src/dsl/expr.js';
+
+const ctxOf = (value: unknown): Ctx => ({
+  working: document(fromValue(value), { sourceFormat: 'json' }),
+});
+
+describe('evalExpr', () => {
+  it('returns literals unchanged', () => {
+    const ctx = ctxOf({});
+    expect(evalExpr('hi', ctx)).toBe('hi');
+    expect(evalExpr(42, ctx)).toBe(42);
+    expect(evalExpr(true, ctx)).toBe(true);
+    expect(evalExpr(null, ctx)).toBeNull();
+  });
+
+  it('resolves $path references against the working document', () => {
+    const ctx = ctxOf({ order: { id: 'A-1', lines: [{ sku: 'W' }] } });
+    expect(evalExpr('$order.id', ctx)).toBe('A-1');
+    expect(evalExpr('$order.lines[0].sku', ctx)).toBe('W');
+  });
+
+  it('returns undefined for a missing reference', () => {
+    expect(evalExpr('$nope.missing', ctxOf({}))).toBeUndefined();
+  });
+
+  it('treats $$ as an escaped literal dollar string', () => {
+    expect(evalExpr('$$order.id', ctxOf({}))).toBe('$order.id');
+  });
+
+  it('evaluates arrays and plain objects deeply', () => {
+    const ctx = ctxOf({ a: 1, b: 2 });
+    expect(evalExpr(['x', '$a', { n: '$b' }], ctx)).toEqual(['x', 1, { n: 2 }]);
+  });
+
+  it('returns _lit argument verbatim (escape hatch)', () => {
+    const ctx = ctxOf({ a: 1 });
+    expect(evalExpr({ _lit: '$a' }, ctx)).toBe('$a');
+    expect(evalExpr({ _lit: { _set: 'not-an-op' } }, ctx)).toEqual({ _set: 'not-an-op' });
+  });
+
+  it('throws on an unknown operator', () => {
+    expect(() => evalExpr({ _nope: 1 }, ctxOf({}))).toThrow(TransformError);
+  });
+});

--- a/notes/DEV_LOG.md
+++ b/notes/DEV_LOG.md
@@ -13,6 +13,27 @@ Newest entries on top. One entry per merged slice.
 
 ---
 
+## 2026-06-05 — v0alpha2 slice 1: expression evaluator + \_set/\_unset
+
+- What changed: Started the v0alpha2 DSL (RFC 0001) as new modules under `core/src/dsl/` so it
+  can land in stacked slices while v0alpha1 keeps powering the CLI; the cutover (CLI adopts v2,
+  v1 removed) is the final slice. `dsl/expr.ts` is the evaluator: a value position is an
+  expression — `$path` reads from the working doc, `$$x` is the literal `$x`, a single
+  `_`-prefixed key is an operator, and plain arrays/objects evaluate deeply so refs/operators
+  nest anywhere. `_lit` returns its arg verbatim (the escape). `dsl/engine.ts` runs a pipeline
+  of single-key `_op` steps, patch-by-default; slice 1 ships `_set` (set named paths, keep the
+  rest) and `_unset` (remove paths). `dsl/errors.ts` holds `TransformError`.
+- What I learned: Two deliberate semantics. (1) A missing reference evaluates to `undefined` and
+  `_set` _skips_ that key — so copying a maybe-absent field is a no-op, not a null write; an
+  explicit `null` literal still writes. (2) `_set` evaluates all its values against the
+  step-start document before applying any, so sibling keys are independent (`{ a: 2, b: $a }`
+  reads the original `a`) — predictable, matches Mongo `$set`. The `$`/`_`/plain trichotomy
+  lives entirely in the evaluator, so structural ops just call `evalExpr` and never parse sigils
+  themselves. Confirmed decisions: fuller operator set, version implied by project, replace-in-
+  place via a final cutover slice, stacked delivery.
+- What is next: v0alpha2 slice 2 — remaining structural ops (`_rename`/`_append`/`_select`/
+  `_when`) and the value operators (`_concat`, string/date, `_eq`/`_gt`/`_in`/`_and`/…, `_cond`).
+
 ## 2026-06-05 — M8 TypeScript escape hatch
 
 - What changed: Added the `ts` op — a custom-code escape hatch. Where custom code enters and


### PR DESCRIPTION
First slice of the v0alpha2 DSL (RFC 0001). New modules under `core/src/dsl/` — **not wired into the CLI yet**, so v0alpha1 keeps running flows; the cutover is the final slice. Every PR stays green.

## Summary
- **`dsl/expr.ts` — expression evaluator.** A value is a literal, a `$path` reference, or a single-key `_op` operator. `$$x` escapes a literal `$x`; plain arrays/objects evaluate deeply so refs/operators nest anywhere; `_lit` returns its argument verbatim.
- **`dsl/engine.ts` — patch-by-default pipeline** of single-key `_op` steps. Ships `_set` (set named paths, keep the rest) and `_unset` (remove paths).
- **`dsl/errors.ts`** — `TransformError`.

## Semantics (deliberate)
- A missing reference → `undefined`, and `_set` **skips** that key (no null write); an explicit `null` literal still writes.
- `_set` evaluates all values against the step-start document → sibling keys are **independent** (`{ a: 2, b: $a }` reads the original `a`), matching Mongo `$set`.

## Decisions baked in (from discussion)
Fuller operator set (coming slice 2), version implied by project, replace-in-place via a final cutover slice, stacked delivery, `_lit` escape.

## Test plan
- `pnpm --filter @weavster/core test` → 95 (+18: 7 expr, 11 engine).
- CLI unchanged → 17, still on v0alpha1.
- `pnpm --filter @weavster/core build` clean.

## Next
Slice 2: `_rename`/`_append`/`_select`/`_when` + value operators (`_concat`, string/date, `_eq`/`_gt`/`_in`/`_and`/…, `_cond`). Slice 3: schema + CLI cutover + migrate golden-path + docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)