### PR TITLE
chore: add Biome linter + CodeRabbit PR summary

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,66 @@
+# yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
+language: en-US
+reviews:
+  profile: chill
+  request_changes_workflow: false
+
+  # High-level summary lands in the PR description (not a walkthrough comment),
+  # replacing the `@coderabbitai summary` placeholder in PULL_REQUEST_TEMPLATE.md.
+  high_level_summary: true
+  high_level_summary_placeholder: '@coderabbitai summary'
+  high_level_summary_in_walkthrough: false
+
+  # `@coderabbitai` in a title gets replaced with a generated title.
+  auto_title_placeholder: '@coderabbitai'
+
+  review_status: true
+  commit_status: true
+  collapse_walkthrough: true
+  changed_files_summary: true
+  sequence_diagrams: true
+  related_issues: true
+  related_prs: true
+  suggested_labels: true
+  suggested_reviewers: true
+  poem: false
+  abort_on_close: true
+
+  auto_review:
+    enabled: true
+    auto_incremental_review: true
+    drafts: false
+
+  finishing_touches:
+    docstrings:
+      enabled: true
+    unit_tests:
+      enabled: true
+
+  # Linters relevant to a TypeScript/JS pnpm monorepo with Docusaurus docs.
+  # CodeRabbit auto-skips a tool when its config/target files are absent, so the
+  # rest are left at their defaults rather than enumerated here.
+  tools:
+    biome:
+      enabled: true
+    markdownlint:
+      enabled: true
+    yamllint:
+      enabled: true
+    actionlint:
+      enabled: true
+    gitleaks:
+      enabled: true
+    languagetool:
+      enabled: true
+      level: default
+    github-checks:
+      enabled: true
+
+chat:
+  auto_reply: true
+
+knowledge_base:
+  web_search:
+    enabled: true
+  code_guidelines:
+    enabled: true

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -22,3 +22,7 @@
 ## Dev log
 
 - [ ] `notes/DEV_LOG.md` updated
+
+---
+
+@coderabbitai summary

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   config and runs Biome on reviews.
 - `@coderabbitai summary` placeholder at the bottom of the PR template (under a `---`), which
   CodeRabbit replaces with a high-level summary in the PR description.
+- `.coderabbit.yaml` configuring CodeRabbit reviews: high-level summary in the PR description
+  (`high_level_summary_in_walkthrough: false`), `chill` profile, and the linters relevant to this
+  repo (Biome, markdownlint, yamllint, actionlint, gitleaks, languagetool).
 
 ## [0.0.3] - 2026-06-06
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### Added
+
+- Biome linter config (`biome.json`) plus `lint` / `lint:fix` scripts. Linter only — Prettier
+  still owns formatting (Biome's formatter and assist are disabled). CodeRabbit auto-detects the
+  config and runs Biome on reviews.
+
 ## [0.0.3] - 2026-06-06
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Biome linter config (`biome.json`) plus `lint` / `lint:fix` scripts. Linter only — Prettier
   still owns formatting (Biome's formatter and assist are disabled). CodeRabbit auto-detects the
   config and runs Biome on reviews.
+- `@coderabbitai summary` placeholder at the bottom of the PR template (under a `---`), which
+  CodeRabbit replaces with a high-level summary in the PR description.
 
 ## [0.0.3] - 2026-06-06
 

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ See the [Getting Started guide](https://docs.weavster.dev/getting-started) for t
   loaded via jiti) when the declarative DSL isn't enough. See
   [TypeScript Transforms](https://docs.weavster.dev/typescript).
 - Contribution rules ([`CONTRIBUTING.md`](CONTRIBUTING.md)) and PR template.
-- Editor/formatter config (`.editorconfig`, Prettier).
+- Editor/formatter config (`.editorconfig`, Prettier) and Biome linter (`biome.json`).
 - Dev log ([`notes/DEV_LOG.md`](notes/DEV_LOG.md)) and changelog
   ([`CHANGELOG.md`](CHANGELOG.md)).
 
@@ -80,6 +80,7 @@ pnpm docs:start     # run the docs site locally
 pnpm docs:build     # production build of the docs site
 pnpm test           # run all package test suites (core + cli)
 pnpm format         # format with Prettier
+pnpm lint           # lint with Biome
 
 # run a command against a project during development
 pnpm --filter @weavster/cli dev validate ./path/to/project

--- a/README.md
+++ b/README.md
@@ -63,9 +63,9 @@ See the [Getting Started guide](https://docs.weavster.dev/getting-started) for t
   [TypeScript Transforms](https://docs.weavster.dev/typescript).
 - Contribution rules ([`CONTRIBUTING.md`](CONTRIBUTING.md)) and PR template.
 - Editor/formatter config (`.editorconfig`, Prettier) and Biome linter (`biome.json`).
-- CodeRabbit reviews: the PR template ends with an `@coderabbitai summary` placeholder under a
-  `---`, which CodeRabbit replaces with a high-level summary of the PR (default behavior, no
-  `.coderabbit.yaml` required).
+- CodeRabbit reviews configured in `.coderabbit.yaml`: the high-level summary is written into the
+  PR description, replacing the `@coderabbitai summary` placeholder the PR template ends with
+  (under a `---`). The config also enables the Biome linter and other tools relevant to this repo.
 - Dev log ([`notes/DEV_LOG.md`](notes/DEV_LOG.md)) and changelog
   ([`CHANGELOG.md`](CHANGELOG.md)).
 

--- a/README.md
+++ b/README.md
@@ -63,6 +63,9 @@ See the [Getting Started guide](https://docs.weavster.dev/getting-started) for t
   [TypeScript Transforms](https://docs.weavster.dev/typescript).
 - Contribution rules ([`CONTRIBUTING.md`](CONTRIBUTING.md)) and PR template.
 - Editor/formatter config (`.editorconfig`, Prettier) and Biome linter (`biome.json`).
+- CodeRabbit reviews: the PR template ends with an `@coderabbitai summary` placeholder under a
+  `---`, which CodeRabbit replaces with a high-level summary of the PR (default behavior, no
+  `.coderabbit.yaml` required).
 - Dev log ([`notes/DEV_LOG.md`](notes/DEV_LOG.md)) and changelog
   ([`CHANGELOG.md`](CHANGELOG.md)).
 

--- a/biome.json
+++ b/biome.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "https://biomejs.dev/schemas/2.4.16/schema.json",
+  "vcs": {
+    "enabled": true,
+    "clientKind": "git",
+    "useIgnoreFile": true
+  },
+  "files": {
+    "includes": ["**", "!pnpm-lock.yaml"]
+  },
+  "formatter": {
+    "enabled": false
+  },
+  "assist": {
+    "enabled": false
+  },
+  "linter": {
+    "enabled": true,
+    "rules": {
+      "recommended": true
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -14,9 +14,12 @@
     "cli:link": "pnpm cli:build && cd cli && pnpm link --global",
     "test": "pnpm -r test",
     "format": "prettier --write .",
-    "format:check": "prettier --check ."
+    "format:check": "prettier --check .",
+    "lint": "biome lint .",
+    "lint:fix": "biome lint --write ."
   },
   "devDependencies": {
+    "@biomejs/biome": "^2.4.16",
     "prettier": "^3.3.3"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     devDependencies:
+      '@biomejs/biome':
+        specifier: ^2.4.16
+        version: 2.4.16
       prettier:
         specifier: ^3.3.3
         version: 3.8.3
@@ -768,6 +771,59 @@ packages:
   '@babel/types@7.29.7':
     resolution: {integrity: sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==}
     engines: {node: '>=6.9.0'}
+
+  '@biomejs/biome@2.4.16':
+    resolution: {integrity: sha512-x9ajFh1zChVybCiM3TN6OD4phAqLgtPZjFrZF+aTMYCPjwBO+k529TX7PPsAqtGNLeV4UgzwQnowEgS7bGmzcA==}
+    engines: {node: '>=14.21.3'}
+    hasBin: true
+
+  '@biomejs/cli-darwin-arm64@2.4.16':
+    resolution: {integrity: sha512-wxPvu4XOA85YJk9ixSWUmq/QBHbid85BISbOAqqBM/5xQpPk9ayjk5375tOlSC0BeCwNSbPFafQBm+vBumXq0A==}
+    engines: {node: '>=14.21.3'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@biomejs/cli-darwin-x64@2.4.16':
+    resolution: {integrity: sha512-xFCqGPwYusQJp4N4NJLi1XJiZqjwFdjhT+KqtNy+Ug3qgfczqnTa6MSDvxJF6TkuDLoYJItMapz6tAf7kCekFw==}
+    engines: {node: '>=14.21.3'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@biomejs/cli-linux-arm64-musl@2.4.16':
+    resolution: {integrity: sha512-oYxnW0ARfJkr72ezzF2OR8N/rtkgLUQeYtF8cFhVswbknHxtTcmzSsanVJP8yQKnGpGpc2ck6c5zLvHahL6Cbg==}
+    engines: {node: '>=14.21.3'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@biomejs/cli-linux-arm64@2.4.16':
+    resolution: {integrity: sha512-2kFb4//jxfZaP6D+Rj5VkHkxgyD9EoRAVBEQb8PKRv+s4NO2zYNJKXFaJmK1CmhufJOWEfpHKaRbOja7qjmdhQ==}
+    engines: {node: '>=14.21.3'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@biomejs/cli-linux-x64-musl@2.4.16':
+    resolution: {integrity: sha512-iHDS+MCM65DPqWGu+ECC3uoALyj2H7F4nVUPxIPjz/PIl94EUu+EDfGZDzFP+NY1EOPVt9NQvwFqq7HdMmowdg==}
+    engines: {node: '>=14.21.3'}
+    cpu: [x64]
+    os: [linux]
+
+  '@biomejs/cli-linux-x64@2.4.16':
+    resolution: {integrity: sha512-NbcBbi/nJqn5baae6wqRXdS7Gadf2uRpehSh6vMSYpG8OhkXl/Xg8aorWrJ+9VWqAT5ml90alLvorkpMW0nBwQ==}
+    engines: {node: '>=14.21.3'}
+    cpu: [x64]
+    os: [linux]
+
+  '@biomejs/cli-win32-arm64@2.4.16':
+    resolution: {integrity: sha512-0rgImMsNb5v/chhkIFe3wu7PEFClS6RBAYUijGL9UsYN3PanSaoK24HSSuSJb1pYbYYVjzAyZTl3gtjJ84BM8A==}
+    engines: {node: '>=14.21.3'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@biomejs/cli-win32-x64@2.4.16':
+    resolution: {integrity: sha512-Kp85jgoBHa05gix6UIRjfCDiUV3w/8VIdZ247VyyO2gEjaw12WEVhdIjlxp/AMzXxqxQwbxNTDVZ3Mwd2RG5rw==}
+    engines: {node: '>=14.21.3'}
+    cpu: [x64]
+    os: [win32]
 
   '@colors/colors@1.5.0':
     resolution: {integrity: sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==}
@@ -7278,6 +7334,41 @@ snapshots:
     dependencies:
       '@babel/helper-string-parser': 7.29.7
       '@babel/helper-validator-identifier': 7.29.7
+
+  '@biomejs/biome@2.4.16':
+    optionalDependencies:
+      '@biomejs/cli-darwin-arm64': 2.4.16
+      '@biomejs/cli-darwin-x64': 2.4.16
+      '@biomejs/cli-linux-arm64': 2.4.16
+      '@biomejs/cli-linux-arm64-musl': 2.4.16
+      '@biomejs/cli-linux-x64': 2.4.16
+      '@biomejs/cli-linux-x64-musl': 2.4.16
+      '@biomejs/cli-win32-arm64': 2.4.16
+      '@biomejs/cli-win32-x64': 2.4.16
+
+  '@biomejs/cli-darwin-arm64@2.4.16':
+    optional: true
+
+  '@biomejs/cli-darwin-x64@2.4.16':
+    optional: true
+
+  '@biomejs/cli-linux-arm64-musl@2.4.16':
+    optional: true
+
+  '@biomejs/cli-linux-arm64@2.4.16':
+    optional: true
+
+  '@biomejs/cli-linux-x64-musl@2.4.16':
+    optional: true
+
+  '@biomejs/cli-linux-x64@2.4.16':
+    optional: true
+
+  '@biomejs/cli-win32-arm64@2.4.16':
+    optional: true
+
+  '@biomejs/cli-win32-x64@2.4.16':
+    optional: true
 
   '@colors/colors@1.5.0':
     optional: true


### PR DESCRIPTION
## What changed

Wire up Biome as a linter for CodeRabbit, configure CodeRabbit reviews, and make CodeRabbit inject its high-level summary into PR descriptions.

- **Biome (linter only):** add `biome.json` with the linter on and the formatter + assist disabled — Prettier still owns formatting. Adds `@biomejs/biome` devDependency and `lint` / `lint:fix` scripts.
- **CodeRabbit config:** add `.coderabbit.yaml` (chill profile; high-level summary written into the PR description, not a walkthrough comment; Biome + markdownlint/yamllint/actionlint/gitleaks/languagetool enabled).
- **PR summary:** the PR template ends with a summary placeholder under a `---` that CodeRabbit replaces with the generated summary.
- README + CHANGELOG updated.

## Notes

- Biome schema pinned to `2.4.16` (latest). CodeRabbit skips Biome if the config schema version exceeds its runner's Biome version — lower the schema if Biome output is missing from reviews.
- `biome lint .` runs clean as config (1601 files; node_modules excluded via .gitignore). It surfaces 5 pre-existing lint issues in existing code — advisory, not fixed in this PR.

---

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Integrated Biome linter for code quality checks with new `lint` and `lint:fix` commands
  * Configured CodeRabbit for automated pull request reviews with AI-powered summaries

* **Documentation**
  * Updated README with linting setup instructions
  * Updated CHANGELOG documenting new linting and review tooling configuration
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)