### PR TITLE
release: npm trusted publishing (OIDC) + npm README

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,7 +8,8 @@ jobs:
   npm:
     runs-on: ubuntu-latest
     permissions:
-      contents: write
+      contents: write # create the GitHub Release
+      id-token: write # OIDC for npm trusted publishing
     steps:
       - uses: actions/checkout@v4
 
@@ -20,6 +21,9 @@ jobs:
           cache: pnpm
           registry-url: 'https://registry.npmjs.org'
 
+      # npm trusted publishing (OIDC) needs npm >= 11.5.1.
+      - run: npm install -g npm@latest
+
       - run: pnpm install --frozen-lockfile
 
       - run: pnpm cli:build
@@ -28,10 +32,13 @@ jobs:
 
       - run: pnpm test
 
-      - name: Publish @weavster/cli to npm
-        run: pnpm --filter @weavster/cli publish --no-git-checks --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+      # pnpm pack rewrites the workspace: protocol in the manifest; npm publish
+      # (which does the OIDC exchange — pnpm does not) ships the prepared tarball.
+      - name: Pack
+        run: pnpm --filter @weavster/cli pack --pack-destination "$RUNNER_TEMP"
+
+      - name: Publish to npm (trusted publisher)
+        run: npm publish "$RUNNER_TEMP"/weavster-cli-*.tgz --access public
 
       - name: Create GitHub Release
         env:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### Added
+
+- `cli/README.md` — the package page shown on npm.
+
+### Changed
+
+- Release workflow now uses **npm trusted publishing (OIDC)** instead of an `NPM_TOKEN` secret:
+  it packs with `pnpm pack` and publishes the tarball with `npm publish` under
+  `permissions: id-token: write` (no long-lived token).
+
 ## [0.0.1] - 2026-06-05
 
 First published release. `@weavster/cli` ships to npm (init / validate / test); the engine,

--- a/cli/README.md
+++ b/cli/README.md
@@ -1,0 +1,64 @@
+# @weavster/cli
+
+The Weavster command-line tool: scaffold, validate, and test config-driven data
+transformation projects. You describe transformations as YAML flows over a canonical
+document model, and run them locally against fixtures.
+
+## Install
+
+```bash
+npm install -g @weavster/cli
+```
+
+## Quickstart
+
+```bash
+weavster init my-integration   # scaffold a project
+cd my-integration
+weavster validate              # check weavster.yaml + flows against their schemas
+weavster test                  # run fixtures through flows, diff against expected output
+```
+
+A scaffolded project looks like:
+
+```text
+my-integration/
+  weavster.yaml          # project config (apiVersion + name)
+  flows/main.yaml        # a transform pipeline
+  fixtures/main/basic/   # input.json + expected.json
+  README.md
+```
+
+## Commands
+
+- `weavster init [dir]` — scaffold a new project that passes `weavster test` out of the box.
+- `weavster validate [path]` — validate `weavster.yaml` and every `flows/*.yaml`.
+- `weavster test [path]` — run each fixture through its flow and report a diff on mismatch.
+
+## Flows in brief
+
+Flows are a patch-by-default pipeline of single-key `_op` steps; values are expressions with
+`$path` references and `_op` operators:
+
+```yaml
+steps:
+  - _set:
+      id: { _upper: $id }
+      name: { _concat: { parts: [$first, $last], sep: ' ' } }
+  - _when:
+      cond: { _eq: [$status, new] }
+      then:
+        - _set: { priority: high }
+```
+
+When the declarative DSL isn't enough, a `_ts` step runs a custom TypeScript function under a
+pure JSON-in/JSON-out contract.
+
+## Documentation
+
+Full docs — concepts, the transform DSL, format packs, and the TypeScript escape hatch — are
+at [docs.weavster.dev](https://docs.weavster.dev).
+
+## License
+
+[BUSL-1.1](https://github.com/weavster-dev/weavster/blob/main/LICENSE).

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -43,8 +43,11 @@ Run from a clean checkout:
 
 ## Tag
 
-- [ ] Move the `[Unreleased]` CHANGELOG section under the new version with a date.
-- [ ] Confirm the `NPM_TOKEN` repo secret is set and can publish to the `@weavster` scope.
+- [ ] Move the `[Unreleased]` CHANGELOG section under the new version with a date, and set the
+      new version in `cli/package.json` (and `core/package.json`).
+- [ ] Confirm npm **trusted publishing** is configured for `@weavster/cli` (npmjs.com → package
+      Settings → Trusted Publisher → GitHub `weavster-dev/weavster`, workflow `release.yml`). No
+      npm token is used — publishing is OIDC-based.
 - [ ] Create the version tag on `main` and push it: `git tag vX.Y.Z && git push origin vX.Y.Z`.
-      The `release` workflow then builds, tests, publishes `@weavster/cli` to npm, and creates a
-      GitHub Release with notes from the matching `CHANGELOG.md` section.
+      The `release` workflow then builds, tests, publishes `@weavster/cli` to npm via OIDC, and
+      creates a GitHub Release with notes from the matching `CHANGELOG.md` section.

--- a/notes/DEV_LOG.md
+++ b/notes/DEV_LOG.md
@@ -13,6 +13,21 @@ Newest entries on top. One entry per merged slice.
 
 ---
 
+## 2026-06-05 — Trusted publishing (OIDC) + npm README
+
+- What changed: After the manual `0.0.1` publish, converted `release.yml` to npm **trusted
+  publishing**: dropped the `NPM_TOKEN` secret, added `permissions: id-token: write`, upgraded npm
+  to `>= 11.5.1` in the job, and switched the publish step to `pnpm pack` → `npm publish <tarball>`.
+  Added `cli/README.md` for the npm package page.
+- What I learned: Two constraints forced the pack-then-publish shape. (1) OIDC trusted publishing
+  is an `npm publish` feature; `pnpm publish` does not do the token exchange. (2) Plain `npm publish`
+  of our package would choke on the `@weavster/core` `workspace:*` devDependency. `pnpm pack` rewrites
+  the workspace protocol in the tarball's manifest, and `npm publish <tarball>` then ships that prepared
+  artifact with OIDC — satisfying both. npm always includes `README.md` in the tarball even with
+  `files: ["dist"]`, and `pnpm pack` also pulls the workspace-root `LICENSE` into the package.
+- What is next: register the trusted publisher on npmjs.com for `@weavster/cli`, then future releases
+  are just a `vX.Y.Z` tag — no token.
+
 ## 2026-06-05 — Release tooling: npm publish for the CLI (0.0.1)
 
 - What changed: Set up the first release. Chose to publish **only `@weavster/cli`** with


### PR DESCRIPTION
Follow-up to the `0.0.1` manual publish: move the release workflow to npm **trusted publishing** (OIDC, no token), and add a package README for npm.

## Changes
- **`release.yml` → OIDC.** Drops `NPM_TOKEN`; adds `permissions: id-token: write`; upgrades npm to `>= 11.5.1`; publishes via `pnpm pack` → `npm publish <tarball>`.
  - Why pack-then-publish: OIDC is an `npm publish` feature (pnpm doesn't do the exchange), but plain `npm publish` rejects our `@weavster/core` `workspace:*` devDep — `pnpm pack` rewrites the manifest, and `npm publish <tarball>` ships that prepared artifact under OIDC.
- **`cli/README.md`** — the npm package page (install, quickstart, commands, flow snippet, docs link).
- RELEASE.md + CHANGELOG updated; no npm token anywhere.

## You still need to (one-time)
Register the trusted publisher on npmjs.com: `@weavster/cli` → Settings → Trusted Publisher → GitHub Actions → org `weavster-dev`, repo `weavster`, workflow `release.yml`. After that, releases are just `git tag vX.Y.Z && git push origin vX.Y.Z`.

## Verification
- `pnpm test` → core 83 + cli 22.
- `pnpm cli:build` clean; `npm pack` tarball includes `README.md` + `dist` + `package.json` (and `LICENSE` via pnpm pack).

🤖 Generated with [Claude Code](https://claude.com/claude-code)