### PR TITLE
v0alpha2 (slice 2): value operators + rest of structural ops

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Added
 
+- v0alpha2 DSL (slice 2, internal): value operators (`_concat`, `_upper`/`_lower`/`_trim`,
+  `_toIso`, `_coalesce`, `_eq`, `_exists`, `_gt`/`_lt`/`_in`, `_and`/`_or`/`_not`, `_cond`) and
+  the remaining structural ops (`_rename`, `_append`, `_select` strict projection, `_when` with
+  an expression condition). Still internal — not wired into the CLI.
 - v0alpha2 DSL (slice 1, internal): expression evaluator (`core/src/dsl/expr.ts`) with `$path`
   references, `$$` escape, deep array/object evaluation, and `_lit`; plus a patch-by-default
   engine (`core/src/dsl/engine.ts`) with the first structural ops `_set` and `_unset`. Not yet

--- a/core/src/dsl/engine.ts
+++ b/core/src/dsl/engine.ts
@@ -7,7 +7,7 @@
  * Values are expressions (see `expr.ts`).
  */
 import { type Document, type Node, fromValue } from '../model.js';
-import { remove, set } from '../path.js';
+import { get, remove, set } from '../path.js';
 import { type Ctx, evalExpr } from './expr.js';
 import { TransformError } from './errors.js';
 
@@ -51,6 +51,58 @@ const STRUCTURAL: Record<string, StructuralOp> = {
       if (typeof path !== 'string') throw new TransformError('"_unset" paths must be strings');
       remove(working, path);
     }
+  },
+
+  /** Move each `from` path to its `to` path. Missing sources are skipped. */
+  _rename(working, arg) {
+    for (const [from, to] of Object.entries(asRecord(arg, '_rename'))) {
+      if (typeof to !== 'string')
+        throw new TransformError('"_rename" targets must be path strings');
+      const node = get(working, from);
+      if (node === undefined) continue;
+      set(working, to, structuredClone(node));
+      remove(working, from);
+    }
+  },
+
+  /** Append an evaluated value to the array at `to` (creating it if absent). */
+  _append(working, arg, ctx) {
+    const spec = asRecord(arg, '_append');
+    if (typeof spec.to !== 'string') throw new TransformError('"_append" needs a "to" path string');
+    const value = fromValue(evalExpr(spec.value, ctx)) as Node;
+    const existing = get(working, spec.to);
+    if (existing === undefined) {
+      set(working, spec.to, { kind: 'array', items: [value] });
+    } else if (existing.kind === 'array') {
+      existing.items.push(value);
+    } else {
+      throw new TransformError(`"_append" target "${spec.to}" is not an array`);
+    }
+  },
+
+  /** Reshape: build a fresh document from only the named paths (strict projection). */
+  _select(working, arg, ctx) {
+    const entries = Object.entries(asRecord(arg, '_select')).map(
+      ([path, expr]) => [path, evalExpr(expr, ctx)] as const,
+    );
+    const fresh: Document = { root: { kind: 'object', fields: {} }, meta: working.meta };
+    for (const [path, value] of entries) {
+      if (value !== undefined) set(fresh, path, fromValue(value) as Node);
+    }
+    working.root = fresh.root;
+  },
+
+  /** Run `then` when `cond` is truthy, otherwise `else`. */
+  _when(working, arg, ctx) {
+    const spec = asRecord(arg, '_when');
+    if (!Array.isArray(spec.then)) throw new TransformError('"_when" needs a "then" step list');
+    if (spec.else !== undefined && !Array.isArray(spec.else)) {
+      throw new TransformError('"_when" "else" must be a step list');
+    }
+    const branch = Boolean(evalExpr(spec.cond, ctx))
+      ? (spec.then as Step[])
+      : ((spec.else as Step[] | undefined) ?? []);
+    runSteps(working, branch, ctx);
   },
 };
 

--- a/core/src/dsl/expr.ts
+++ b/core/src/dsl/expr.ts
@@ -20,8 +20,80 @@ export interface Ctx {
 
 export type ValueOp = (arg: unknown, ctx: Ctx) => unknown;
 
-/** Value operators (`_concat`, comparisons, …). Populated as the DSL grows. */
-export const VALUE_OPS: Record<string, ValueOp> = {};
+const toStr = (value: unknown): string =>
+  value === null || value === undefined ? '' : String(value);
+const deepEqual = (a: unknown, b: unknown): boolean => JSON.stringify(a) === JSON.stringify(b);
+
+function pair(arg: unknown, op: string): [unknown, unknown] {
+  if (!Array.isArray(arg) || arg.length !== 2) {
+    throw new TransformError(`"${op}" expects a list of two expressions`);
+  }
+  return [arg[0], arg[1]];
+}
+
+function list(arg: unknown, op: string): unknown[] {
+  if (!Array.isArray(arg)) throw new TransformError(`"${op}" expects a list`);
+  return arg;
+}
+
+function record(arg: unknown, op: string): Record<string, unknown> {
+  if (arg === null || typeof arg !== 'object' || Array.isArray(arg)) {
+    throw new TransformError(`"${op}" expects a map`);
+  }
+  return arg as Record<string, unknown>;
+}
+
+/** Value operators usable in any value position. */
+export const VALUE_OPS: Record<string, ValueOp> = {
+  _concat(arg, ctx) {
+    const parts = Array.isArray(arg) ? arg : list(record(arg, '_concat').parts, '_concat');
+    const sep = Array.isArray(arg) ? '' : toStr(record(arg, '_concat').sep);
+    return parts.map((p) => toStr(evalExpr(p, ctx))).join(sep);
+  },
+  _upper: (arg, ctx) => toStr(evalExpr(arg, ctx)).toUpperCase(),
+  _lower: (arg, ctx) => toStr(evalExpr(arg, ctx)).toLowerCase(),
+  _trim: (arg, ctx) => toStr(evalExpr(arg, ctx)).trim(),
+  _toIso(arg, ctx) {
+    const date = new Date(toStr(evalExpr(arg, ctx)));
+    if (Number.isNaN(date.getTime())) throw new TransformError('"_toIso" got an unparseable date');
+    return date.toISOString();
+  },
+  _coalesce(arg, ctx) {
+    for (const expr of list(arg, '_coalesce')) {
+      const value = evalExpr(expr, ctx);
+      if (value !== null && value !== undefined) return value;
+    }
+    return null;
+  },
+  _eq(arg, ctx) {
+    const [a, b] = pair(arg, '_eq');
+    return deepEqual(evalExpr(a, ctx), evalExpr(b, ctx));
+  },
+  _exists: (arg, ctx) => evalExpr(arg, ctx) !== undefined,
+  _gt(arg, ctx) {
+    const [a, b] = pair(arg, '_gt');
+    return (evalExpr(a, ctx) as number) > (evalExpr(b, ctx) as number);
+  },
+  _lt(arg, ctx) {
+    const [a, b] = pair(arg, '_lt');
+    return (evalExpr(a, ctx) as number) < (evalExpr(b, ctx) as number);
+  },
+  _in(arg, ctx) {
+    const [needle, haystack] = pair(arg, '_in');
+    const items = evalExpr(haystack, ctx);
+    if (!Array.isArray(items))
+      throw new TransformError('"_in" expects an array as its second argument');
+    const value = evalExpr(needle, ctx);
+    return items.some((item) => deepEqual(item, value));
+  },
+  _and: (arg, ctx) => list(arg, '_and').every((e) => Boolean(evalExpr(e, ctx))),
+  _or: (arg, ctx) => list(arg, '_or').some((e) => Boolean(evalExpr(e, ctx))),
+  _not: (arg, ctx) => !evalExpr(arg, ctx),
+  _cond(arg, ctx) {
+    const o = record(arg, '_cond');
+    return Boolean(evalExpr(o.if, ctx)) ? evalExpr(o.then, ctx) : evalExpr(o.else, ctx);
+  },
+};
 
 function isOperator(keys: string[]): boolean {
   return keys.length === 1 && keys[0].startsWith('_');

--- a/core/test/dsl-engine.test.ts
+++ b/core/test/dsl-engine.test.ts
@@ -50,6 +50,65 @@ describe('_unset', () => {
   });
 });
 
+describe('_rename', () => {
+  it('moves a path and skips missing sources', () => {
+    expect(
+      run({ order: { '@id': 'A1' } }, [{ _rename: { 'order.@id': 'id', 'order.nope': 'x' } }]),
+    ).toEqual({ order: {}, id: 'A1' });
+  });
+});
+
+describe('_append', () => {
+  it('creates the array when absent', () => {
+    expect(run({}, [{ _append: { to: 'ids', value: 'x' } }])).toEqual({ ids: ['x'] });
+  });
+
+  it('appends to an existing array', () => {
+    expect(
+      run({ ids: ['a'] }, [{ _append: { to: 'ids', value: '$seed' } }, { _set: { seed: 'b' } }]),
+    ).toEqual({ ids: ['a', null], seed: 'b' });
+  });
+
+  it('errors when the target is not an array', () => {
+    expect(() => run({ ids: 1 }, [{ _append: { to: 'ids', value: 'x' } }])).toThrow(/not an array/);
+  });
+});
+
+describe('_select', () => {
+  it('keeps only the named paths (strict projection)', () => {
+    expect(
+      run({ a: 1, b: 2, c: 3 }, [{ _select: { x: '$a', y: { _concat: ['$b', '-', '$c'] } } }]),
+    ).toEqual({ x: 1, y: '2-3' });
+  });
+
+  it('skips a projected key whose value is undefined', () => {
+    expect(run({ a: 1 }, [{ _select: { x: '$a', y: '$missing' } }])).toEqual({ x: 1 });
+  });
+});
+
+describe('_when', () => {
+  it('runs then/else by an expression condition', () => {
+    const steps = (status: string) =>
+      run({ status }, [
+        {
+          _when: {
+            cond: { _eq: ['$status', 'new'] },
+            then: [{ _set: { priority: 'high' } }],
+            else: [{ _set: { priority: 'normal' } }],
+          },
+        },
+      ]);
+    expect(steps('new')).toEqual({ status: 'new', priority: 'high' });
+    expect(steps('done')).toEqual({ status: 'done', priority: 'normal' });
+  });
+
+  it('reports nested step errors with the when context', () => {
+    expect(() => run({}, [{ _when: { cond: true, then: [{ _frob: 1 }] } }])).toThrow(
+      /step 0 \(_when\): step 0: unknown operator "_frob"/,
+    );
+  });
+});
+
 describe('applyFlow', () => {
   it('does not mutate the input document', () => {
     const input = docOf({ a: 1 });

--- a/core/test/dsl-expr.test.ts
+++ b/core/test/dsl-expr.test.ts
@@ -45,3 +45,57 @@ describe('evalExpr', () => {
     expect(() => evalExpr({ _nope: 1 }, ctxOf({}))).toThrow(TransformError);
   });
 });
+
+describe('value operators', () => {
+  const ctx = ctxOf({ first: 'jane', last: 'doe', n: 5, tags: ['a', 'b'], when: '2026-06-04' });
+
+  it('_concat joins, in array or { parts, sep } form', () => {
+    expect(evalExpr({ _concat: ['$first', '!'] }, ctx)).toBe('jane!');
+    expect(evalExpr({ _concat: { parts: ['$first', '$last'], sep: ' ' } }, ctx)).toBe('jane doe');
+  });
+
+  it('_upper / _lower / _trim', () => {
+    expect(evalExpr({ _upper: '$first' }, ctx)).toBe('JANE');
+    expect(evalExpr({ _lower: 'AB' }, ctx)).toBe('ab');
+    expect(evalExpr({ _trim: '  x ' }, ctx)).toBe('x');
+  });
+
+  it('_toIso converts a date, or throws on an unparseable one', () => {
+    expect(evalExpr({ _toIso: '$when' }, ctx)).toBe('2026-06-04T00:00:00.000Z');
+    expect(() => evalExpr({ _toIso: 'nope' }, ctx)).toThrow(TransformError);
+  });
+
+  it('_coalesce returns the first non-null', () => {
+    expect(evalExpr({ _coalesce: ['$missing', '$first'] }, ctx)).toBe('jane');
+    expect(evalExpr({ _coalesce: ['$missing', null] }, ctx)).toBeNull();
+  });
+
+  it('_eq and _exists', () => {
+    expect(evalExpr({ _eq: ['$first', 'jane'] }, ctx)).toBe(true);
+    expect(evalExpr({ _eq: ['$first', 'x'] }, ctx)).toBe(false);
+    expect(evalExpr({ _exists: '$first' }, ctx)).toBe(true);
+    expect(evalExpr({ _exists: '$missing' }, ctx)).toBe(false);
+  });
+
+  it('_gt / _lt / _in', () => {
+    expect(evalExpr({ _gt: ['$n', 3] }, ctx)).toBe(true);
+    expect(evalExpr({ _lt: ['$n', 3] }, ctx)).toBe(false);
+    expect(evalExpr({ _in: ['$last', ['doe', 'roe']] }, ctx)).toBe(true);
+    expect(evalExpr({ _in: ['b', '$tags'] }, ctx)).toBe(true);
+  });
+
+  it('_and / _or / _not', () => {
+    expect(evalExpr({ _and: [{ _eq: ['$first', 'jane'] }, { _gt: ['$n', 1] }] }, ctx)).toBe(true);
+    expect(evalExpr({ _or: [{ _eq: ['$first', 'x'] }, { _gt: ['$n', 1] }] }, ctx)).toBe(true);
+    expect(evalExpr({ _not: { _eq: ['$first', 'x'] } }, ctx)).toBe(true);
+  });
+
+  it('_cond chooses a branch and evaluates only the taken one', () => {
+    expect(evalExpr({ _cond: { if: { _gt: ['$n', 3] }, then: 'big', else: 'small' } }, ctx)).toBe(
+      'big',
+    );
+    expect(evalExpr({ _cond: { if: { _lt: ['$n', 3] }, then: 'big', else: 'small' } }, ctx)).toBe(
+      'small',
+    );
+  });
+});

--- a/notes/DEV_LOG.md
+++ b/notes/DEV_LOG.md
@@ -13,6 +13,26 @@ Newest entries on top. One entry per merged slice.
 
 ---
 
+## 2026-06-05 — v0alpha2 slice 2: value operators + rest of structural ops
+
+- What changed: Filled in `VALUE_OPS` (`dsl/expr.ts`) and the structural op table (`dsl/engine.ts`).
+  Value operators: `_concat` (array or `{ parts, sep }`), `_upper`/`_lower`/`_trim`, `_toIso`,
+  `_coalesce`, `_eq`, `_exists`, `_gt`/`_lt`/`_in`, `_and`/`_or`/`_not`, `_cond`. Structural ops:
+  `_rename` (move, skip missing source), `_append` (push to an array, create if absent, error if
+  the target is a non-array), `_select` (strict projection — build a fresh root from only the
+  named paths), `_when` (run then/else by an expression condition; recurses, nests error context).
+  Still internal; the CLI runs v0alpha1 until slice 3.
+- What I learned: Operators compose because each calls `evalExpr` on its own sub-args — `_cond`
+  evaluates only the taken branch, `_when` is just `_cond` at the step level over sub-pipelines,
+  and `_select` is `_set` into an empty root. Predicate truthiness is plain JS `Boolean(...)`, and
+  the comparison ops return real booleans, so conditions read naturally. Two coercion rules kept
+  consistent via one helper: `_concat`/string ops treat null/undefined as `''`; `_coalesce` skips
+  both null and undefined. A test trap to remember: putting `key: undefined` in a fixture input
+  object is not "absent" — `fromValue` turns it into a `null`, so test missing-ness with a path
+  that genuinely isn't there.
+- What is next: v0alpha2 slice 3 — bump the schema to a single-key `_op` form, cut the CLI over
+  to the v0alpha2 engine, remove v0alpha1, migrate the golden-path flow, and rewrite the DSL docs.
+
 ## 2026-06-05 — v0alpha2 slice 1: expression evaluator + \_set/\_unset
 
 - What changed: Started the v0alpha2 DSL (RFC 0001) as new modules under `core/src/dsl/` so it


### PR DESCRIPTION
Second v0alpha2 slice. Still **internal** — CLI runs v0alpha1 until the cutover slice.

## Value operators (`dsl/expr.ts`)
`_concat` (array or `{ parts, sep }`), `_upper`/`_lower`/`_trim`, `_toIso`, `_coalesce`, `_eq`, `_exists`, `_gt`/`_lt`/`_in`, `_and`/`_or`/`_not`, `_cond`. Each evaluates its own sub-expressions, so operators compose and nest anywhere a value appears.

## Structural ops (`dsl/engine.ts`)
- `_rename` — move a path, skip a missing source.
- `_append` — push to an array, create it if absent, error on a non-array target.
- `_select` — strict projection: build a fresh root from only the named paths.
- `_when` — run `then`/`else` by an expression condition; recurses, nests error context.

## Notes
- Truthiness is plain JS `Boolean(...)`; comparison ops return real booleans.
- `_concat`/string ops treat null/undefined as `''`; `_coalesce` skips null + undefined.

## Test plan
- `pnpm --filter @weavster/core test` → 111 (+16: value ops + structural ops).
- CLI unchanged → 17 on v0alpha1.
- `pnpm --filter @weavster/core build` clean.

## Next
Slice 3 (cutover): bump the schema to single-key `_op`, switch the CLI to the v0alpha2 engine, remove v0alpha1, migrate the golden-path flow (incl. `ts` → `_ts`), rewrite the DSL docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)