### PR TITLE
fix(release): drop registry-url so OIDC trusted publishing works

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,11 +15,12 @@ jobs:
 
       - uses: pnpm/action-setup@v4
 
+      # No registry-url: it would write an _authToken to .npmrc and force token
+      # auth, which shadows OIDC trusted publishing. The default registry is npm.
       - uses: actions/setup-node@v4
         with:
           node-version: 22
           cache: pnpm
-          registry-url: 'https://registry.npmjs.org'
 
       # npm trusted publishing (OIDC) needs npm >= 11.5.1.
       - run: npm install -g npm@latest

--- a/notes/DEV_LOG.md
+++ b/notes/DEV_LOG.md
@@ -13,6 +13,19 @@ Newest entries on top. One entry per merged slice.
 
 ---
 
+## 2026-06-06 — Fix OIDC publish (drop registry-url)
+
+- What changed: Removed `registry-url` from the `setup-node` step in `release.yml`. The first
+  `v0.0.2` release run failed at publish with `E404 / you do not have permission`.
+- What I learned: `setup-node`'s `registry-url` writes `//registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}`
+  into `.npmrc`. With no `NODE_AUTH_TOKEN` set (we use OIDC, not a token), that expands to an empty
+  token, so npm attempted (empty) **token auth** and never took the OIDC path — the registry returned
+  404 (its masked "unauthorized" for a scoped package). Trusted publishing only triggers when **no**
+  `_authToken` is configured. Dropping `registry-url` leaves the default registry and no token line,
+  so `npm publish` with `id-token: write` uses OIDC. The tag must be recreated on the fixed commit
+  (a re-run uses the workflow file from the tag's tree).
+- What is next: re-tag `v0.0.2` on the fixed `main` and push to publish.
+
 ## 2026-06-05 — Trusted publishing (OIDC) + npm README
 
 - What changed: After the manual `0.0.1` publish, converted `release.yml` to npm **trusted


### PR DESCRIPTION
The `v0.0.2` release failed at publish (`E404 / you do not have permission`).

## Cause
`setup-node`'s `registry-url` writes `//registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}` into `.npmrc`. We don't set `NODE_AUTH_TOKEN` (OIDC, not a token), so it expands to an **empty token** → npm attempted empty token auth and never used OIDC → registry 404.

## Fix
Remove `registry-url` from `setup-node`. With no `_authToken` configured and `id-token: write` granted, `npm publish` uses **OIDC trusted publishing**. Default registry is npm anyway.

## After merge — re-tag (the failed tag points at the pre-fix commit)
```bash
git push origin :refs/tags/v0.0.2     # delete remote tag
git tag -d v0.0.2                      # delete local tag
git checkout main && git pull
git tag v0.0.2 && git push origin v0.0.2
```
(0.0.2 was never published, so reusing the version is fine.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)