### PR TITLE
ci: make Claude review always comment on the PR

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -38,6 +38,25 @@ jobs:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
           plugins: 'code-review@claude-code-plugins'
-          prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'
+          # track_progress posts (and updates) a tracking comment on the PR, so a
+          # clean review is still visible instead of running silently.
+          track_progress: 'true'
+          # Run the code-review plugin, then always leave a top-level summary on
+          # the PR (even with no findings). Inline findings go on the lines.
+          prompt: |
+            REPO: ${{ github.repository }}
+            PR NUMBER: ${{ github.event.pull_request.number }}
+
+            Review this pull request by running the code-review plugin:
+            /code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}
+
+            Then post a concise top-level summary comment on the PR with
+            `gh pr comment` — even if there are no issues, say so. Use
+            mcp__github_inline_comment__create_inline_comment (with confirmed: true)
+            for specific line-level findings. Only post GitHub comments; do not
+            return the review as a chat message.
+          # Tools the review needs to read the diff and post comments.
+          claude_args: |
+            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*)"
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ### Changed
 
 - Grants the workflow `pull-requests: write` (was `read`), required to post the comment.
+- Claude Code Review now runs the `code-review` plugin with `track_progress: true` and posts a
+  top-level PR summary comment (via `gh pr comment`) plus inline findings, so every PR gets a
+  visible review even when the diff is clean. Follows the action's "Automatic PR Code Review"
+  recipe (`claude_args` allowlists the comment/diff tools).
 - Add `@biomejs/biome` as a dev dependency so `pnpm lint` runs locally, wire it into CI, and
   clear the findings: drop unused imports, simplify redundant boolean casts, give the escape-hatch
   test functions real types, use a stable React key in the docs homepage, and disable


### PR DESCRIPTION
## What

Update `claude-code-review.yml` so the Claude review **always leaves a visible comment**, following the action's [Automatic PR Code Review](https://github.com/anthropics/claude-code-action/blob/main/docs/solutions.md#automatic-pr-code-review) recipe — while keeping the `code-review` plugin for the actual review.

Changes to the `claude-code-action` step:
- **`track_progress: 'true'`** — posts/updates a tracking comment (visible even on a clean diff).
- **Prompt** runs `/code-review:code-review` (plugin), then posts a top-level summary via `gh pr comment` and inline findings via the inline-comment tool. Says so explicitly even when there are no issues.
- **`claude_args`** allowlists the comment/diff tools (`gh pr comment`, `gh pr diff`, `gh pr view`, inline-comment MCP).

## Why

Prior runs were silent on trivial PRs (e.g. #76): the plugin only buffers inline comments, so a clean diff produced `No buffered inline comments` and nothing posted. The earlier `pull-requests: write` bump didn't help — Claude posts via its GitHub App (OIDC) token, not the workflow token. `track_progress` + an explicit summary comment is the real fix.

## Note on testing

This change does **not** self-test on this PR: for `pull_request` events GitHub runs the workflow from the **base branch (main)**, so #78's own review uses main's current (unfixed) workflow. It takes effect **after merge** — the next PR, or any new push to an open PR, will get the visible Claude comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced code review workflow to enable progress tracking and improved feedback visibility on pull requests.
  * Configured the workflow to post concise summary comments and use GitHub's inline commenting for specific findings.

* **Documentation**
  * Updated changelog documenting improved code review workflow behavior and progress tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->