### PR TITLE
ci: post Claude review tracking comment on every PR

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: read
+      pull-requests: write
       issues: read
       id-token: write
 

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -36,9 +36,6 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          # Post a tracking comment on every PR so the review is visible even
-          # when there are no inline findings (otherwise a clean run is silent).
-          track_progress: 'true'
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
           plugins: 'code-review@claude-code-plugins'
           prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -36,6 +36,9 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          # Post a tracking comment on every PR so the review is visible even
+          # when there are no inline findings (otherwise a clean run is silent).
+          track_progress: 'true'
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
           plugins: 'code-review@claude-code-plugins'
           prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Changed
 
+- Claude Code Review now runs with `track_progress: true`, so it posts a visible tracking
+  comment on every PR instead of staying silent when a clean diff produces no inline findings.
 - Add `@biomejs/biome` as a dev dependency so `pnpm lint` runs locally, wire it into CI, and
   clear the findings: drop unused imports, simplify redundant boolean casts, give the escape-hatch
   test functions real types, use a stable React key in the docs homepage, and disable

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Changed
 
+- Grants the workflow `pull-requests: write` (was `read`), required to post the comment.
 - Add `@biomejs/biome` as a dev dependency so `pnpm lint` runs locally, wire it into CI, and
   clear the findings: drop unused imports, simplify redundant boolean casts, give the escape-hatch
   test functions real types, use a stable React key in the docs homepage, and disable

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,6 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Changed
 
-- Claude Code Review now runs with `track_progress: true`, so it posts a visible tracking
-  comment on every PR instead of staying silent when a clean diff produces no inline findings.
 - Add `@biomejs/biome` as a dev dependency so `pnpm lint` runs locally, wire it into CI, and
   clear the findings: drop unused imports, simplify redundant boolean casts, give the escape-hatch
   test functions real types, use a stable React key in the docs homepage, and disable


### PR DESCRIPTION
## What

Set `track_progress: true` on `claude-code-action@v1` in `claude-code-review.yml`.

## Why

On PR #76 (a one-line dictionary change) the Claude review ran successfully but posted nothing — the `/code-review` plugin only emits inline comments for findings, so a clean diff is silent and looks like no review ran. `track_progress: true` forces a visible tracking comment on every PR (applies to the `opened`/`synchronize`/`ready_for_review`/`reopened` events this workflow already triggers on).

## Verified

- Confirmed `track_progress` is a valid `claude-code-action@v1` input.
- Workflow YAML parses.
- This PR itself should now get a visible Claude tracking comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated code review workflow so the review action can post visible review comments and other PR artifacts during execution, improving automated review visibility on pull requests.

* **Documentation**
  * Updated changelog to note the workflow’s new behavior allowing review comments and artifacts to appear alongside PRs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->