### PR TITLE
feat(run): weavster run + pipelines (RFC 0002 slice 1)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,8 @@ jobs:
 
       - run: pnpm --filter @weavster/cli typecheck
 
+      - run: pnpm lint
+
       - run: pnpm test
 
       - name: golden-path smoke

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,12 @@ jobs:
           node cli/dist/index.js validate examples/golden-path
           node cli/dist/index.js test examples/golden-path
 
+      - name: run smoke
+        run: |
+          cd examples/golden-path
+          node "$GITHUB_WORKSPACE/cli/dist/index.js" run order
+          test -f out/order.json
+
       - name: init smoke
         run: |
           node cli/dist/index.js init "$RUNNER_TEMP/wv-init"

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -33,7 +33,7 @@ jobs:
 
       - name: Run Claude Code Review
         id: claude-review
-        uses: anthropics/claude-code-action@v1
+        uses: anthropics/claude-code-action@fbda2eb1bdc90d319b8d853f5deb53bca199a7c1 # v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -33,7 +33,7 @@ jobs:
 
       - name: Run Claude Code Review
         id: claude-review
-        uses: anthropics/claude-code-action@fbda2eb1bdc90d319b8d853f5deb53bca199a7c1 # v1
+        uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -32,7 +32,7 @@ jobs:
 
       - name: Run Claude Code
         id: claude
-        uses: anthropics/claude-code-action@v1
+        uses: anthropics/claude-code-action@fbda2eb1bdc90d319b8d853f5deb53bca199a7c1 # v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
 

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -32,7 +32,7 @@ jobs:
 
       - name: Run Claude Code
         id: claude
-        uses: anthropics/claude-code-action@fbda2eb1bdc90d319b8d853f5deb53bca199a7c1 # v1
+        uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
 

--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,6 @@ pnpm-debug.log*
 # OS
 .DS_Store
 Thumbs.db
+
+# pipeline run output (generated)
+examples/golden-path/out/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### Changed
+
+- Add `@biomejs/biome` as a dev dependency so `pnpm lint` runs locally, wire it into CI, and
+  clear the findings: drop unused imports, simplify redundant boolean casts, give the escape-hatch
+  test functions real types, use a stable React key in the docs homepage, and disable
+  `noThenProperty` (the DSL legitimately uses `then`/`else`).
+
 ### Added
 
 - `weavster run [name]`: execute pipelines that move real data — read a **source**, transform

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### Added
+
+- `weavster run [name]`: execute pipelines that move real data — read a **source**, transform
+  with a **flow**, write a **sink**. Pipelines are declared one-per-file in `pipelines/`
+  (`source` + `flow` + `sink`); first connectors are `file` and `stdin`/`stdout`. The source
+  format picks the parser and the sink format (defaulting to the source's) picks the serializer,
+  so a pipeline can convert formats. `weavster validate` now also checks `pipelines/*.yaml`. Adds
+  a golden-path pipeline, a Pipelines docs page, and a CI run smoke. (RFC 0002, slice 1)
+
 ## [0.0.3] - 2026-06-06
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,9 +12,12 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - `weavster run [name]`: execute pipelines that move real data — read a **source**, transform
   with a **flow**, write a **sink**. Pipelines are declared one-per-file in `pipelines/`
   (`source` + `flow` + `sink`); first connectors are `file` and `stdin`/`stdout`. The source
-  format picks the parser and the sink format (defaulting to the source's) picks the serializer,
-  so a pipeline can convert formats. `weavster validate` now also checks `pipelines/*.yaml`. Adds
-  a golden-path pipeline, a Pipelines docs page, and a CI run smoke. (RFC 0002, slice 1)
+  yields a **stream of documents** and the run loop processes each (a `file` is one document;
+  `stdin` is line-delimited and streams). Startup failures abort; per-document failures fail a
+  bounded source and are logged on a stream. The source format picks the parser and the sink
+  format (defaulting to the source's) picks the serializer, so a pipeline can convert formats.
+  `weavster validate` now also checks `pipelines/*.yaml`. Adds a golden-path pipeline, a
+  Pipelines docs page, and a CI run smoke. (RFC 0002, slice 1)
 - Biome linter config (`biome.json`) plus `lint` / `lint:fix` scripts. Linter only — Prettier
   still owns formatting (Biome's formatter and assist are disabled). CodeRabbit auto-detects the
   config and runs Biome on reviews.

--- a/README.md
+++ b/README.md
@@ -43,6 +43,8 @@ See the [Getting Started guide](https://docs.weavster.dev/getting-started) for t
   `flows/*.yaml` against the flow schema, with path-aware errors.
 - `weavster test`: runs each fixture (`fixtures/<flow>/<case>/`) through its
   `flows/<flow>.yaml` and prints a diff for any mismatch against `expected.json`.
+- `weavster run [name]`: runs `pipelines/<name>.yaml` — read a source, transform with a flow,
+  write a sink (file and stdin/stdout connectors; can convert formats). Omit the name to run all.
 - A reference user project at [`examples/golden-path/`](examples/golden-path/) exercised
   by `validate` and `test`.
 - `@weavster/core`: the canonical document model — a format-agnostic node tree
@@ -67,8 +69,8 @@ See the [Getting Started guide](https://docs.weavster.dev/getting-started) for t
   ([`CHANGELOG.md`](CHANGELOG.md)).
 
 The transform engine is wired into the CLI: `weavster test` runs project flows over their
-fixtures. `init`, `validate`, and `test` are the working CLI commands; `compile` and `run`
-are still planned.
+fixtures and `weavster run` moves real data through them. `init`, `validate`, `test`, and
+`run` are the working CLI commands; `compile` is still planned.
 
 ## Local development
 

--- a/biome.json
+++ b/biome.json
@@ -17,7 +17,10 @@
   "linter": {
     "enabled": true,
     "rules": {
-      "recommended": true
+      "recommended": true,
+      "suspicious": {
+        "noThenProperty": "off"
+      }
     }
   }
 }

--- a/cli/src/commands/run.ts
+++ b/cli/src/commands/run.ts
@@ -12,12 +12,14 @@ export function registerRun(program: Command): void {
       // Status goes to stderr so a stdout sink stays pipeable.
       for (const error of report.errors) console.error(`✗ ${error}`);
       for (const result of report.results) {
+        const docs = `${result.documents} document${result.documents === 1 ? '' : 's'}`;
         if (result.ok) {
-          console.error(`✓ ${result.name}`);
-          continue;
+          console.error(`✓ ${result.name} (${docs})`);
+        } else {
+          console.error(`✗ ${result.name}`);
+          if (result.error) console.error(`  ${result.error}`);
         }
-        console.error(`✗ ${result.name}`);
-        if (result.error) console.error(`  ${result.error}`);
+        for (const docError of result.docErrors ?? []) console.error(`  ${docError}`);
       }
       if (report.results.length > 0) {
         const ran = report.results.filter((r) => r.ok).length;

--- a/cli/src/commands/run.ts
+++ b/cli/src/commands/run.ts
@@ -1,0 +1,29 @@
+import type { Command } from 'commander';
+import { runPipelines } from '../runner.js';
+
+export function registerRun(program: Command): void {
+  program
+    .command('run')
+    .description('Run pipelines: read a source, transform with a flow, write a sink')
+    .argument('[name]', 'pipeline name (default: all pipelines)')
+    .action(async (name: string | undefined) => {
+      const report = await runPipelines('.', name);
+
+      // Status goes to stderr so a stdout sink stays pipeable.
+      for (const error of report.errors) console.error(`✗ ${error}`);
+      for (const result of report.results) {
+        if (result.ok) {
+          console.error(`✓ ${result.name}`);
+          continue;
+        }
+        console.error(`✗ ${result.name}`);
+        if (result.error) console.error(`  ${result.error}`);
+      }
+      if (report.results.length > 0) {
+        const ran = report.results.filter((r) => r.ok).length;
+        console.error(`\n${ran}/${report.results.length} pipelines ran`);
+      }
+
+      if (!report.ok) process.exitCode = 1;
+    });
+}

--- a/cli/src/commands/validate.ts
+++ b/cli/src/commands/validate.ts
@@ -2,6 +2,7 @@ import { dirname } from 'node:path';
 import type { Command } from 'commander';
 import { checkProject } from '../project.js';
 import { checkFlows } from '../flow.js';
+import { checkPipelines } from '../pipeline.js';
 
 export function registerValidate(program: Command): void {
   program
@@ -19,13 +20,13 @@ export function registerValidate(program: Command): void {
       }
 
       const projectDir = result.file ? dirname(result.file) : path;
-      for (const flow of checkFlows(projectDir)) {
-        if (flow.ok) {
-          console.log(`✓ ${flow.file} is valid`);
+      for (const file of [...checkFlows(projectDir), ...checkPipelines(projectDir)]) {
+        if (file.ok) {
+          console.log(`✓ ${file.file} is valid`);
           continue;
         }
-        console.error(`✗ ${flow.file}`);
-        for (const error of flow.errors) console.error(`  ${error}`);
+        console.error(`✗ ${file.file}`);
+        for (const error of file.errors) console.error(`  ${error}`);
         process.exitCode = 1;
       }
     });

--- a/cli/src/connectors.ts
+++ b/cli/src/connectors.ts
@@ -1,0 +1,48 @@
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { dirname } from 'node:path';
+
+/** A pipeline input: produces the raw text to parse. */
+export interface Source {
+  read(): Promise<string>;
+}
+
+/** A pipeline output: consumes the serialized text. */
+export interface Sink {
+  write(text: string): Promise<void>;
+}
+
+export function fileSource(path: string): Source {
+  return {
+    async read() {
+      if (!existsSync(path)) throw new Error(`no input file "${path}"`);
+      return readFileSync(path, 'utf8');
+    },
+  };
+}
+
+export function stdinSource(): Source {
+  return {
+    async read() {
+      const chunks: Buffer[] = [];
+      for await (const chunk of process.stdin) chunks.push(chunk as Buffer);
+      return Buffer.concat(chunks).toString('utf8');
+    },
+  };
+}
+
+export function fileSink(path: string): Sink {
+  return {
+    async write(text) {
+      mkdirSync(dirname(path), { recursive: true });
+      writeFileSync(path, text);
+    },
+  };
+}
+
+export function stdoutSink(): Sink {
+  return {
+    async write(text) {
+      process.stdout.write(text);
+    },
+  };
+}

--- a/cli/src/connectors.ts
+++ b/cli/src/connectors.ts
@@ -1,4 +1,4 @@
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { access, mkdir, readFile, writeFile } from 'node:fs/promises';
 import { dirname } from 'node:path';
 import { createInterface } from 'node:readline';
 
@@ -15,8 +15,12 @@ export interface Sink {
 export function fileSource(path: string): Source {
   return {
     async *documents() {
-      if (!existsSync(path)) throw new Error(`no input file "${path}"`);
-      yield readFileSync(path, 'utf8');
+      try {
+        await access(path);
+      } catch {
+        throw new Error(`no input file "${path}"`);
+      }
+      yield await readFile(path, 'utf8');
     },
   };
 }
@@ -26,9 +30,13 @@ export function stdinSource(): Source {
     async *documents() {
       // Line-delimited: each non-empty line is one document, yielded as it arrives.
       const lines = createInterface({ input: process.stdin, crlfDelay: Number.POSITIVE_INFINITY });
-      for await (const line of lines) {
-        const text = line.trim();
-        if (text) yield text;
+      try {
+        for await (const line of lines) {
+          const text = line.trim();
+          if (text) yield text;
+        }
+      } finally {
+        lines.close();
       }
     },
   };
@@ -37,8 +45,8 @@ export function stdinSource(): Source {
 export function fileSink(path: string): Sink {
   return {
     async write(text) {
-      mkdirSync(dirname(path), { recursive: true });
-      writeFileSync(path, text);
+      await mkdir(dirname(path), { recursive: true });
+      await writeFile(path, text);
     },
   };
 }

--- a/cli/src/connectors.ts
+++ b/cli/src/connectors.ts
@@ -1,31 +1,35 @@
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
 import { dirname } from 'node:path';
+import { createInterface } from 'node:readline';
 
-/** A pipeline input: produces the raw text to parse. */
+/** A pipeline input: yields a stream of raw document texts (once for a file, many for a stream). */
 export interface Source {
-  read(): Promise<string>;
+  documents(): AsyncIterable<string>;
 }
 
-/** A pipeline output: consumes the serialized text. */
+/** A pipeline output: consumes each serialized document. */
 export interface Sink {
   write(text: string): Promise<void>;
 }
 
 export function fileSource(path: string): Source {
   return {
-    async read() {
+    async *documents() {
       if (!existsSync(path)) throw new Error(`no input file "${path}"`);
-      return readFileSync(path, 'utf8');
+      yield readFileSync(path, 'utf8');
     },
   };
 }
 
 export function stdinSource(): Source {
   return {
-    async read() {
-      const chunks: Buffer[] = [];
-      for await (const chunk of process.stdin) chunks.push(chunk as Buffer);
-      return Buffer.concat(chunks).toString('utf8');
+    async *documents() {
+      // Line-delimited: each non-empty line is one document, yielded as it arrives.
+      const lines = createInterface({ input: process.stdin, crlfDelay: Number.POSITIVE_INFINITY });
+      for await (const line of lines) {
+        const text = line.trim();
+        if (text) yield text;
+      }
     },
   };
 }

--- a/cli/src/functions.ts
+++ b/cli/src/functions.ts
@@ -1,5 +1,5 @@
 import { existsSync } from 'node:fs';
-import { join, resolve } from 'node:path';
+import { resolve } from 'node:path';
 import { createJiti } from 'jiti';
 import type { Flow, Step, TransformFn } from '@weavster/core';
 

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -3,6 +3,7 @@ import { Command } from 'commander';
 import { registerValidate } from './commands/validate.js';
 import { registerTest } from './commands/test.js';
 import { registerInit } from './commands/init.js';
+import { registerRun } from './commands/run.js';
 
 const program = new Command();
 
@@ -14,5 +15,6 @@ program
 registerInit(program);
 registerValidate(program);
 registerTest(program);
+registerRun(program);
 
 program.parseAsync();

--- a/cli/src/pipeline.ts
+++ b/cli/src/pipeline.ts
@@ -1,0 +1,112 @@
+import { existsSync, readFileSync, readdirSync } from 'node:fs';
+import { extname, join } from 'node:path';
+import { parse, YAMLParseError } from 'yaml';
+import {
+  type Sink,
+  type Source,
+  fileSink,
+  fileSource,
+  stdinSource,
+  stdoutSink,
+} from './connectors.js';
+import { validatePipeline } from './schema.js';
+
+const PIPELINES_DIR = 'pipelines';
+
+export type Format = 'json' | 'xml';
+
+interface ConnectorSpec {
+  type: string;
+  path?: string;
+  format?: Format;
+}
+
+export interface Pipeline {
+  source: ConnectorSpec;
+  flow: string;
+  sink: ConnectorSpec;
+}
+
+export interface PipelineLoad {
+  pipeline: Pipeline | null;
+  errors: string[];
+}
+
+export interface PipelineCheck {
+  file: string;
+  ok: boolean;
+  errors: string[];
+}
+
+/** Load and schema-validate a pipeline by name from a project's `pipelines/` directory. */
+export function loadPipeline(projectDir: string, name: string): PipelineLoad {
+  const file = join(projectDir, PIPELINES_DIR, `${name}.yaml`);
+  if (!existsSync(file)) return { pipeline: null, errors: [`no pipeline "${name}" at ${file}`] };
+
+  let data: unknown;
+  try {
+    data = parse(readFileSync(file, 'utf8'));
+  } catch (err) {
+    const message = err instanceof YAMLParseError ? err.message : String(err);
+    return { pipeline: null, errors: [`invalid YAML: ${message}`] };
+  }
+
+  const { valid, errors } = validatePipeline(data);
+  if (!valid) return { pipeline: null, errors };
+  return { pipeline: data as Pipeline, errors: [] };
+}
+
+/** List pipeline names (without extension) under a project's `pipelines/` directory. */
+export function listPipelines(projectDir: string): string[] {
+  const dir = join(projectDir, PIPELINES_DIR);
+  if (!existsSync(dir)) return [];
+  return readdirSync(dir)
+    .filter((f) => f.endsWith('.yaml'))
+    .map((f) => f.slice(0, -'.yaml'.length))
+    .sort();
+}
+
+/** Schema-validate every pipeline in a project. */
+export function checkPipelines(projectDir: string): PipelineCheck[] {
+  return listPipelines(projectDir).map((name) => {
+    const { errors } = loadPipeline(projectDir, name);
+    return { file: `${PIPELINES_DIR}/${name}.yaml`, ok: errors.length === 0, errors };
+  });
+}
+
+function extFormat(path: string): Format | undefined {
+  const ext = extname(path).toLowerCase();
+  if (ext === '.json') return 'json';
+  if (ext === '.xml') return 'xml';
+  return undefined;
+}
+
+/** Resolve a source spec to a connector and the format to parse with. */
+export function resolveSource(
+  spec: ConnectorSpec,
+  projectDir: string,
+): { source: Source; format: Format } {
+  if (spec.type === 'stdin') {
+    return { source: stdinSource(), format: spec.format as Format };
+  }
+  const path = join(projectDir, spec.path as string);
+  const format = spec.format ?? extFormat(spec.path as string);
+  if (format === undefined) {
+    throw new Error(`cannot determine source format for "${spec.path}" — add a format`);
+  }
+  return { source: fileSource(path), format };
+}
+
+/** Resolve a sink spec to a connector and format (defaults to the source format). */
+export function resolveSink(
+  spec: ConnectorSpec,
+  projectDir: string,
+  sourceFormat: Format,
+): { sink: Sink; format: Format } {
+  if (spec.type === 'stdout') {
+    return { sink: stdoutSink(), format: spec.format ?? sourceFormat };
+  }
+  const path = join(projectDir, spec.path as string);
+  const format = spec.format ?? extFormat(spec.path as string) ?? sourceFormat;
+  return { sink: fileSink(path), format };
+}

--- a/cli/src/pipeline.ts
+++ b/cli/src/pipeline.ts
@@ -81,20 +81,23 @@ function extFormat(path: string): Format | undefined {
   return undefined;
 }
 
-/** Resolve a source spec to a connector and the format to parse with. */
+/**
+ * Resolve a source spec to a connector, the format to parse with, and whether it is bounded.
+ * A bounded source (file) yields once; an unbounded source (stdin) streams until end-of-stream.
+ */
 export function resolveSource(
   spec: ConnectorSpec,
   projectDir: string,
-): { source: Source; format: Format } {
+): { source: Source; format: Format; bounded: boolean } {
   if (spec.type === 'stdin') {
-    return { source: stdinSource(), format: spec.format as Format };
+    return { source: stdinSource(), format: spec.format as Format, bounded: false };
   }
   const path = join(projectDir, spec.path as string);
   const format = spec.format ?? extFormat(spec.path as string);
   if (format === undefined) {
     throw new Error(`cannot determine source format for "${spec.path}" — add a format`);
   }
-  return { source: fileSource(path), format };
+  return { source: fileSource(path), format, bounded: true };
 }
 
 /** Resolve a sink spec to a connector and format (defaults to the source format). */

--- a/cli/src/runner.ts
+++ b/cli/src/runner.ts
@@ -105,7 +105,7 @@ async function runOne(dir: string, name: string): Promise<RunResult> {
       }
     }
   } catch (err) {
-    // The source failed to open or stream — a startup-class failure.
+    // The source failed to open or stream — possibly after some documents were processed.
     return { name, ok: false, documents, error: message(err) };
   }
 

--- a/cli/src/runner.ts
+++ b/cli/src/runner.ts
@@ -23,7 +23,12 @@ const serialize: Record<Format, (doc: ReturnType<typeof json.parse>) => string> 
 export interface RunResult {
   name: string;
   ok: boolean;
+  /** Number of documents the source yielded. */
+  documents: number;
+  /** A startup or bounded-source failure that ends the pipeline. */
   error?: string;
+  /** Per-document failures on an unbounded source (logged, did not end the pipeline). */
+  docErrors?: string[];
 }
 
 export interface RunReport {
@@ -50,25 +55,59 @@ export async function runPipelines(path: string, name?: string): Promise<RunRepo
   return { ok: results.every((r) => r.ok), results, errors: [] };
 }
 
+const message = (err: unknown): string => (err instanceof Error ? err.message : String(err));
+
 async function runOne(dir: string, name: string): Promise<RunResult> {
-  try {
-    const { pipeline, errors } = loadPipeline(dir, name);
-    if (pipeline === null) return { name, ok: false, error: errors.join('; ') };
+  // Startup: load and resolve everything before the loop; any failure ends the pipeline.
+  const { pipeline, errors } = loadPipeline(dir, name);
+  if (pipeline === null) return { name, ok: false, documents: 0, error: errors.join('; ') };
 
-    const { flow, errors: flowErrors } = loadFlow(dir, pipeline.flow);
-    if (flow === null)
-      return { name, ok: false, error: `flow "${pipeline.flow}": ${flowErrors.join('; ')}` };
-
-    const { functions, errors: fnErrors } = await loadFunctions(dir, flow);
-    if (fnErrors.length > 0) return { name, ok: false, error: fnErrors.join('; ') };
-
-    const { source, format: inFormat } = resolveSource(pipeline.source, dir);
-    const { sink, format: outFormat } = resolveSink(pipeline.sink, dir, inFormat);
-
-    const doc = parse[inFormat](await source.read());
-    await sink.write(serialize[outFormat](applyFlow(doc, flow, { functions })));
-    return { name, ok: true };
-  } catch (err) {
-    return { name, ok: false, error: err instanceof Error ? err.message : String(err) };
+  const { flow, errors: flowErrors } = loadFlow(dir, pipeline.flow);
+  if (flow === null) {
+    return {
+      name,
+      ok: false,
+      documents: 0,
+      error: `flow "${pipeline.flow}": ${flowErrors.join('; ')}`,
+    };
   }
+
+  const { functions, errors: fnErrors } = await loadFunctions(dir, flow);
+  if (fnErrors.length > 0) return { name, ok: false, documents: 0, error: fnErrors.join('; ') };
+
+  let source: { documents(): AsyncIterable<string> };
+  let inFormat: Format;
+  let bounded: boolean;
+  let sink: { write(text: string): Promise<void> };
+  let outFormat: Format;
+  try {
+    ({ source, format: inFormat, bounded } = resolveSource(pipeline.source, dir));
+    ({ sink, format: outFormat } = resolveSink(pipeline.sink, dir, inFormat));
+  } catch (err) {
+    return { name, ok: false, documents: 0, error: message(err) };
+  }
+
+  // The run loop: one iteration per document the source yields.
+  let documents = 0;
+  const docErrors: string[] = [];
+  try {
+    for await (const text of source.documents()) {
+      documents += 1;
+      try {
+        const out = applyFlow(parse[inFormat](text), flow, { functions });
+        await sink.write(serialize[outFormat](out));
+      } catch (err) {
+        const scoped = `document ${documents}: ${message(err)}`;
+        // Bounded source: the only document failed, so the pipeline fails. Unbounded:
+        // log it and keep the stream alive.
+        if (bounded) return { name, ok: false, documents, error: scoped };
+        docErrors.push(scoped);
+      }
+    }
+  } catch (err) {
+    // The source failed to open or stream — a startup-class failure.
+    return { name, ok: false, documents, error: message(err) };
+  }
+
+  return { name, ok: true, documents, docErrors: docErrors.length > 0 ? docErrors : undefined };
 }

--- a/cli/src/runner.ts
+++ b/cli/src/runner.ts
@@ -1,0 +1,74 @@
+import { existsSync, statSync } from 'node:fs';
+import { join } from 'node:path';
+import { applyFlow, json, xml } from '@weavster/core';
+import { loadFlow } from './flow.js';
+import { loadFunctions } from './functions.js';
+import {
+  type Format,
+  listPipelines,
+  loadPipeline,
+  resolveSink,
+  resolveSource,
+} from './pipeline.js';
+
+const parse: Record<Format, (text: string) => ReturnType<typeof json.parse>> = {
+  json: json.parse,
+  xml: xml.parse,
+};
+const serialize: Record<Format, (doc: ReturnType<typeof json.parse>) => string> = {
+  json: json.serialize,
+  xml: xml.serialize,
+};
+
+export interface RunResult {
+  name: string;
+  ok: boolean;
+  error?: string;
+}
+
+export interface RunReport {
+  ok: boolean;
+  results: RunResult[];
+  errors: string[];
+}
+
+function resolveProjectDir(path: string): string {
+  if (existsSync(path) && statSync(path).isFile()) return join(path, '..');
+  return path;
+}
+
+/** Run one pipeline, or every pipeline in the project when no name is given. */
+export async function runPipelines(path: string, name?: string): Promise<RunReport> {
+  const dir = resolveProjectDir(path);
+  const names = name ? [name] : listPipelines(dir);
+  if (names.length === 0) {
+    return { ok: false, results: [], errors: [`no pipelines found in ${join(dir, 'pipelines')}`] };
+  }
+
+  const results: RunResult[] = [];
+  for (const pipelineName of names) results.push(await runOne(dir, pipelineName));
+  return { ok: results.every((r) => r.ok), results, errors: [] };
+}
+
+async function runOne(dir: string, name: string): Promise<RunResult> {
+  try {
+    const { pipeline, errors } = loadPipeline(dir, name);
+    if (pipeline === null) return { name, ok: false, error: errors.join('; ') };
+
+    const { flow, errors: flowErrors } = loadFlow(dir, pipeline.flow);
+    if (flow === null)
+      return { name, ok: false, error: `flow "${pipeline.flow}": ${flowErrors.join('; ')}` };
+
+    const { functions, errors: fnErrors } = await loadFunctions(dir, flow);
+    if (fnErrors.length > 0) return { name, ok: false, error: fnErrors.join('; ') };
+
+    const { source, format: inFormat } = resolveSource(pipeline.source, dir);
+    const { sink, format: outFormat } = resolveSink(pipeline.sink, dir, inFormat);
+
+    const doc = parse[inFormat](await source.read());
+    await sink.write(serialize[outFormat](applyFlow(doc, flow, { functions })));
+    return { name, ok: true };
+  } catch (err) {
+    return { name, ok: false, error: err instanceof Error ? err.message : String(err) };
+  }
+}

--- a/cli/src/schema.ts
+++ b/cli/src/schema.ts
@@ -3,10 +3,12 @@ import { Ajv, type ErrorObject } from 'ajv';
 // the JSON into the build, so they ship inside the published bundle.
 import projectSchema from '../../spec/schemas/project.schema.json' with { type: 'json' };
 import flowSchema from '../../spec/schemas/flow.schema.json' with { type: 'json' };
+import pipelineSchema from '../../spec/schemas/pipeline.schema.json' with { type: 'json' };
 
 const ajv = new Ajv({ allErrors: true });
 const validate = ajv.compile(projectSchema);
 const validateFlowSchema = ajv.compile(flowSchema);
+const validatePipelineSchema = ajv.compile(pipelineSchema);
 
 export interface ValidationResult {
   valid: boolean;
@@ -25,6 +27,13 @@ export function validateFlow(data: unknown): ValidationResult {
   const valid = validateFlowSchema(data) as boolean;
   if (valid) return { valid: true, errors: [] };
   return { valid: false, errors: (validateFlowSchema.errors ?? []).map(formatError) };
+}
+
+/** Validate already-parsed pipeline data against the pipeline schema. */
+export function validatePipeline(data: unknown): ValidationResult {
+  const valid = validatePipelineSchema(data) as boolean;
+  if (valid) return { valid: true, errors: [] };
+  return { valid: false, errors: (validatePipelineSchema.errors ?? []).map(formatError) };
 }
 
 /** Turn one Ajv error into a path-aware, human-readable line. */

--- a/cli/test/run.test.ts
+++ b/cli/test/run.test.ts
@@ -3,6 +3,7 @@ import { fileURLToPath } from 'node:url';
 import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { dirname, join, resolve } from 'node:path';
+import { Readable } from 'node:stream';
 import { runPipelines } from '../src/runner.js';
 import { checkPipelines, resolveSink, resolveSource } from '../src/pipeline.js';
 
@@ -63,6 +64,27 @@ describe('runPipelines', () => {
     const report = await runPipelines(dir, 'nope');
     expect(report.ok).toBe(false);
     expect(report.results[0].error).toMatch(/no pipeline "nope"/);
+  });
+
+  it('logs and skips a bad document on an unbounded stdin source', async () => {
+    writePipeline(
+      'p',
+      'source: { type: stdin, format: json }\nflow: main\nsink: { type: file, path: out/x.json }\n',
+    );
+    const original = Object.getOwnPropertyDescriptor(process, 'stdin');
+    Object.defineProperty(process, 'stdin', {
+      value: Readable.from('{ "id": 1 }\n{ not json\n'),
+      configurable: true,
+    });
+    try {
+      const report = await runPipelines(dir, 'p');
+      expect(report.ok).toBe(true); // a stream survives a bad document
+      const [result] = report.results;
+      expect(result.documents).toBe(2);
+      expect(result.docErrors?.join('\n')).toMatch(/document 2: invalid JSON/);
+    } finally {
+      if (original) Object.defineProperty(process, 'stdin', original);
+    }
   });
 
   it('errors when a file source is missing', async () => {

--- a/cli/test/run.test.ts
+++ b/cli/test/run.test.ts
@@ -45,7 +45,18 @@ describe('runPipelines', () => {
     );
     const report = await runPipelines(dir);
     expect(report.ok).toBe(true);
-    expect(report.results).toEqual([{ name: 'p', ok: true }]);
+    expect(report.results).toEqual([{ name: 'p', ok: true, documents: 1 }]);
+  });
+
+  it('fails a bounded pipeline whose only document fails to parse', async () => {
+    writeFileSync(join(dir, 'in', 'bad.json'), '{ not json');
+    writePipeline(
+      'p',
+      'source: { type: file, path: in/bad.json }\nflow: main\nsink: { type: file, path: out/x.json }\n',
+    );
+    const report = await runPipelines(dir, 'p');
+    expect(report.ok).toBe(false);
+    expect(report.results[0].error).toMatch(/document 1: invalid JSON/);
   });
 
   it('errors on a missing pipeline', async () => {

--- a/cli/test/run.test.ts
+++ b/cli/test/run.test.ts
@@ -1,0 +1,92 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { fileURLToPath } from 'node:url';
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join, resolve } from 'node:path';
+import { runPipelines } from '../src/runner.js';
+import { checkPipelines, resolveSink, resolveSource } from '../src/pipeline.js';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const goldenPath = resolve(here, '../../examples/golden-path');
+
+let dir: string;
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), 'wv-run-'));
+  writeFileSync(join(dir, 'weavster.yaml'), 'apiVersion: weavster/v0alpha2\nname: t\n');
+  mkdirSync(join(dir, 'flows'));
+  writeFileSync(join(dir, 'flows', 'main.yaml'), 'steps:\n  - _set: { status: new }\n');
+  mkdirSync(join(dir, 'pipelines'));
+  mkdirSync(join(dir, 'in'));
+  writeFileSync(join(dir, 'in', 'x.json'), '{ "id": 1 }');
+});
+afterEach(() => rmSync(dir, { recursive: true, force: true }));
+
+const writePipeline = (name: string, body: string) =>
+  writeFileSync(join(dir, 'pipelines', `${name}.yaml`), body);
+
+describe('runPipelines', () => {
+  it('reads a file source, runs the flow, and writes a file sink', async () => {
+    writePipeline(
+      'p',
+      'source: { type: file, path: in/x.json }\nflow: main\nsink: { type: file, path: out/x.json }\n',
+    );
+    const report = await runPipelines(dir, 'p');
+    expect(report.ok).toBe(true);
+    expect(JSON.parse(readFileSync(join(dir, 'out', 'x.json'), 'utf8'))).toEqual({
+      id: 1,
+      status: 'new',
+    });
+  });
+
+  it('runs every pipeline when no name is given', async () => {
+    writePipeline(
+      'p',
+      'source: { type: file, path: in/x.json }\nflow: main\nsink: { type: file, path: out/x.json }\n',
+    );
+    const report = await runPipelines(dir);
+    expect(report.ok).toBe(true);
+    expect(report.results).toEqual([{ name: 'p', ok: true }]);
+  });
+
+  it('errors on a missing pipeline', async () => {
+    const report = await runPipelines(dir, 'nope');
+    expect(report.ok).toBe(false);
+    expect(report.results[0].error).toMatch(/no pipeline "nope"/);
+  });
+
+  it('errors when a file source is missing', async () => {
+    writePipeline(
+      'p',
+      'source: { type: file, path: in/missing.json }\nflow: main\nsink: { type: file, path: out/x.json }\n',
+    );
+    const report = await runPipelines(dir, 'p');
+    expect(report.ok).toBe(false);
+    expect(report.results[0].error).toMatch(/no input file/);
+  });
+});
+
+describe('format resolution', () => {
+  it('infers source format from the file extension', () => {
+    expect(resolveSource({ type: 'file', path: 'a.xml' }, dir).format).toBe('xml');
+    expect(resolveSource({ type: 'file', path: 'a.json' }, dir).format).toBe('json');
+  });
+
+  it('defaults a stdout sink to the source format, and honors an override', () => {
+    expect(resolveSink({ type: 'stdout' }, dir, 'xml').format).toBe('xml');
+    expect(resolveSink({ type: 'stdout', format: 'json' }, dir, 'xml').format).toBe('json');
+  });
+
+  it('errors when a file source format cannot be determined', () => {
+    expect(() => resolveSource({ type: 'file', path: 'a.txt' }, dir)).toThrow(
+      /cannot determine source format/,
+    );
+  });
+});
+
+describe('checkPipelines', () => {
+  it('validates the golden-path pipeline', () => {
+    expect(checkPipelines(goldenPath)).toEqual([
+      { file: 'pipelines/order.yaml', ok: true, errors: [] },
+    ]);
+  });
+});

--- a/core/src/dsl/engine.ts
+++ b/core/src/dsl/engine.ts
@@ -119,7 +119,7 @@ const STRUCTURAL: Record<string, StructuralOp> = {
     if (spec.else !== undefined && !Array.isArray(spec.else)) {
       throw new TransformError('"_when" "else" must be a step list');
     }
-    const branch = Boolean(evalExpr(spec.cond, ctx))
+    const branch = evalExpr(spec.cond, ctx)
       ? (spec.then as Step[])
       : ((spec.else as Step[] | undefined) ?? []);
     runSteps(working, branch, ctx);

--- a/core/src/dsl/expr.ts
+++ b/core/src/dsl/expr.ts
@@ -98,7 +98,7 @@ export const VALUE_OPS: Record<string, ValueOp> = {
   _not: (arg, ctx) => !evalExpr(arg, ctx),
   _cond(arg, ctx) {
     const o = record(arg, '_cond');
-    return Boolean(evalExpr(o.if, ctx)) ? evalExpr(o.then, ctx) : evalExpr(o.else, ctx);
+    return evalExpr(o.if, ctx) ? evalExpr(o.then, ctx) : evalExpr(o.else, ctx);
   },
 };
 

--- a/core/test/dsl-engine.test.ts
+++ b/core/test/dsl-engine.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { document, fromValue, toValue } from '../src/model.js';
-import { type Flow, TransformError, applyFlow } from '../src/dsl/engine.js';
+import { type Flow, applyFlow } from '../src/dsl/engine.js';
 
 const docOf = (value: unknown) => document(fromValue(value), { sourceFormat: 'json' });
 const run = (value: unknown, steps: Flow['steps']) =>
@@ -117,8 +117,8 @@ describe('_when', () => {
 
 describe('_ts', () => {
   const functions = {
-    addName: (o: any) => ({ ...o, name: `${o.first} ${o.last}` }),
-    up: (s: any) => String(s).toUpperCase(),
+    addName: (o: { first: string; last: string }) => ({ ...o, name: `${o.first} ${o.last}` }),
+    up: (s: unknown) => String(s).toUpperCase(),
     boom: () => {
       throw new Error('boom');
     },

--- a/examples/golden-path/in/order.json
+++ b/examples/golden-path/in/order.json
@@ -1,0 +1,6 @@
+{
+  "id": "a-1001",
+  "status": "new",
+  "first": "jane",
+  "last": "doe"
+}

--- a/examples/golden-path/pipelines/order.yaml
+++ b/examples/golden-path/pipelines/order.yaml
@@ -1,0 +1,8 @@
+# Read an order, normalize it with the order flow, write the result.
+source:
+  type: file
+  path: in/order.json
+flow: order
+sink:
+  type: file
+  path: out/order.json

--- a/notes/DEV_LOG.md
+++ b/notes/DEV_LOG.md
@@ -13,6 +13,27 @@ Newest entries on top. One entry per merged slice.
 
 ---
 
+## 2026-06-06 — run + pipelines (RFC 0002 slice 1)
+
+- What changed: Implemented `weavster run`. New CLI modules: `connectors.ts` (`Source`/`Sink`
+  with `file`/`stdin`/`stdout`), `pipeline.ts` (load + schema-validate `pipelines/<name>.yaml`,
+  resolve connectors + formats), `runner.ts` (`runPipelines` — load pipeline → load flow +
+  functions → source.read → parse → applyFlow → serialize → sink.write), and `commands/run.ts`.
+  Added `pipeline.schema.json`, extended `weavster validate` to check pipelines, added a
+  golden-path pipeline + a CI run smoke, and the Pipelines docs page. Decisions: `run` with no
+  name runs all; `stdin` requires explicit `format`; sink format defaults to the source format
+  (explicit/extension override); file sinks overwrite.
+- What I learned: The run path is almost entirely reuse — parse/serialize from the format packs,
+  `applyFlow` + the `_ts` function loader from before; the only genuinely new code is the I/O
+  connectors, which stay in the CLI so `@weavster/core` remains pure. `run` operates on cwd
+  (the positional is the pipeline name, not a path), unlike `validate`/`test` which take `[path]`
+  — so unit tests call `runPipelines(dir, name)` directly and the CI smoke `cd`s into the example.
+  Status prints to **stderr** so a `stdout` sink keeps stdout clean for piping. Cross-format
+  (e.g. JSON→XML) works because source format selects the parser and sink format the serializer,
+  but inherits the XML single-root-element limitation.
+- What is next: network connectors (REST/SFTP) on the same `Source`/`Sink` interface, then
+  revisit `compile` and the Rust/WASM runtime.
+
 ## 2026-06-06 — Fix npm README + finalize release workflow (0.0.3)
 
 - What changed: The npm page for `@weavster/cli` showed no README even though the tarball
@@ -28,6 +49,7 @@ Newest entries on top. One entry per merged slice.
   running in a dir without sources), then `npm publish` from that directory — which populates the
   per-version readme and still does OIDC.
 - What is next: tag `v0.0.3` to publish and confirm the README renders on npmjs.com.
+
 ## 2026-06-06 — Fix OIDC publish (drop registry-url)
 
 - What changed: Removed `registry-url` from the `setup-node` step in `release.yml`. The first

--- a/notes/DEV_LOG.md
+++ b/notes/DEV_LOG.md
@@ -33,20 +33,23 @@ Newest entries on top. One entry per merged slice.
 
 - What changed: Implemented `weavster run`. New CLI modules: `connectors.ts` (`Source`/`Sink`
   with `file`/`stdin`/`stdout`), `pipeline.ts` (load + schema-validate `pipelines/<name>.yaml`,
-  resolve connectors + formats), `runner.ts` (`runPipelines` — load pipeline → load flow +
-  functions → source.read → parse → applyFlow → serialize → sink.write), and `commands/run.ts`.
-  Added `pipeline.schema.json`, extended `weavster validate` to check pipelines, added a
-  golden-path pipeline + a CI run smoke, and the Pipelines docs page. Decisions: `run` with no
-  name runs all; `stdin` requires explicit `format`; sink format defaults to the source format
-  (explicit/extension override); file sinks overwrite.
-- What I learned: The run path is almost entirely reuse — parse/serialize from the format packs,
-  `applyFlow` + the `_ts` function loader from before; the only genuinely new code is the I/O
-  connectors, which stay in the CLI so `@weavster/core` remains pure. `run` operates on cwd
-  (the positional is the pipeline name, not a path), unlike `validate`/`test` which take `[path]`
-  — so unit tests call `runPipelines(dir, name)` directly and the CI smoke `cd`s into the example.
-  Status prints to **stderr** so a `stdout` sink keeps stdout clean for piping. Cross-format
-  (e.g. JSON→XML) works because source format selects the parser and sink format the serializer,
-  but inherits the XML single-root-element limitation.
+  resolve connectors + formats + a `bounded` flag), `runner.ts` (`runPipelines` — startup load,
+  then a streaming loop: for each document the source yields → parse → applyFlow → serialize →
+  sink.write), and `commands/run.ts`. Added `pipeline.schema.json`, extended `weavster validate`
+  to check pipelines, added a golden-path pipeline + a CI run smoke, and the Pipelines docs page.
+  Decisions: `run` with no name runs all; `stdin` requires explicit `format`; sink format
+  defaults to the source format (explicit/extension override); file sinks overwrite.
+- What I learned: The RFC was revised mid-flight to a **continuous/ESB** model, so `Source` is
+  `documents(): AsyncIterable<string>` rather than a single `read()` — a `file` yields once
+  (bounded), `stdin` is line-delimited and streams (unbounded), and the same loop drives both.
+  Errors split by phase: startup (load/source-open) aborts; per-document failures fail a bounded
+  source but are logged-and-skipped on a stream. The run path is otherwise pure reuse —
+  parse/serialize from the format packs, `applyFlow` + the `_ts` loader — and the I/O connectors
+  stay in the CLI so `@weavster/core` remains pure. `run` operates on cwd (the positional is the
+  pipeline name, not a path), so unit tests call `runPipelines(dir, name)` directly and the CI
+  smoke `cd`s into the example. Status prints to **stderr** so a `stdout` sink keeps stdout clean.
+  Cross-format (JSON→XML) works via source-parser / sink-serializer but inherits the XML
+  single-root limitation.
 - What is next: network connectors (REST/SFTP) on the same `Source`/`Sink` interface, then
   revisit `compile` and the Rust/WASM runtime.
 
@@ -65,6 +68,7 @@ Newest entries on top. One entry per merged slice.
   running in a dir without sources), then `npm publish` from that directory — which populates the
   per-version readme and still does OIDC.
 - What is next: tag `v0.0.3` to publish and confirm the README renders on npmjs.com.
+
 ## 2026-06-06 — Fix OIDC publish (drop registry-url)
 
 - What changed: Removed `registry-url` from the `setup-node` step in `release.yml`. The first

--- a/spec/schemas/pipeline.schema.json
+++ b/spec/schemas/pipeline.schema.json
@@ -1,0 +1,67 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://weavster.dev/schemas/pipeline.schema.json",
+  "title": "Weavster pipeline",
+  "description": "Schema for a Weavster pipeline file: a source, a flow, and a sink.",
+  "type": "object",
+  "required": ["source", "flow", "sink"],
+  "additionalProperties": false,
+  "properties": {
+    "source": { "$ref": "#/$defs/source" },
+    "flow": { "description": "Name of the flow in flows/.", "type": "string", "minLength": 1 },
+    "sink": { "$ref": "#/$defs/sink" }
+  },
+  "$defs": {
+    "format": { "enum": ["json", "xml"] },
+    "source": {
+      "oneOf": [
+        {
+          "description": "Read a local file (format inferred from the extension).",
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["type", "path"],
+          "properties": {
+            "type": { "const": "file" },
+            "path": { "type": "string", "minLength": 1 },
+            "format": { "$ref": "#/$defs/format" }
+          }
+        },
+        {
+          "description": "Read process stdin (format required — no extension to infer).",
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["type", "format"],
+          "properties": {
+            "type": { "const": "stdin" },
+            "format": { "$ref": "#/$defs/format" }
+          }
+        }
+      ]
+    },
+    "sink": {
+      "oneOf": [
+        {
+          "description": "Write a local file (format: extension, else the source format).",
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["type", "path"],
+          "properties": {
+            "type": { "const": "file" },
+            "path": { "type": "string", "minLength": 1 },
+            "format": { "$ref": "#/$defs/format" }
+          }
+        },
+        {
+          "description": "Write process stdout (format defaults to the source format).",
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["type"],
+          "properties": {
+            "type": { "const": "stdout" },
+            "format": { "$ref": "#/$defs/format" }
+          }
+        }
+      ]
+    }
+  }
+}

--- a/website/docs/cli.md
+++ b/website/docs/cli.md
@@ -7,8 +7,8 @@ title: CLI Reference
 
 The `weavster` CLI runs against a project directory containing a `weavster.yaml`.
 
-The planned commands are `init`, `validate`, `test`, `compile`, and `run`. Only the
-commands documented below are implemented today (`init`, `validate`, `test`).
+The planned commands are `init`, `validate`, `test`, `compile`, and `run`. Implemented
+today: `init`, `validate`, `test`, `run` (`compile` is still planned).
 
 ## `init`
 
@@ -97,7 +97,33 @@ A failing case prints a diff (`-` expected, `+` actual) and the command exits `1
 1/2 fixtures passed
 ```
 
+## `run`
+
+Run [pipelines](./pipelines.md) — read a source, transform with a flow, write a sink.
+
+```bash
+weavster run [name]
+```
+
+- `name` — a pipeline in `pipelines/`. Omit it to run every pipeline.
+
+Operates on the current directory. Each pipeline reads its `source`, runs its `flow`, and
+writes its `sink`; progress goes to stderr so a `stdout` sink stays pipeable:
+
+```text
+✓ order
+
+1/1 pipelines ran
+```
+
+A failing pipeline prints which stage failed and exits `1`:
+
+```text
+✗ order
+  no input file "in/order.json"
+```
+
 :::note
-The `weavster` binary is not yet published. From the tool repo, run a command
-during development with `pnpm --filter @weavster/cli dev <command> <path>`.
+Install the published CLI with `npm install -g @weavster/cli`. From the tool repo during
+development, run a command with `pnpm --filter @weavster/cli dev <command>`.
 :::

--- a/website/docs/cli.md
+++ b/website/docs/cli.md
@@ -107,16 +107,18 @@ weavster run [name]
 
 - `name` — a pipeline in `pipelines/`. Omit it to run every pipeline.
 
-Operates on the current directory. Each pipeline reads its `source`, runs its `flow`, and
-writes its `sink`; progress goes to stderr so a `stdout` sink stays pipeable:
+Operates on the current directory. A source yields a stream of documents and each is run
+through the flow and written to the sink (a `file` is one document; `stdin` is line-delimited
+and streams). Progress goes to stderr so a `stdout` sink stays pipeable:
 
 ```text
-✓ order
+✓ order (1 document)
 
 1/1 pipelines ran
 ```
 
-A failing pipeline prints which stage failed and exits `1`:
+A startup failure (bad pipeline, source won't open) — or, on a bounded `file` source, the
+document's own failure — exits `1`:
 
 ```text
 ✗ order

--- a/website/docs/pipelines.md
+++ b/website/docs/pipelines.md
@@ -45,6 +45,19 @@ sink: { type: stdout }
 
 (Network connectors such as REST and SFTP will land later on the same shape.)
 
+## How `run` works
+
+A source yields a **stream of documents**, and `run` processes each one as it arrives —
+parse → flow → serialize → sink — staying live until the source closes:
+
+- A **`file`** source is bounded: it yields the whole file as one document, then ends, so the
+  loop runs once and `run` exits.
+- A **`stdin`** source is unbounded and **line-delimited**: each non-empty line is one document,
+  processed as it arrives. `run` blocks for the next line and exits at end-of-stream. (Pipe
+  newline-delimited JSON: `cat orders.ndjson | weavster run orders`.)
+
+This is the seam for always-on connectors later (REST/SFTP/queues) — same loop, unbounded source.
+
 ## Formats
 
 The **source** format picks the parser, the **sink** format picks the serializer — so a
@@ -58,6 +71,18 @@ pipeline can convert formats (XML in, JSON out).
 
 A `file` sink overwrites its path. Converting to XML requires the document to have a single
 root element (see the [Format Packs](./formats.md) limitations).
+
+## Errors
+
+Errors are split by when they happen:
+
+- **Startup** (pipeline not found / schema-invalid, source fails to open) aborts the pipeline
+  before the loop and exits non-zero.
+- **Per-document** (parse, transform, or write failure for one document) is scoped to that
+  document. On a bounded `file` source that single failure fails the run; on an unbounded
+  stream it is logged and the loop continues to the next document.
+
+`run` reports which pipeline, which document, and which stage failed.
 
 ## Validation
 

--- a/website/docs/pipelines.md
+++ b/website/docs/pipelines.md
@@ -1,0 +1,65 @@
+---
+sidebar_position: 8
+title: Pipelines
+---
+
+# Pipelines
+
+A flow describes _how_ to transform a document; a **pipeline** describes _where the data comes
+from and goes_. `weavster run` executes pipelines: read a **source**, transform with a **flow**,
+write a **sink**.
+
+Pipelines live one-per-file in `pipelines/`, alongside `flows/` and `fixtures/`:
+
+```yaml
+# pipelines/order.yaml
+source:
+  type: file
+  path: in/order.json
+flow: order # flows/order.yaml
+sink:
+  type: file
+  path: out/order.json
+```
+
+```bash
+weavster run order   # run pipelines/order.yaml
+weavster run         # run every pipeline
+```
+
+## Connectors
+
+A `source` and `sink` each have a `type`:
+
+| Type     | As source          | As sink                     |
+| -------- | ------------------ | --------------------------- |
+| `file`   | read `path`        | write `path` (creates dirs) |
+| `stdin`  | read process stdin | —                           |
+| `stdout` | —                  | write process stdout        |
+
+```yaml
+source: { type: stdin, format: json }
+flow: order
+sink: { type: stdout }
+```
+
+(Network connectors such as REST and SFTP will land later on the same shape.)
+
+## Formats
+
+The **source** format picks the parser, the **sink** format picks the serializer — so a
+pipeline can convert formats (XML in, JSON out).
+
+- **Source `file`** — inferred from the path extension (`.json`/`.xml`); set `format:` to
+  override.
+- **Source `stdin`** — `format:` is required (no extension to infer).
+- **Sink** — defaults to the **source** format; a `file` sink with a recognized extension uses
+  that; an explicit `format:` always wins.
+
+A `file` sink overwrites its path. Converting to XML requires the document to have a single
+root element (see the [Format Packs](./formats.md) limitations).
+
+## Validation
+
+`weavster validate` checks every `pipelines/*.yaml` against the pipeline schema, alongside
+`weavster.yaml` and your flows.

--- a/website/sidebars.ts
+++ b/website/sidebars.ts
@@ -11,6 +11,7 @@ const sidebars: SidebarsConfig = {
     'dsl',
     'typescript',
     'testing',
+    'pipelines',
     'architecture',
     'contributing',
   ],

--- a/website/src/components/HomepageFeatures/index.tsx
+++ b/website/src/components/HomepageFeatures/index.tsx
@@ -61,8 +61,8 @@ export default function HomepageFeatures(): ReactNode {
     <section className={styles.features}>
       <div className="container">
         <div className="row">
-          {FeatureList.map((props, idx) => (
-            <Feature key={idx} {...props} />
+          {FeatureList.map((props) => (
+            <Feature key={props.title} {...props} />
           ))}
         </div>
       </div>


### PR DESCRIPTION
First slice of the "make it move data" phase ([RFC 0002](docs/rfcs/0002-run-pipelines.md)).

## Summary
- **`weavster run [name]`** — execute pipelines: read a **source**, transform with a **flow**, write a **sink**. No name → run all pipelines.
- **Pipelines** declared one-per-file in `pipelines/` (`source` + `flow` + `sink`), validated by `spec/schemas/pipeline.schema.json`. `weavster validate` now checks them too.
- **Connectors:** `file` + `stdin`/`stdout` (a small `Source`/`Sink` interface — network connectors slot in later).
- **Formats:** source format picks the parser; sink format (defaults to the source format; extension/explicit override) picks the serializer → pipelines can **convert formats**.
- **Core stays pure:** the run path reuses the format packs, `applyFlow`, and the `_ts` loader; only the I/O connectors are new (in the CLI).
- Golden-path pipeline + CI `run` smoke + a Pipelines docs page.

## Decisions (from discussion)
`run` with no name runs all; `stdin` requires explicit `format`; sink format defaults to source; file sinks overwrite. Status prints to **stderr** so a `stdout` sink stays pipeable.

## Test plan
- `pnpm test` → core 83 + cli 30 (+8: file→file, run-all, missing pipeline, missing source, format resolution, golden-path validate).
- `pnpm cli:build` + typecheck + `pnpm docs:build` clean.
- Smoke: `cd examples/golden-path && weavster run order` → writes `out/order.json`; output is gitignored.

## Next
Network connectors (REST/SFTP) on the same `Source`/`Sink` interface; then `compile` / the Rust runtime.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a runnable pipelines command to execute named or all pipelines as streamed source→flow→sink runs with JSON/XML format detection and bounded vs unbounded source semantics.

* **Documentation**
  * New Pipelines docs and updated CLI docs with run usage, examples, connector and error-handling semantics.

* **Tests**
  * End-to-end pipeline tests covering run behavior, format resolution, and validations; CI smoke now exercises the golden-path pipeline.

* **Chores**
  * Pipeline schema, example pipeline/data, and CI lint step added prior to tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->