### PR TITLE
release: bump to 0.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+## [0.0.2] - 2026-06-05
+
 ### Added
 
 - `cli/README.md` — the package page shown on npm.

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@weavster/cli",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Weavster CLI: scaffold, validate, and test config-driven data transformation projects.",
   "license": "BUSL-1.1",
   "type": "module",

--- a/core/package.json
+++ b/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@weavster/core",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "private": true,
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
Version bump for the next release.

- `@weavster/cli` + `@weavster/core` → **0.0.2**.
- CHANGELOG `[Unreleased]` rolled under `[0.0.2]` (npm README + OIDC trusted publishing).

## To release after merge
Make sure the trusted publisher is registered (npmjs.com → `@weavster/cli` → Trusted Publisher → `weavster-dev/weavster`, workflow `release.yml`), then:

```bash
git tag v0.0.2 && git push origin v0.0.2
```

The `release` workflow publishes `@weavster/cli@0.0.2` via OIDC and creates the GitHub Release.

## Verification
- `pnpm install --frozen-lockfile` clean; `pnpm test` → core 83 + cli 22; build clean; tarball reports `version: 0.0.2`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)