### PR TITLE
docs(rfc): run + pipelines design (RFC 0002)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,13 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   pipelines (`pipelines/<name>.yaml` = source + flow + sink), with file and stdin/stdout
   connectors. Draft only — the first "make it move data" phase.
 
+### Changed
+
+- RFC 0002: `weavster run` now runs continuously like an ESB (source yields a stream of
+  documents; the loop stays live until end-of-stream) rather than one-shot. `run` with no name
+  always runs every pipeline (no `--all` flag). Resolved the `run` default-target open question;
+  reworked the data-flow, connector interface (`Source.documents()`), and error handling to match.
+
 ## [0.0.3] - 2026-06-06
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### Added
+
+- RFC 0002 (`docs/rfcs/0002-run-pipelines.md`): design for `weavster run` and config-driven
+  pipelines (`pipelines/<name>.yaml` = source + flow + sink), with file and stdin/stdout
+  connectors. Draft only — the first "make it move data" phase.
+
 ## [0.0.3] - 2026-06-06
 
 ### Fixed

--- a/docs/rfcs/0002-run-pipelines.md
+++ b/docs/rfcs/0002-run-pipelines.md
@@ -36,14 +36,23 @@ Run it:
 
 ```bash
 weavster run orders     # runs pipelines/orders.yaml
-weavster run            # runs every pipeline in pipelines/
+weavster run            # runs every pipeline in pipelines/ (no flag needed)
 ```
 
-Data flow:
+`run` with no name **always** runs every pipeline in `pipelines/`. There is no `--all` flag —
+running everything is the default, and naming a pipeline narrows to that one.
+
+Data flow — the source yields a stream of documents and the run loop processes each one as it
+arrives, staying live until the source closes:
 
 ```text
-source.read() ──▶ format pack parse ──▶ flow (applyFlow + functions) ──▶ format pack serialize ──▶ sink.write()
+for each document from source:
+  source ──▶ format pack parse ──▶ flow (applyFlow + functions) ──▶ format pack serialize ──▶ sink.write()
 ```
+
+A bounded source (a `file`) yields one document, then closes — the loop runs once and `run`
+exits. An unbounded source (`stdin`, and later REST/SFTP/queues) keeps yielding; `run` blocks
+waiting for the next document and exits only when the source signals end-of-stream.
 
 This reuses everything already built: the JSON/XML packs, the v0alpha2 engine, and the `_ts`
 function loader. Only the source/sink I/O is new — and it lives in the CLI, keeping
@@ -66,11 +75,12 @@ sink: { type: stdout, format: json }
 ```
 
 The connector interface is small and pluggable, so REST/SFTP/etc. slot in later without
-touching the run loop:
+touching the run loop. A source is an async iterable of documents, so the same loop drives both
+a one-shot file and an always-on stream:
 
 ```ts
 interface Source {
-  read(): Promise<string>;
+  documents(): AsyncIterable<string>; // yields once for file; many for stdin/streams
 }
 interface Sink {
   write(text: string): Promise<void>;
@@ -96,15 +106,24 @@ connector types, valid format). `weavster validate` is extended to check every
 
 ## Errors
 
-Each stage surfaces a clear, contextual error and a non-zero exit:
+Errors split by when they happen, because the loop is continuous:
+
+**Startup errors** abort before the loop and exit non-zero:
 
 - pipeline not found / schema-invalid;
-- source read failure (missing file, empty stdin);
+- source open failure (missing file, unreachable endpoint).
+
+**Per-document errors** are scoped to one document and, by default, do **not** kill a live
+pipeline — the document is reported and the loop continues to the next:
+
 - parse failure (`JsonParseError`/`XmlParseError`);
 - transform failure (`TransformError`, already step-scoped);
 - sink write failure (permissions, etc.).
 
-`run` reports which pipeline and which stage failed.
+End-of-stream is not an error: an empty/closed `stdin` or an exhausted `file` ends the loop
+cleanly. For a bounded (one-shot) source, a per-document failure is the only document's failure,
+so `run` exits non-zero; for an unbounded source it logs and keeps running. `run` reports which
+pipeline, which document, and which stage failed.
 
 ## Slices
 
@@ -120,7 +139,10 @@ Each stage surfaces a clear, contextual error and a non-zero exit:
 ## Non-goals (this phase)
 
 - Network connectors (REST, SFTP, TCP) — a later slice, on the same connector interface.
-- Long-running / scheduled / watch execution — `run` is one-shot.
+- Scheduled / cron execution — out of scope for this phase. (`run` itself is **continuous**:
+  like other ESBs, a pipeline stays live and keeps moving data from its source rather than
+  exiting after one document. One-shot processing of a single fixed input is a degenerate case
+  of the continuous loop, not the default.)
 - The `compile` command — deferred until there's a concrete need (e.g. bundling for the
   Rust/WASM runtime).
 - The Rust/WASM production runtime itself.
@@ -129,11 +151,9 @@ Each stage surfaces a clear, contextual error and a non-zero exit:
 ## Open questions
 
 1. **stdio default format** — require `format:` explicitly, or default to `json`?
-2. **`run` default target** — `run` with no name runs all pipelines (proposed); or should it
-   require a name and treat "all" as `run --all`?
-3. **File sink overwrite** — always overwrite, or refuse without `--force`?
-4. **Multiple sources/sinks** — one each for now; is fan-in/fan-out ever needed here?
-5. **Where does a pipeline's flow get its `_ts` functions** — same `functions/` dir as today
+2. **File sink overwrite** — always overwrite, or refuse without `--force`?
+3. **Multiple sources/sinks** — one each for now; is fan-in/fan-out ever needed here?
+4. **Where does a pipeline's flow get its `_ts` functions** — same `functions/` dir as today
    (yes, proposed; the function loader is unchanged).
-6. **Cross-format edge cases** — XML requires a single root element; a JSON→XML pipeline whose
+5. **Cross-format edge cases** — XML requires a single root element; a JSON→XML pipeline whose
    document isn't a single-root object errors at serialize. Document as a limitation.

--- a/docs/rfcs/0002-run-pipelines.md
+++ b/docs/rfcs/0002-run-pipelines.md
@@ -1,0 +1,139 @@
+# RFC 0002 — `weavster run` and pipelines
+
+- Status: **Draft** (design only; no implementation yet)
+- Phase: "make it move data" (first post-MVP phase)
+- Builds on: the v0alpha2 DSL ([RFC 0001](./0001-v0alpha2-dsl.md)) and the existing format packs
+
+## Summary
+
+Add a config-driven `weavster run` that moves real data through a flow: read from a **source**,
+transform with a **flow**, write to a **sink**. Pipelines are declared one-per-file in a
+`pipelines/` directory (mirroring `flows/` and `fixtures/`). The first connectors are **local
+file** and **stdin/stdout**.
+
+## Motivation
+
+Today Weavster transforms _fixtures_ — it proves a flow is correct but never touches real data.
+The product is an _integration_ tool; the missing piece is actually moving a document from a
+source, through a flow, to a sink. `run` is that piece.
+
+## Pipelines
+
+A pipeline is a file `pipelines/<name>.yaml`:
+
+```yaml
+# pipelines/orders.yaml
+source:
+  type: file
+  path: in/order.json
+flow: order # flows/order.yaml
+sink:
+  type: file
+  path: out/order.json
+```
+
+Run it:
+
+```bash
+weavster run orders     # runs pipelines/orders.yaml
+weavster run            # runs every pipeline in pipelines/
+```
+
+Data flow:
+
+```text
+source.read() ──▶ format pack parse ──▶ flow (applyFlow + functions) ──▶ format pack serialize ──▶ sink.write()
+```
+
+This reuses everything already built: the JSON/XML packs, the v0alpha2 engine, and the `_ts`
+function loader. Only the source/sink I/O is new — and it lives in the CLI, keeping
+`@weavster/core` pure.
+
+## Connectors
+
+A connector is a typed `source` or `sink`. The first two:
+
+| Type     | As source          | As sink                     |
+| -------- | ------------------ | --------------------------- |
+| `file`   | read `path`        | write `path` (creates dirs) |
+| `stdin`  | read process stdin | —                           |
+| `stdout` | —                  | write process stdout        |
+
+```yaml
+source: { type: stdin, format: json }
+flow: order
+sink: { type: stdout, format: json }
+```
+
+The connector interface is small and pluggable, so REST/SFTP/etc. slot in later without
+touching the run loop:
+
+```ts
+interface Source {
+  read(): Promise<string>;
+}
+interface Sink {
+  write(text: string): Promise<void>;
+}
+```
+
+## Format selection
+
+The **source** format chooses the parser; the **sink** format chooses the serializer — so a
+pipeline can convert formats (e.g. XML in, JSON out).
+
+- `file`: inferred from the path extension (`.json` → json, `.xml` → xml); override with an
+  explicit `format:`.
+- `stdin`/`stdout`: no extension, so `format:` is required (default `json` if omitted — TBD,
+  see open questions).
+
+## Validation
+
+A new `spec/schemas/pipeline.schema.json` describes the pipeline file (source/flow/sink, known
+connector types, valid format). `weavster validate` is extended to check every
+`pipelines/*.yaml` too — alongside `weavster.yaml` and `flows/*.yaml`. The project's
+`apiVersion` still governs; adding pipelines is additive and needs no schema-version bump.
+
+## Errors
+
+Each stage surfaces a clear, contextual error and a non-zero exit:
+
+- pipeline not found / schema-invalid;
+- source read failure (missing file, empty stdin);
+- parse failure (`JsonParseError`/`XmlParseError`);
+- transform failure (`TransformError`, already step-scoped);
+- sink write failure (permissions, etc.).
+
+`run` reports which pipeline and which stage failed.
+
+## Slices
+
+1. **Core run path + file/stdio connectors.** Pipeline schema + loader, the connector
+   interface with `file`/`stdin`/`stdout`, the `weavster run [name]` command, `validate`
+   extended to pipelines, and tests.
+2. **Example + docs.** A golden-path pipeline (`pipelines/order.yaml` reading a sample input,
+   writing output), a CLI Reference `run` section, a "Pipelines" docs page, and a CI smoke that
+   runs the example end to end.
+
+(File and stdio are both small; they may land together in slice 1.)
+
+## Non-goals (this phase)
+
+- Network connectors (REST, SFTP, TCP) — a later slice, on the same connector interface.
+- Long-running / scheduled / watch execution — `run` is one-shot.
+- The `compile` command — deferred until there's a concrete need (e.g. bundling for the
+  Rust/WASM runtime).
+- The Rust/WASM production runtime itself.
+- Secrets management (only needed once network connectors arrive).
+
+## Open questions
+
+1. **stdio default format** — require `format:` explicitly, or default to `json`?
+2. **`run` default target** — `run` with no name runs all pipelines (proposed); or should it
+   require a name and treat "all" as `run --all`?
+3. **File sink overwrite** — always overwrite, or refuse without `--force`?
+4. **Multiple sources/sinks** — one each for now; is fan-in/fan-out ever needed here?
+5. **Where does a pipeline's flow get its `_ts` functions** — same `functions/` dir as today
+   (yes, proposed; the function loader is unchanged).
+6. **Cross-format edge cases** — XML requires a single root element; a JSON→XML pipeline whose
+   document isn't a single-root object errors at serialize. Document as a limitation.

--- a/notes/DEV_LOG.md
+++ b/notes/DEV_LOG.md
@@ -13,6 +13,22 @@ Newest entries on top. One entry per merged slice.
 
 ---
 
+## 2026-06-06 — RFC 0002: run + pipelines (next phase design)
+
+- What changed: With the MVP shipped, picked the next phase — "make it move data" — and wrote
+  `docs/rfcs/0002-run-pipelines.md`. `weavster run` reads from a source, transforms with a flow,
+  and writes to a sink; pipelines are declared one-per-file in a `pipelines/` directory (mirroring
+  `flows/`/`fixtures/`). First connectors: local `file` and `stdin`/`stdout`. Decisions from
+  discussion: config-driven via a pipelines dir (not CLI flags or inline config), file+stdio first,
+  `compile` deferred.
+- What I learned: The run path reuses everything — JSON/XML packs, the v0alpha2 engine, the `_ts`
+  loader — so the only new surface is source/sink I/O, which stays in the CLI to keep
+  `@weavster/core` pure. A nice property falls out: because source format picks the parser and sink
+  format picks the serializer, a pipeline can convert formats (XML in, JSON out). Connectors are a
+  tiny `read()`/`write()` interface so REST/SFTP slot in later without touching the run loop.
+- What is next: implement RFC 0002 slice 1 — pipeline schema + loader, file/stdio connectors, the
+  `weavster run` command, `validate` extended to pipelines, and tests.
+
 ## 2026-06-06 — Fix npm README + finalize release workflow (0.0.3)
 
 - What changed: The npm page for `@weavster/cli` showed no README even though the tarball
@@ -28,6 +44,7 @@ Newest entries on top. One entry per merged slice.
   running in a dir without sources), then `npm publish` from that directory — which populates the
   per-version readme and still does OIDC.
 - What is next: tag `v0.0.3` to publish and confirm the README renders on npmjs.com.
+
 ## 2026-06-06 — Fix OIDC publish (drop registry-url)
 
 - What changed: Removed `registry-url` from the `setup-node` step in `release.yml`. The first


### PR DESCRIPTION
Design-only RFC for the first post-MVP phase: **make it move data**. No implementation.

## Proposes
- **`weavster run`** moves real data: source → flow → sink.
- **Pipelines** declared one-per-file in a `pipelines/` directory (mirrors `flows/`/`fixtures/`): `source` + `flow` + `sink`.
- First connectors: **local `file`** and **`stdin`/`stdout`** (a tiny `read()`/`write()` interface so REST/SFTP slot in later).
- Source format picks the parser, sink format picks the serializer → pipelines can **convert formats** (XML in, JSON out).
- `validate` extended to check `pipelines/*.yaml`; core stays pure (I/O lives in the CLI).

## Decisions baked in (from discussion)
- Config-driven via a `pipelines/` dir (not CLI flags / inline config) ✅
- `file` + `stdio` connectors first ✅
- `compile` deferred ✅

## Scope
Slice 1: pipeline schema + loader + file/stdio connectors + `weavster run` + validate-pipelines + tests. Slice 2: golden-path pipeline + docs + CI smoke. Non-goals: network connectors, scheduling, `compile`, the Rust/WASM runtime.

Open questions (stdio default format, `run` default target, sink overwrite, etc.) listed in the RFC.

File: `docs/rfcs/0002-run-pipelines.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
---
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added RFC 0002 documenting the new `weavster run` command for executing pipelines
  * Pipelines configured via YAML files with source, flow, and sink sections
  * Includes initial connector types and validation behavior documentation
  * Updated changelog and development log with planning notes
<!-- end of auto-generated comment: release notes by coderabbit.ai -->