### PR TITLE
fix(release): render npm README + finalize OIDC workflow (0.0.3)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,11 +15,12 @@ jobs:
 
       - uses: pnpm/action-setup@v4
 
+      # No registry-url: it would write an _authToken to .npmrc and force token
+      # auth, which shadows OIDC trusted publishing. The default registry is npm.
       - uses: actions/setup-node@v4
         with:
           node-version: 22
           cache: pnpm
-          registry-url: 'https://registry.npmjs.org'
 
       # npm trusted publishing (OIDC) needs npm >= 11.5.1.
       - run: npm install -g npm@latest
@@ -32,13 +33,20 @@ jobs:
 
       - run: pnpm test
 
-      # pnpm pack rewrites the workspace: protocol in the manifest; npm publish
-      # (which does the OIDC exchange — pnpm does not) ships the prepared tarball.
-      - name: Pack
-        run: pnpm --filter @weavster/cli pack --pack-destination "$RUNNER_TEMP"
+      # Assemble a clean publish directory: built dist + README + LICENSE and a
+      # manifest with the workspace devDependency and scripts stripped. Publishing
+      # from a directory (not a tarball) lets npm populate the per-version readme
+      # that npmjs.com renders.
+      - name: Prepare publish directory
+        run: |
+          mkdir -p "$RUNNER_TEMP/pub/dist"
+          cp -r cli/dist/. "$RUNNER_TEMP/pub/dist/"
+          cp cli/README.md LICENSE "$RUNNER_TEMP/pub/"
+          node -e "const p=require('./cli/package.json'); delete p.devDependencies; delete p.scripts; require('fs').writeFileSync(process.env.RUNNER_TEMP + '/pub/package.json', JSON.stringify(p, null, 2) + '\n')"
 
       - name: Publish to npm (trusted publisher)
-        run: npm publish "$RUNNER_TEMP"/weavster-cli-*.tgz --access public
+        run: npm publish --access public
+        working-directory: ${{ runner.temp }}/pub
 
       - name: Create GitHub Release
         env:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+## [0.0.3] - 2026-06-06
+
+### Fixed
+
+- The npm package README now renders on npmjs.com. The release workflow publishes from a
+  prepared directory (built `dist` + `README.md` + `LICENSE` + a manifest with the workspace
+  devDependency and scripts stripped) instead of a pre-packed tarball, so npm populates the
+  per-version readme. Also dropped `setup-node`'s `registry-url`, which had forced empty-token
+  auth and blocked OIDC trusted publishing.
+
 ## [0.0.2] - 2026-06-05
 
 ### Added

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@weavster/cli",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "Weavster CLI: scaffold, validate, and test config-driven data transformation projects.",
   "license": "BUSL-1.1",
   "type": "module",

--- a/core/package.json
+++ b/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@weavster/core",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "private": true,
   "type": "module",
   "main": "./dist/index.js",

--- a/notes/DEV_LOG.md
+++ b/notes/DEV_LOG.md
@@ -13,6 +13,22 @@ Newest entries on top. One entry per merged slice.
 
 ---
 
+## 2026-06-06 — Fix npm README + finalize release workflow (0.0.3)
+
+- What changed: The npm page for `@weavster/cli` showed no README even though the tarball
+  contained one. Switched the release workflow to publish from a **prepared directory** instead
+  of a pre-packed tarball, and bumped to 0.0.3. Also dropped `setup-node`'s `registry-url` (it
+  forced empty-token auth and blocked OIDC).
+- What I learned: Registry data told the story — the packument top-level `readme` was set (1822
+  chars) but the **per-version** `readme` was `0`. npmjs.com renders the per-version readme, and
+  `npm publish <tarball.tgz>` does not populate it (npm only extracts the README into the version
+  manifest when publishing from a directory). The fix: in CI, assemble `$RUNNER_TEMP/pub` with the
+  built `dist`, `README.md`, `LICENSE`, and a `package.json` that has `devDependencies` and
+  `scripts` stripped (no `workspace:*` ref for `npm publish` to choke on, no `prepublishOnly`
+  running in a dir without sources), then `npm publish` from that directory — which populates the
+  per-version readme and still does OIDC.
+- What is next: tag `v0.0.3` to publish and confirm the README renders on npmjs.com.
+
 ## 2026-06-05 — Trusted publishing (OIDC) + npm README
 
 - What changed: After the manual `0.0.1` publish, converted `release.yml` to npm **trusted


### PR DESCRIPTION
The npm page for `@weavster/cli` shows no README, even though the tarball contains one.

## Root cause
Registry data: the packument's **top-level** `readme` is set (1822 chars), but the **per-version** `readme` is `0`. npmjs.com renders the per-version readme, and `npm publish <tarball.tgz>` doesn't populate it — npm only extracts the README into the version manifest when publishing **from a directory**.

## Fix
- **Publish from a prepared directory.** CI assembles `$RUNNER_TEMP/pub` = built `dist` + `README.md` + `LICENSE` + a `package.json` with `devDependencies` and `scripts` stripped (so no `workspace:*` ref for `npm publish` to reject, and no `prepublishOnly` running in a source-less dir), then `npm publish` from there → per-version readme populated, OIDC still used.
- **Drop `registry-url`** from `setup-node` (it wrote an empty `_authToken`, forcing token auth and blocking OIDC). Supersedes #69 — please close it.
- Bump to **0.0.3**.

## Verified
- Prepared dir packs to 4 files (LICENSE, README.md, dist/index.js, package.json), no devDeps/scripts, runtime deps intact.
- `pnpm test` → core 83 + cli 22; build + typecheck clean; lockfile frozen-OK.

## Release
After merge: `git tag v0.0.3 && git push origin v0.0.3` → workflow publishes 0.0.3 via OIDC from the directory; the README should then render on npmjs.com.

🤖 Generated with [Claude Code](https://claude.com/claude-code)