### PR TITLE
feat(engine): engine core — manifest, wasmtime host, run loop (E3)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,6 +48,13 @@ jobs:
 
       - run: pnpm --filter @weavster/cli typecheck
 
+      # Pre-download the Javy binary once. javy-cli fetches it on first use, and
+      # vitest runs the compile test files in parallel workers — without this
+      # they race the same download and one captures the "Downloading…" notice
+      # as a compile error (flaky failure).
+      - name: warm the Javy binary
+        run: pnpm --filter @weavster/cli exec javy --version
+
       # Runs `coverage` in every workspace package that defines it. New JS/TS
       # packages (e.g. the UI) are picked up automatically once they add a
       # `coverage` script — no change needed here. (Lint runs in the `quality`

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,6 +115,27 @@ jobs:
         name: clippy
         run: cargo clippy --workspace --all-targets --locked -- -D warnings
 
+      # The artifact-driven engine tests (tests/artifact.rs) self-skip unless a
+      # compiled golden-path artifact exists, and only the TS toolchain can
+      # produce one. Build it here so coverage reflects the wasm host and run
+      # loop, not just the manifest-failure paths. This is the only place Node
+      # touches the engine — its build and image stay Node-free.
+      - if: steps.detect.outputs.present == 'true'
+        uses: pnpm/action-setup@v4
+
+      - if: steps.detect.outputs.present == 'true'
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - if: steps.detect.outputs.present == 'true'
+        name: compile the golden-path artifact (for engine tests)
+        run: |
+          pnpm install --frozen-lockfile
+          pnpm --filter @weavster/core build
+          pnpm --filter @weavster/cli dev compile "$GITHUB_WORKSPACE/examples/golden-path"
+
       - if: steps.detect.outputs.present == 'true'
         uses: taiki-e/install-action@v2
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,20 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Added
 
+- Implement the engine core (Engine Plan E3 / RFC 0003 slice 3): `weavster-engine <artifact-dir>`
+  runs a compiled artifact end-to-end. The engine loads and validates `manifest.json` (refusing
+  unknown `manifestVersion`/`abiVersion` or connector types loudly), JIT-compiles each flow's
+  `flows/<flow>.wasm` once at startup, and drives every pipeline concurrently — each pipeline a
+  FIFO concurrency-1 loop (`source → transform → sink`, documents in input order) over the Javy
+  stdin/stdout envelope ABI from `docs/ARTIFACT_SPEC.md`. Per the **S4** spike
+  (`engine/examples/s4_lifecycle.rs`), each document gets a fresh wasmtime store + instance
+  (~1.3 ms) — a Javy module is a WASI command, so instances cannot be pooled, and module
+  compilation (~220 ms) is the once-per-flow cost. Resource limits ship with `TODO(config)`
+  defaults — a 256 MB memory cap and a 10 s epoch wall-clock deadline, so a runaway `_ts`
+  (infinite loop) traps instead of hanging. Startup errors abort non-zero; a poison document
+  fails the (bounded) run with a structured JSON log line carrying pipeline/document/stage.
+  Integration tests cover manifest failures without an artifact and self-skip the wasm-driven
+  cases when the golden artifact hasn't been compiled.
 - Add `weavster compile` (Engine Plan E2): compile a project's enabled pipelines into a portable
   artifact (`manifest.json` + `flows/<flow>.wasm`) the Rust engine (E3) can run. Adds a
   `pipelines:` switchboard to `weavster.yaml` (each entry a `{name, enabled}`; `enabled` defaults

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,5 +3,2544 @@
 version = 4
 
 [[package]]
+name = "addr2line"
+version = "0.24.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dfbe277e56a376000877090da837660b4427aad530e3028d44e0bffe4f89a1c1"
+dependencies = [
+ "gimli",
+]
+
+[[package]]
+name = "allocator-api2"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
+
+[[package]]
+name = "ambient-authority"
+version = "0.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9d4ee0d472d1cd2e28c97dfa124b3d8d992e10eb0a035f33f5d12e3a177ba3b"
+
+[[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "anyhow"
+version = "1.0.102"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+
+[[package]]
+name = "ar_archive_writer"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7eb93bbb63b9c227414f6eb3a0adfddca591a8ce1e9b60661bb08969b87e340b"
+dependencies = [
+ "object 0.37.3",
+]
+
+[[package]]
+name = "arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
+
+[[package]]
+name = "async-trait"
+version = "0.1.89"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "bitflags"
+version = "2.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
+
+[[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
+name = "bumpalo"
+version = "3.20.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
+dependencies = [
+ "allocator-api2",
+]
+
+[[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+
+[[package]]
+name = "bytes"
+version = "1.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
+
+[[package]]
+name = "cap-fs-ext"
+version = "3.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5528f85b1e134ae811704e41ef80930f56e795923f866813255bc342cc20654"
+dependencies = [
+ "cap-primitives",
+ "cap-std",
+ "io-lifetimes",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "cap-net-ext"
+version = "3.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20a158160765c6a7d0d8c072a53d772e4cb243f38b04bfcf6b4939cfbe7482e7"
+dependencies = [
+ "cap-primitives",
+ "cap-std",
+ "rustix 1.1.4",
+ "smallvec",
+]
+
+[[package]]
+name = "cap-primitives"
+version = "3.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6cf3aea8a5081171859ef57bc1606b1df6999df4f1110f8eef68b30098d1d3a"
+dependencies = [
+ "ambient-authority",
+ "fs-set-times",
+ "io-extras",
+ "io-lifetimes",
+ "ipnet",
+ "maybe-owned",
+ "rustix 1.1.4",
+ "rustix-linux-procfs",
+ "windows-sys 0.59.0",
+ "winx",
+]
+
+[[package]]
+name = "cap-rand"
+version = "3.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8144c22e24bbcf26ade86cb6501a0916c46b7e4787abdb0045a467eb1645a1d"
+dependencies = [
+ "ambient-authority",
+ "rand",
+]
+
+[[package]]
+name = "cap-std"
+version = "3.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6dc3090992a735d23219de5c204927163d922f42f575a0189b005c62d37549a"
+dependencies = [
+ "cap-primitives",
+ "io-extras",
+ "io-lifetimes",
+ "rustix 1.1.4",
+]
+
+[[package]]
+name = "cap-time-ext"
+version = "3.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "def102506ce40c11710a9b16e614af0cde8e76ae51b1f48c04b8d79f4b671a80"
+dependencies = [
+ "ambient-authority",
+ "cap-primitives",
+ "iana-time-zone",
+ "once_cell",
+ "rustix 1.1.4",
+ "winx",
+]
+
+[[package]]
+name = "cc"
+version = "1.2.63"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "556e016178bb5662a08681bbe0f00f8e17631781a4dfc8c45e466e4b185ec27f"
+dependencies = [
+ "find-msvc-tools",
+ "jobserver",
+ "libc",
+ "shlex",
+]
+
+[[package]]
+name = "cfg-if"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "cobs"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fa961b519f0b462e3a3b4a34b64d119eeaca1d59af726fe450bbba07a9fc0a1"
+dependencies = [
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
+name = "cpp_demangle"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2bb79cb74d735044c972aae58ed0aaa9a837e85b01106a54c39e42e97f62253"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
+name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "cranelift-assembler-x64"
+version = "0.121.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ce81edaca6167d1f78da026afa92d7ff957a80aa82a79076e11cd34cde20165"
+dependencies = [
+ "cranelift-assembler-x64-meta",
+]
+
+[[package]]
+name = "cranelift-assembler-x64-meta"
+version = "0.121.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d0d51e12f958551165969c6e8767e1e461729f6c1ccae923b0ba1d5cbcbbbf8"
+dependencies = [
+ "cranelift-srcgen",
+]
+
+[[package]]
+name = "cranelift-bforest"
+version = "0.121.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41294c755094d2c8a514cea903039742474423f2e91601332eab5f4094f76333"
+dependencies = [
+ "cranelift-entity",
+]
+
+[[package]]
+name = "cranelift-bitset"
+version = "0.121.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebb6f5d0df5bd0d02c63ec48e8f2e38a176b123f59e084f22caf89a0d0593e7e"
+dependencies = [
+ "serde",
+ "serde_derive",
+]
+
+[[package]]
+name = "cranelift-codegen"
+version = "0.121.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e543cdb278b7c15f739021cf880ee1808c68fa2402febb87edb9307f552c8fec"
+dependencies = [
+ "bumpalo",
+ "cranelift-assembler-x64",
+ "cranelift-bforest",
+ "cranelift-bitset",
+ "cranelift-codegen-meta",
+ "cranelift-codegen-shared",
+ "cranelift-control",
+ "cranelift-entity",
+ "cranelift-isle",
+ "gimli",
+ "hashbrown 0.15.5",
+ "log",
+ "pulley-interpreter",
+ "regalloc2",
+ "rustc-hash",
+ "serde",
+ "smallvec",
+ "target-lexicon",
+ "wasmtime-math",
+]
+
+[[package]]
+name = "cranelift-codegen-meta"
+version = "0.121.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f979c75cfd712dbc754799dfe4a4d0db7a51defc2e36d006b27a8a63e018eece"
+dependencies = [
+ "cranelift-assembler-x64-meta",
+ "cranelift-codegen-shared",
+ "cranelift-srcgen",
+ "pulley-interpreter",
+]
+
+[[package]]
+name = "cranelift-codegen-shared"
+version = "0.121.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2f36e74ba4033490587a47952f74390cb7d4f1fc1fa28ace50564e491f1e38f"
+
+[[package]]
+name = "cranelift-control"
+version = "0.121.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6671962c7d65b9a7ad038cd92da6784744d8a9ecf8ded8bb9a1f7046dbe2ccf"
+dependencies = [
+ "arbitrary",
+]
+
+[[package]]
+name = "cranelift-entity"
+version = "0.121.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee832f8329fa87c5df6c1d64a8506a58031e6f8a190d9b21b1900272a4dbb47d"
+dependencies = [
+ "cranelift-bitset",
+ "serde",
+ "serde_derive",
+]
+
+[[package]]
+name = "cranelift-frontend"
+version = "0.121.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f7bc17aa3277214eab4b63a03544b1b46962154012b751c9f14c2a5419c6471"
+dependencies = [
+ "cranelift-codegen",
+ "log",
+ "smallvec",
+ "target-lexicon",
+]
+
+[[package]]
+name = "cranelift-isle"
+version = "0.121.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cff02dcecae2e7e9c61b713f1fb46eabecdca9f55b49f99859ceb1a3e7f4a9cb"
+
+[[package]]
+name = "cranelift-native"
+version = "0.121.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90f76fd681f35bdf17be9c3e516b9acc0c7bd61b81faf95496decd8e0000979c"
+dependencies = [
+ "cranelift-codegen",
+ "libc",
+ "target-lexicon",
+]
+
+[[package]]
+name = "cranelift-srcgen"
+version = "0.121.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c3d9071bc5ee5573e723d9d84a45b7025a29e8f2c5ad81b3b9d0293129541d9"
+
+[[package]]
+name = "crc32fast"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "crypto-common"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
+
+[[package]]
+name = "debugid"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef552e6f588e446098f6ba40d89ac146c8c7b64aade83c051ee00bb5d2bc18d"
+dependencies = [
+ "uuid",
+]
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
+]
+
+[[package]]
+name = "directories-next"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "339ee130d97a610ea5a5872d2bbb130fdf68884ff09d3028b81bec8a1ac23bbc"
+dependencies = [
+ "cfg-if",
+ "dirs-sys-next",
+]
+
+[[package]]
+name = "dirs-sys-next"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ebda144c4fe02d1f7ea1a7d9641b6fc6b580adcfa024ae48797ecdeb6825b4d"
+dependencies = [
+ "libc",
+ "redox_users",
+ "winapi",
+]
+
+[[package]]
+name = "displaydoc"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "either"
+version = "1.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
+
+[[package]]
+name = "embedded-io"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef1a6892d9eef45c8fa6b9e0086428a2cca8491aca8f787c534a3d6d0bcb3ced"
+
+[[package]]
+name = "embedded-io"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edd0f118536f44f5ccd48bcb8b111bdc3de888b58c74639dfb034a357d0f206d"
+
+[[package]]
+name = "encoding_rs"
+version = "0.8.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
+name = "equivalent"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
+name = "errno"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
+dependencies = [
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "fallible-iterator"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
+
+[[package]]
+name = "fd-lock"
+version = "4.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ce92ff622d6dadf7349484f42c93271a0d49b7cc4d466a936405bacbe10aa78"
+dependencies = [
+ "cfg-if",
+ "rustix 1.1.4",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "find-msvc-tools"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "form_urlencoded"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
+dependencies = [
+ "percent-encoding",
+]
+
+[[package]]
+name = "fs-set-times"
+version = "0.20.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94e7099f6313ecacbe1256e8ff9d617b75d1bcb16a6fddef94866d225a01a14a"
+dependencies = [
+ "io-lifetimes",
+ "rustix 1.1.4",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "futures"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-channel"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+]
+
+[[package]]
+name = "futures-core"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+
+[[package]]
+name = "futures-io"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
+
+[[package]]
+name = "futures-sink"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
+
+[[package]]
+name = "futures-task"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
+
+[[package]]
+name = "futures-util"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+ "futures-task",
+ "pin-project-lite",
+ "slab",
+]
+
+[[package]]
+name = "fxhash"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c31b6d751ae2c7f11320402d34e41349dd1016f8d5d45e48c4312bc8625af50c"
+dependencies = [
+ "byteorder",
+]
+
+[[package]]
+name = "fxprof-processed-profile"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27d12c0aed7f1e24276a241aadc4cb8ea9f83000f34bc062b7cc2d51e3b0fabd"
+dependencies = [
+ "bitflags",
+ "debugid",
+ "fxhash",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
+ "wasip2",
+]
+
+[[package]]
+name = "gimli"
+version = "0.31.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
+dependencies = [
+ "fallible-iterator",
+ "indexmap",
+ "stable_deref_trait",
+]
+
+[[package]]
+name = "glob"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
+
+[[package]]
+name = "hashbrown"
+version = "0.15.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+dependencies = [
+ "foldhash",
+ "serde",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+
+[[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "iana-time-zone"
+version = "0.1.65"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e31bc9ad994ba00e440a8aa5c9ef0ec67d5cb5e5cb0cc7f8b744a35b389cc470"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "log",
+ "wasm-bindgen",
+ "windows-core",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
+]
+
+[[package]]
+name = "icu_collections"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c6b649701667bbe825c3b7e6388cb521c23d88644678e83c0c4d0a621a34b43"
+dependencies = [
+ "displaydoc",
+ "potential_utf",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locale_core"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edba7861004dd3714265b4db54a3c390e880ab658fec5f7db895fae2046b5bb6"
+dependencies = [
+ "displaydoc",
+ "litemap",
+ "tinystr",
+ "writeable",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f6c8828b67bf8908d82127b2054ea1b4427ff0230ee9141c54251934ab1b599"
+dependencies = [
+ "icu_collections",
+ "icu_normalizer_data",
+ "icu_properties",
+ "icu_provider",
+ "smallvec",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer_data"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7aedcccd01fc5fe81e6b489c15b247b8b0690feb23304303a9e560f37efc560a"
+
+[[package]]
+name = "icu_properties"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "020bfc02fe870ec3a66d93e677ccca0562506e5872c650f893269e08615d74ec"
+dependencies = [
+ "icu_collections",
+ "icu_locale_core",
+ "icu_properties_data",
+ "icu_provider",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_properties_data"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "616c294cf8d725c6afcd8f55abc17c56464ef6211f9ed59cccffe534129c77af"
+
+[[package]]
+name = "icu_provider"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85962cf0ce02e1e0a629cc34e7ca3e373ce20dda4c4d7294bbd0bf1fdb59e614"
+dependencies = [
+ "displaydoc",
+ "icu_locale_core",
+ "writeable",
+ "yoke",
+ "zerofrom",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "id-arena"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
+
+[[package]]
+name = "idna"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de"
+dependencies = [
+ "idna_adapter",
+ "smallvec",
+ "utf8_iter",
+]
+
+[[package]]
+name = "idna_adapter"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
+dependencies = [
+ "icu_normalizer",
+ "icu_properties",
+]
+
+[[package]]
+name = "indexmap"
+version = "2.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
+dependencies = [
+ "equivalent",
+ "hashbrown 0.17.1",
+ "serde",
+ "serde_core",
+]
+
+[[package]]
+name = "io-extras"
+version = "0.18.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2285ddfe3054097ef4b2fe909ef8c3bcd1ea52a8f0d274416caebeef39f04a65"
+dependencies = [
+ "io-lifetimes",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "io-lifetimes"
+version = "2.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06432fb54d3be7964ecd3649233cddf80db2832f47fec34c01f65b3d9d774983"
+
+[[package]]
+name = "ipnet"
+version = "2.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
+
+[[package]]
+name = "itertools"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itoa"
+version = "1.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
+
+[[package]]
+name = "ittapi"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b996fe614c41395cdaedf3cf408a9534851090959d90d54a535f675550b64b1"
+dependencies = [
+ "anyhow",
+ "ittapi-sys",
+ "log",
+]
+
+[[package]]
+name = "ittapi-sys"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52f5385394064fa2c886205dba02598013ce83d3e92d33dbdc0c52fe0e7bf4fc"
+dependencies = [
+ "cc",
+]
+
+[[package]]
+name = "jobserver"
+version = "0.1.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
+dependencies = [
+ "getrandom 0.3.4",
+ "libc",
+]
+
+[[package]]
+name = "js-sys"
+version = "0.3.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2025f20d7a4fa7785846e7b63d10a76d3f1cee98ee5cb79ea59703f95e42162"
+dependencies = [
+ "cfg-if",
+ "futures-util",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "leb128"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6cc46bac87ef8093eed6f272babb833b6443374399985ac8ed28471ee0918545"
+
+[[package]]
+name = "leb128fmt"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
+
+[[package]]
+name = "libc"
+version = "0.2.186"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
+
+[[package]]
+name = "libm"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
+
+[[package]]
+name = "libredox"
+version = "0.1.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f02ab6bace2054fb888a3c16f990117b579d14a3088e472d63c6011fa185c9d3"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.4.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
+
+[[package]]
+name = "litemap"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
+
+[[package]]
+name = "log"
+version = "0.4.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "953f07c43838f8e6f9758cab68bf5bed85465e7587ebe0b823f1bcd81978ad3a"
+
+[[package]]
+name = "mach2"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d640282b302c0bb0a2a8e0233ead9035e3bed871f0b7e81fe4a1ec829765db44"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "maybe-owned"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4facc753ae494aeb6e3c22f839b158aebd4f9270f55cd3c79906c45476c47ab4"
+
+[[package]]
+name = "memchr"
+version = "2.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b947ae49db0d222b1dbc6b113ce7248a3fc3a6ca21b696717bfc000ba4484d8"
+
+[[package]]
+name = "memfd"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad38eb12aea514a0466ea40a80fd8cc83637065948eb4a426e4aa46261175227"
+dependencies = [
+ "rustix 1.1.4",
+]
+
+[[package]]
+name = "mio"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02bd0af71c67b473010cbbc60715ee815645a4dc942899111f494b4b737d6fda"
+dependencies = [
+ "libc",
+ "wasi",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "object"
+version = "0.36.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62948e14d923ea95ea2c7c86c71013138b66525b86bdc08d2dcc262bdb497b87"
+dependencies = [
+ "crc32fast",
+ "hashbrown 0.15.5",
+ "indexmap",
+ "memchr",
+]
+
+[[package]]
+name = "object"
+version = "0.37.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff76201f031d8863c38aa7f905eca4f53abbfa15f609db4277d44cd8938f33fe"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "once_cell"
+version = "1.21.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+
+[[package]]
+name = "percent-encoding"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
+
+[[package]]
+name = "pkg-config"
+version = "0.3.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
+
+[[package]]
+name = "postcard"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6764c3b5dd454e283a30e6dfe78e9b31096d9e32036b5d1eaac7a6119ccb9a24"
+dependencies = [
+ "cobs",
+ "embedded-io 0.4.0",
+ "embedded-io 0.6.1",
+ "serde",
+]
+
+[[package]]
+name = "potential_utf"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
+dependencies = [
+ "zerovec",
+]
+
+[[package]]
+name = "ppv-lite86"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy",
+]
+
+[[package]]
+name = "proc-macro2"
+version = "1.0.106"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "psm"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "645dbe486e346d9b5de3ef16ede18c26e6c70ad97418f4874b8b1889d6e761ea"
+dependencies = [
+ "ar_archive_writer",
+ "cc",
+]
+
+[[package]]
+name = "pulley-interpreter"
+version = "34.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be14280b69a9cbb6ada02a7aa5f7b3f1b72d1043b5bc9336990b700525dea6e3"
+dependencies = [
+ "cranelift-bitset",
+ "log",
+ "pulley-macros",
+ "wasmtime-math",
+]
+
+[[package]]
+name = "pulley-macros"
+version = "34.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "076f1be746801280af4c96c4407b5fd1d09cfa53ab27ba0ac7dd8f207e7bbf83"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "quote"
+version = "1.0.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
+dependencies = [
+ "proc-macro2",
+]
+
+[[package]]
+name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "rand"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
+dependencies = [
+ "libc",
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom 0.2.17",
+]
+
+[[package]]
+name = "rayon"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb39b166781f92d482534ef4b4b1b2568f42613b53e5b6c160e24cfbfa30926d"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "redox_users"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
+dependencies = [
+ "getrandom 0.2.17",
+ "libredox",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "regalloc2"
+version = "0.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5216b1837de2149f8bc8e6d5f88a9326b63b8c836ed58ce4a0a29ec736a59734"
+dependencies = [
+ "allocator-api2",
+ "bumpalo",
+ "hashbrown 0.15.5",
+ "log",
+ "rustc-hash",
+ "smallvec",
+]
+
+[[package]]
+name = "rustc-demangle"
+version = "0.1.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b50b8869d9fc858ce7266cce0194bd74df58b9d0e3f6df3a9fc8eb470d95c09d"
+
+[[package]]
+name = "rustc-hash"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
+
+[[package]]
+name = "rustix"
+version = "0.38.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.4.15",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "rustix"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.12.1",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustix-linux-procfs"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2fc84bf7e9aa16c4f2c758f27412dc9841341e16aa682d9c7ac308fe3ee12056"
+dependencies = [
+ "once_cell",
+ "rustix 1.1.4",
+]
+
+[[package]]
+name = "rustversion"
+version = "1.0.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
+name = "semver"
+version = "1.0.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
+dependencies = [
+ "serde",
+ "serde_core",
+]
+
+[[package]]
+name = "serde"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+dependencies = [
+ "serde_core",
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_core"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.150"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
+dependencies = [
+ "itoa",
+ "memchr",
+ "serde",
+ "serde_core",
+ "zmij",
+]
+
+[[package]]
+name = "serde_spanned"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
+name = "shlex"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
+
+[[package]]
+name = "slab"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
+
+[[package]]
+name = "smallvec"
+version = "1.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "socket2"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
+dependencies = [
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "stable_deref_trait"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
+name = "syn"
+version = "2.0.117"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "synstructure"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "system-interface"
+version = "0.27.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc4592f674ce18521c2a81483873a49596655b179f71c5e05d10c1fe66c78745"
+dependencies = [
+ "bitflags",
+ "cap-fs-ext",
+ "cap-std",
+ "fd-lock",
+ "io-lifetimes",
+ "rustix 0.38.44",
+ "windows-sys 0.59.0",
+ "winx",
+]
+
+[[package]]
+name = "target-lexicon"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adb6935a6f5c20170eeceb1a3835a49e12e19d792f6dd344ccc76a985ca5a6ca"
+
+[[package]]
+name = "termcolor"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
+name = "thiserror"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+dependencies = [
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
+dependencies = [
+ "thiserror-impl 2.0.18",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tinystr"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
+dependencies = [
+ "displaydoc",
+ "zerovec",
+]
+
+[[package]]
+name = "tokio"
+version = "1.52.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
+dependencies = [
+ "bytes",
+ "libc",
+ "mio",
+ "pin-project-lite",
+ "socket2",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "toml"
+version = "0.8.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.22.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
+dependencies = [
+ "indexmap",
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_write",
+ "winnow",
+]
+
+[[package]]
+name = "toml_write"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
+
+[[package]]
+name = "tracing"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
+dependencies = [
+ "pin-project-lite",
+ "tracing-attributes",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
+dependencies = [
+ "once_cell",
+]
+
+[[package]]
+name = "trait-variant"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70977707304198400eb4835a78f6a9f928bf41bba420deb8fdb175cd965d77a7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "typenum"
+version = "1.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
+
+[[package]]
+name = "unicode-ident"
+version = "1.0.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "unicode-width"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
+
+[[package]]
+name = "unicode-xid"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "url"
+version = "2.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff67a8a4397373c3ef660812acab3268222035010ab8680ec4215f38ba3d0eed"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "percent-encoding",
+ "serde",
+]
+
+[[package]]
+name = "utf8_iter"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+
+[[package]]
+name = "uuid"
+version = "1.23.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "144d6b123cef80b301b8f72a9e2ca4370ddec21950d0a103dd22c437006d2db7"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "wasi"
+version = "0.11.1+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
+
+[[package]]
+name = "wasip2"
+version = "1.0.1+wasi-0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0562428422c63773dad2c345a1882263bbf4d65cf3f42e90921f787ef5ad58e7"
+dependencies = [
+ "wit-bindgen",
+]
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.123"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a254a4b10c19a76f09a27640e7ffbf9bc30bf67e16a3bf28aaefa4920fe81563"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "rustversion",
+ "wasm-bindgen-macro",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.123"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24a40fc75b0ec6f3746ceb10d36f53a93dcd68a93b11b6445983945d79eba0dc"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.123"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "908f34bd9b9ce3d4caf07b72dfab63d61504d156856c6bd3cd87fa350cf3985b"
+dependencies = [
+ "bumpalo",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.123"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7acbf7616c27b194bbb550bf77ed0c2c3e5b7fd1260a93082b95fb7f47959b92"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "wasm-encoder"
+version = "0.233.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9679ae3cf7cfa2ca3a327f7fab97f27f3294d402fd1a76ca8ab514e17973e4d3"
+dependencies = [
+ "leb128fmt",
+ "wasmparser 0.233.0",
+]
+
+[[package]]
+name = "wasm-encoder"
+version = "0.251.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a879a421bd17c528b74721b2abf4c62e8f1d1889c2ba8c3c50d02deaf2ce395"
+dependencies = [
+ "leb128fmt",
+ "wasmparser 0.251.0",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.233.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b51cb03afce7964bbfce46602d6cb358726f36430b6ba084ac6020d8ce5bc102"
+dependencies = [
+ "bitflags",
+ "hashbrown 0.15.5",
+ "indexmap",
+ "semver",
+ "serde",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.251.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "437970b35b1a85cfde9c74b2398352d8d653f3bd8e3a3db0c063ea8f5b4b36ff"
+dependencies = [
+ "bitflags",
+ "indexmap",
+ "semver",
+]
+
+[[package]]
+name = "wasmprinter"
+version = "0.233.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "abf8e5b732895c99b21aa615f1b73352e51bbe2b2cb6c87eae7f990d07c1ac18"
+dependencies = [
+ "anyhow",
+ "termcolor",
+ "wasmparser 0.233.0",
+]
+
+[[package]]
+name = "wasmtime"
+version = "34.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec10e50038f22ab407fdd8708120b8feed3450a02618efcf26ca47e82122927d"
+dependencies = [
+ "addr2line",
+ "anyhow",
+ "async-trait",
+ "bitflags",
+ "bumpalo",
+ "cc",
+ "cfg-if",
+ "encoding_rs",
+ "fxprof-processed-profile",
+ "gimli",
+ "hashbrown 0.15.5",
+ "indexmap",
+ "ittapi",
+ "libc",
+ "log",
+ "mach2",
+ "memfd",
+ "object 0.36.7",
+ "once_cell",
+ "postcard",
+ "psm",
+ "pulley-interpreter",
+ "rayon",
+ "rustix 1.1.4",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "smallvec",
+ "target-lexicon",
+ "trait-variant",
+ "wasm-encoder 0.233.0",
+ "wasmparser 0.233.0",
+ "wasmtime-asm-macros",
+ "wasmtime-cache",
+ "wasmtime-component-macro",
+ "wasmtime-component-util",
+ "wasmtime-cranelift",
+ "wasmtime-environ",
+ "wasmtime-fiber",
+ "wasmtime-jit-debug",
+ "wasmtime-jit-icache-coherence",
+ "wasmtime-math",
+ "wasmtime-slab",
+ "wasmtime-versioned-export-macros",
+ "wasmtime-winch",
+ "wat",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "wasmtime-asm-macros"
+version = "34.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d379cda46d6fd18619e282a75fbb09b70b3d0f166b605f45b4059dfaf9dc6ce"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
+name = "wasmtime-cache"
+version = "34.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f421723a7736c0767ceb422afef69b41526864bd0f026e0f49bb2bde7168f9a6"
+dependencies = [
+ "anyhow",
+ "base64",
+ "directories-next",
+ "log",
+ "postcard",
+ "rustix 1.1.4",
+ "serde",
+ "serde_derive",
+ "sha2",
+ "toml",
+ "windows-sys 0.59.0",
+ "zstd",
+]
+
+[[package]]
+name = "wasmtime-component-macro"
+version = "34.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b08be093e0a876da45f79070c2ada4656f2785eb77c01b86ce60be3153920a5"
+dependencies = [
+ "anyhow",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasmtime-component-util",
+ "wasmtime-wit-bindgen",
+ "wit-parser",
+]
+
+[[package]]
+name = "wasmtime-component-util"
+version = "34.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0451ce0dd94a33d0dbd57934ce666a04c2753a5262ca2bc84cf6a67cf5303dc"
+
+[[package]]
+name = "wasmtime-cranelift"
+version = "34.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15aa836683d7398f13f2f26bbe74c404ceaba66b6bbb96700d6b7f91bec90e03"
+dependencies = [
+ "anyhow",
+ "cfg-if",
+ "cranelift-codegen",
+ "cranelift-control",
+ "cranelift-entity",
+ "cranelift-frontend",
+ "cranelift-native",
+ "gimli",
+ "itertools",
+ "log",
+ "object 0.36.7",
+ "pulley-interpreter",
+ "smallvec",
+ "target-lexicon",
+ "thiserror 2.0.18",
+ "wasmparser 0.233.0",
+ "wasmtime-environ",
+ "wasmtime-math",
+ "wasmtime-versioned-export-macros",
+]
+
+[[package]]
+name = "wasmtime-environ"
+version = "34.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "317081a0cbbb1f749d348b262575608fc082d47ab11b6247bbe9163eeb955777"
+dependencies = [
+ "anyhow",
+ "cpp_demangle",
+ "cranelift-bitset",
+ "cranelift-entity",
+ "gimli",
+ "indexmap",
+ "log",
+ "object 0.36.7",
+ "postcard",
+ "rustc-demangle",
+ "semver",
+ "serde",
+ "serde_derive",
+ "smallvec",
+ "target-lexicon",
+ "wasm-encoder 0.233.0",
+ "wasmparser 0.233.0",
+ "wasmprinter",
+ "wasmtime-component-util",
+]
+
+[[package]]
+name = "wasmtime-fiber"
+version = "34.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6763b33eceefc443f6477d84dc8751df5f23d280d7e01f28339fa3ec4b00ff13"
+dependencies = [
+ "anyhow",
+ "cc",
+ "cfg-if",
+ "libc",
+ "rustix 1.1.4",
+ "wasmtime-asm-macros",
+ "wasmtime-versioned-export-macros",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "wasmtime-jit-debug"
+version = "34.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f935b198c58d3f85b6f8d2fedcbaf71e6f41dee3a8278d60cbe9326b82ac91aa"
+dependencies = [
+ "cc",
+ "object 0.36.7",
+ "rustix 1.1.4",
+ "wasmtime-versioned-export-macros",
+]
+
+[[package]]
+name = "wasmtime-jit-icache-coherence"
+version = "34.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ea6b740d1a35f2cebfe88e013ac8a4a84ff8dabc3a392df920abf554e871cf2"
+dependencies = [
+ "anyhow",
+ "cfg-if",
+ "libc",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "wasmtime-math"
+version = "34.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62fa317691aedc64aae3a86b3d786e4b2b0007bc0b56e0b6098b8b5a85ab2134"
+dependencies = [
+ "libm",
+]
+
+[[package]]
+name = "wasmtime-slab"
+version = "34.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60a06819d24370273021054b50589e3078e7f5cfac15515e58b3fbbebf5e5b39"
+
+[[package]]
+name = "wasmtime-versioned-export-macros"
+version = "34.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ca100ed168ffc9b37aefc07a5be440645eab612a2ff6e2ff884e8cc3740e666"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "wasmtime-wasi"
+version = "34.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb691e92f81f339a215c6fb78f10fb9c03886a34995eba84f14d6aa846b72161"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "bitflags",
+ "bytes",
+ "cap-fs-ext",
+ "cap-net-ext",
+ "cap-rand",
+ "cap-std",
+ "cap-time-ext",
+ "fs-set-times",
+ "futures",
+ "io-extras",
+ "io-lifetimes",
+ "rustix 1.1.4",
+ "system-interface",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "url",
+ "wasmtime",
+ "wasmtime-wasi-io",
+ "wiggle",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "wasmtime-wasi-io"
+version = "34.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5703fe2988cf503431c11989bec85bda910077925c232aeaf8d52c408fec48c5"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "bytes",
+ "futures",
+ "wasmtime",
+]
+
+[[package]]
+name = "wasmtime-winch"
+version = "34.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "595f51430606a7b5578f34e0d7c73dca52a22ed24756f2ba9d4d0c1bde8631af"
+dependencies = [
+ "anyhow",
+ "cranelift-codegen",
+ "gimli",
+ "object 0.36.7",
+ "target-lexicon",
+ "wasmparser 0.233.0",
+ "wasmtime-cranelift",
+ "wasmtime-environ",
+ "winch-codegen",
+]
+
+[[package]]
+name = "wasmtime-wit-bindgen"
+version = "34.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "233fdcb96f9097be697319ba647ef42bdbdb40e89f04c8ae3713103813b5b793"
+dependencies = [
+ "anyhow",
+ "heck",
+ "indexmap",
+ "wit-parser",
+]
+
+[[package]]
+name = "wast"
+version = "35.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ef140f1b49946586078353a453a1d28ba90adfc54dde75710bc1931de204d68"
+dependencies = [
+ "leb128",
+]
+
+[[package]]
+name = "wast"
+version = "251.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5cc7467dda0a96142eb2c980329dfb62480b1e1d3622fdeb1a44e2bca6ceed74"
+dependencies = [
+ "bumpalo",
+ "leb128fmt",
+ "memchr",
+ "unicode-width",
+ "wasm-encoder 0.251.0",
+]
+
+[[package]]
+name = "wat"
+version = "1.251.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81b1086c9e85b95bd6a229a928bc6c6d0662e42af0250c88d067b418831ea4d4"
+dependencies = [
+ "wast 251.0.0",
+]
+
+[[package]]
 name = "weavster-engine"
 version = "0.0.0"
+dependencies = [
+ "anyhow",
+ "glob",
+ "serde",
+ "serde_json",
+ "wasmtime",
+ "wasmtime-wasi",
+]
+
+[[package]]
+name = "wiggle"
+version = "34.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b61d3bcb6a981233e8b774738f4495ad2c724a0d73ac626f373944e9ba1e3101"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "bitflags",
+ "thiserror 2.0.18",
+ "tracing",
+ "wasmtime",
+ "wiggle-macro",
+]
+
+[[package]]
+name = "wiggle-generate"
+version = "34.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e7f9816357d0d2bd1c0af68b6e302013152dfdeef4b6a488de87dc2026ed6fa"
+dependencies = [
+ "anyhow",
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "witx",
+]
+
+[[package]]
+name = "wiggle-macro"
+version = "34.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e215597862a78dc57fb6988bd09b76af8e632ca4cb74bc26fe3ab129b8cb3b9"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wiggle-generate",
+]
+
+[[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "winch-codegen"
+version = "34.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdf007d7940f62127ce4f33a8aa92dadedfdc78c3860a057e06c8c24e26e180d"
+dependencies = [
+ "anyhow",
+ "cranelift-assembler-x64",
+ "cranelift-codegen",
+ "gimli",
+ "regalloc2",
+ "smallvec",
+ "target-lexicon",
+ "thiserror 2.0.18",
+ "wasmparser 0.233.0",
+ "wasmtime-cranelift",
+ "wasmtime-environ",
+ "wasmtime-math",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.59.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-link"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-result"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "winnow"
+version = "0.7.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "winx"
+version = "0.36.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f3fd376f71958b862e7afb20cfe5a22830e1963462f3a17f49d82a6c1d1f42d"
+dependencies = [
+ "bitflags",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.46.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f17a85883d4e6d00e8a97c586de764dabcc06133f7f1d55dce5cdc070ad7fe59"
+
+[[package]]
+name = "wit-parser"
+version = "0.233.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f22f1cd55247a2e616870b619766e9522df36b7abafbb29bbeb34b7a9da7e9f0"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "indexmap",
+ "log",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser 0.233.0",
+]
+
+[[package]]
+name = "witx"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e366f27a5cabcddb2706a78296a40b8fcc451e1a6aba2fc1d94b4a01bdaaef4b"
+dependencies = [
+ "anyhow",
+ "log",
+ "thiserror 1.0.69",
+ "wast 35.0.2",
+]
+
+[[package]]
+name = "writeable"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
+
+[[package]]
+name = "yoke"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "709fe23a0424b6a435d82152b1bd3fdfb0833487d5fa90d05d42762a9891fef5"
+dependencies = [
+ "stable_deref_trait",
+ "yoke-derive",
+ "zerofrom",
+]
+
+[[package]]
+name = "yoke-derive"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.52"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce1022995ff5ff5d841ad7d994facc23098cd40152f2c1d11cd607c6f530653f"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.52"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ae7f38b72ec2a254e2b87ef277cf2cd4fb97cbebf944faa6f33354da0867930"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "zerofrom"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ec05a11813ea801ff6d75110ad09cd0824ddba17dfe17128ea0d5f68e6c5272"
+dependencies = [
+ "zerofrom-derive",
+]
+
+[[package]]
+name = "zerofrom-derive"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
+
+[[package]]
+name = "zerotrie"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf"
+dependencies = [
+ "displaydoc",
+ "yoke",
+ "zerofrom",
+]
+
+[[package]]
+name = "zerovec"
+version = "0.11.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
+dependencies = [
+ "yoke",
+ "zerofrom",
+ "zerovec-derive",
+]
+
+[[package]]
+name = "zerovec-derive"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "zmij"
+version = "1.0.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+
+[[package]]
+name = "zstd"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e91ee311a569c327171651566e07972200e76fcfe2242a4fa446149a3881c08a"
+dependencies = [
+ "zstd-safe",
+]
+
+[[package]]
+name = "zstd-safe"
+version = "7.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f49c4d5f0abb602a93fb8736af2a4f4dd9512e36f7f570d66e65ff867ed3b9d"
+dependencies = [
+ "zstd-sys",
+]
+
+[[package]]
+name = "zstd-sys"
+version = "2.0.16+zstd.1.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e19ebc2adc8f83e43039e79776e3fda8ca919132d68a1fed6a5faca2683748"
+dependencies = [
+ "cc",
+ "pkg-config",
+]

--- a/README.md
+++ b/README.md
@@ -85,7 +85,12 @@ See the [Getting Started guide](https://docs.weavster.dev/getting-started) for t
   `manifest.json` schema ([`spec/schemas/manifest.schema.json`](spec/schemas/manifest.schema.json)),
   the `manifest.json` + `flows/<name>.wasm` artifact layout, and the WASM input/result envelope —
   the contract the Rust engine (RFC 0003) and `weavster compile` are built against. `compile`
-  produces this artifact today; the Rust engine that consumes it is not yet implemented.
+  produces this artifact and the engine runs it today.
+- Rust engine core ([`engine/`](engine/)): `weavster-engine <artifact-dir>` loads + validates the
+  manifest (refusing unknown versions loudly), JIT-compiles each flow module once, and runs every
+  pipeline concurrently — FIFO per pipeline, fresh wasmtime store per document, with a memory cap
+  and wall-clock deadline so runaway transforms trap instead of hanging. Structured JSON logs
+  carry pipeline/document/stage.
 - Dev log ([`notes/DEV_LOG.md`](notes/DEV_LOG.md)) and changelog
   ([`CHANGELOG.md`](CHANGELOG.md)).
 
@@ -118,9 +123,19 @@ pnpm --filter @weavster/cli dev test ./path/to/project
 ### Engine (Rust)
 
 The production runtime ([RFC 0003](docs/rfcs/0003-engine-runtime.md)) lives in
-[`engine/`](engine/), a Rust workspace at the repo root. It is currently a stub — the
-manifest loader, wasmtime host, and run loop land in later milestones (see
+[`engine/`](engine/), a Rust workspace at the repo root. The engine core works today:
+`weavster-engine <artifact-dir>` runs a compiled artifact (manifest loader, wasmtime host over
+the Javy ABI, per-pipeline run loop with resource limits). The connector registry, Docker
+image, and parity gate land in later milestones (see
 [`docs/ENGINE_PLAN.md`](docs/ENGINE_PLAN.md)).
+
+```bash
+# end to end: compile the golden path, then run the artifact with the engine
+pnpm --filter @weavster/cli dev compile ./examples/golden-path
+mkdir -p examples/golden-path/target/artifact/in
+cp examples/golden-path/in/order.json examples/golden-path/target/artifact/in/
+cargo run -- examples/golden-path/target/artifact
+```
 
 **Build boundary:** Rust and the pnpm/TS packages sit side by side but never mix. The TS
 toolchain builds the CLI that _produces_ WASM artifacts; the engine only _runs_ them, so no

--- a/docs/ENGINE_PLAN.md
+++ b/docs/ENGINE_PLAN.md
@@ -52,8 +52,12 @@ These are RFC 0003's open questions. Time-box each; the answer feeds the milesto
   a dynamically-linked shared provider is a later size optimization if needed).
 - **S3 — `_ts` bundling.** How a function's own imports/deps bundle (esbuild) and what is
   disallowed in the sandbox. **[E2]**
-- **S4 — instance lifecycle.** Re-init a pooled instance vs fresh instantiate per document;
-  Wizer preinit as a later optimization. **[E3]**
+- **S4 — instance lifecycle.** ✅ Resolved (E3): **compile each flow `Module` once at startup
+  (~220 ms for a 2.5 MB Javy module), fresh `Store` + instance per document (~1.3 ms,
+  byte-stable over 50 runs).** A Javy module is a WASI command — `_start` runs exactly once —
+  so "re-init a pooled instance" isn't a thing; per-document cost is QuickJS init inside the
+  module, not wasmtime instantiation. Wizer preinit remains a later optimization.
+  (`engine/examples/s4_lifecycle.rs`.)
 - **S5 — large/streaming documents.** Javy's stdin/stdout is whole-buffer per call. **[E3, may
   defer]**
 - **S6 — artifact shape.** Directory vs tarball/OCI for distribution. **[E1]**
@@ -106,18 +110,20 @@ Bundle each enabled flow → JS → Javy → `flows/<name>.wasm`; emit the manif
 The thin binary: load manifest, host the WASM, run the loop. File source/sink only.
 (RFC 0003 slice 3. Depends on **S4**; **S5** may defer.)
 
-- [ ] Load + validate the manifest; refuse unknown `manifestVersion`/`abiVersion` loudly.
+- [x] Load + validate the manifest; refuse unknown `manifestVersion`/`abiVersion` loudly.
       → verify: a mismatched `abiVersion` fails fast with a clear message.
-- [ ] wasmtime host over the Javy stdin/stdout ABI; pool instances, re-init between documents
-      (**S4**). → verify: a pooled instance processes N documents with stable output.
-- [ ] Per-pipeline run loop: `source → transform → sink` behind a **FIFO queue, concurrency 1**;
+- [x] wasmtime host over the Javy stdin/stdout ABI; compile each `Module` once, fresh store +
+      instance per document (**S4** — pooling isn't possible for a WASI command module).
+      → verify: N documents through one compiled module yield stable output.
+- [x] Per-pipeline run loop: `source → transform → sink` behind a **FIFO queue, concurrency 1**;
       pipelines concurrent with each other. → verify: documents come out in input order.
-- [ ] Error scoping: startup errors abort non-zero; per-document errors **log-and-move-on** on a
+- [x] Error scoping: startup errors abort non-zero; per-document errors **log-and-move-on** on a
       live stream, fail a bounded run; report pipeline + document + `stage`. → verify: a poison
-      document is logged and the stream continues.
-- [ ] Resource limits with `TODO(config)` defaults: memory cap, wall-clock (epoch), pooled
+      document is logged with pipeline/document/stage (every E3 source is bounded, so it fails
+      the run; the stream path lands with the first unbounded connector).
+- [x] Resource limits with `TODO(config)` defaults: memory cap, wall-clock (epoch), pooled
       single-doc. → verify: a runaway `_ts` (infinite loop) is interrupted, not hung.
-- [ ] Structured logs. → verify: a run emits pipeline/document/stage fields.
+- [x] Structured logs. → verify: a run emits pipeline/document/stage fields.
 
 ## E4 — Connector trait + registry
 

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -10,3 +10,14 @@ publish = false
 [[bin]]
 name = "weavster-engine"
 path = "src/main.rs"
+
+[dependencies]
+anyhow = "1.0.102"
+glob = "0.3.3"
+serde = { version = "1.0.228", features = ["derive"] }
+serde_json = "1.0.150"
+wasmtime = "34.0.2"
+wasmtime-wasi = "34.0.2"
+
+[dev-dependencies]
+serde_json = "1.0.150"

--- a/engine/examples/s4_lifecycle.rs
+++ b/engine/examples/s4_lifecycle.rs
@@ -1,0 +1,65 @@
+//! S4 spike: instance lifecycle for Javy flow modules.
+//!
+//! A Javy module is a WASI *command* — `_start` runs main exactly once — so
+//! "re-init a pooled instance" cannot mean re-running an existing instance.
+//! The real comparison is where the cost sits:
+//!   - `Module::new` (JIT compile of the 2.5 MB module): once.
+//!   - fresh `Store` + instantiate + `_start` per document: per call.
+//!
+//! Run: cargo run --release --example s4_lifecycle -- <path/to/order.wasm>
+
+use std::time::Instant;
+use wasmtime::{Engine, Linker, Module, Store};
+use wasmtime_wasi::p2::WasiCtxBuilder;
+use wasmtime_wasi::p2::pipe::{MemoryInputPipe, MemoryOutputPipe};
+use wasmtime_wasi::preview1::{self, WasiP1Ctx};
+
+fn run_one(engine: &Engine, module: &Module, linker: &Linker<WasiP1Ctx>, input: &str) -> String {
+    let stdout = MemoryOutputPipe::new(1 << 20);
+    let wasi = WasiCtxBuilder::new()
+        .stdin(MemoryInputPipe::new(input.to_string()))
+        .stdout(stdout.clone())
+        .inherit_stderr()
+        .build_p1();
+    let mut store = Store::new(engine, wasi);
+    let instance = linker.instantiate(&mut store, module).expect("instantiate");
+    let start = instance
+        .get_typed_func::<(), ()>(&mut store, "_start")
+        .expect("_start");
+    start.call(&mut store, ()).expect("run");
+    drop(store);
+    String::from_utf8(stdout.contents().to_vec()).expect("utf8")
+}
+
+fn main() {
+    let wasm_path = std::env::args()
+        .nth(1)
+        .expect("usage: s4_lifecycle <flow.wasm>");
+    let engine = Engine::default();
+
+    let t = Instant::now();
+    let module = Module::from_file(&engine, &wasm_path).expect("compile");
+    let compile_ms = t.elapsed().as_millis();
+
+    let mut linker: Linker<WasiP1Ctx> = Linker::new(&engine);
+    preview1::add_to_linker_sync(&mut linker, |ctx| ctx).expect("link wasi");
+
+    let envelope = r#"{"in":"json","out":"json","payload":"{\"id\":\"a1\",\"first\":\"Ada\",\"last\":\"Lovelace\",\"status\":\"new\"}"}"#;
+
+    // Warm-up + correctness: N runs must produce byte-identical output.
+    let first = run_one(&engine, &module, &linker, envelope);
+    println!("first output: {}", &first[..first.len().min(120)]);
+
+    let n = 50;
+    let t = Instant::now();
+    let mut all_same = true;
+    for _ in 0..n {
+        let out = run_one(&engine, &module, &linker, envelope);
+        all_same &= out == first;
+    }
+    let per_doc_us = t.elapsed().as_micros() / n;
+
+    println!("module compile: {compile_ms} ms (once)");
+    println!("fresh store+instantiate+run: {per_doc_us} us/doc over {n} docs");
+    println!("stable output across {n} fresh instances: {all_same}");
+}

--- a/engine/examples/s4_lifecycle.rs
+++ b/engine/examples/s4_lifecycle.rs
@@ -6,7 +6,7 @@
 //!   - `Module::new` (JIT compile of the 2.5 MB module): once.
 //!   - fresh `Store` + instantiate + `_start` per document: per call.
 //!
-//! Run: cargo run --release --example s4_lifecycle -- <path/to/order.wasm>
+//! Run: cargo run --release --example s4_lifecycle -- <path/to/flow.wasm>
 
 use std::time::Instant;
 use wasmtime::{Engine, Linker, Module, Store};

--- a/engine/src/host.rs
+++ b/engine/src/host.rs
@@ -1,0 +1,184 @@
+//! wasmtime host over the Javy stdin/stdout ABI (Engine Plan E3 slice 2).
+//!
+//! Lifecycle per the S4 spike: JIT-compile each flow `Module` once at startup
+//! (~220 ms for a 2.5 MB Javy module), then a fresh `Store` + instance per
+//! document (~1.3 ms) — a Javy module is a WASI command whose `_start` runs
+//! exactly once, and a fresh store gives perfect isolation between documents.
+//!
+//! Resource limits (TODO(config) defaults): a memory cap per store and an
+//! epoch-based wall-clock deadline so a runaway `_ts` (infinite loop) is
+//! interrupted instead of hanging the pipeline.
+
+use anyhow::{Context, Result, bail};
+use serde::{Deserialize, Serialize};
+use std::path::Path;
+use std::sync::Arc;
+use std::time::Duration;
+use wasmtime::{Config, Engine, Linker, Module, Store, StoreLimits, StoreLimitsBuilder};
+use wasmtime_wasi::p2::WasiCtxBuilder;
+use wasmtime_wasi::p2::pipe::{MemoryInputPipe, MemoryOutputPipe};
+use wasmtime_wasi::preview1::{self, WasiP1Ctx};
+
+// TODO(config): per-flow tuning. Defaults per RFC 0003 ("defaults now").
+const MEMORY_CAP_BYTES: usize = 256 * 1024 * 1024;
+const WALL_CLOCK_LIMIT: Duration = Duration::from_secs(10);
+const EPOCH_TICK: Duration = Duration::from_millis(100);
+const STDOUT_CAP_BYTES: usize = 64 * 1024 * 1024;
+
+/// The input envelope the host writes to a flow module's stdin.
+#[derive(Serialize)]
+pub struct InputEnvelope<'a> {
+    pub r#in: &'a str,
+    pub out: &'a str,
+    pub payload: &'a str,
+}
+
+/// The result envelope a flow module writes to stdout.
+#[derive(Debug, Deserialize)]
+pub struct ResultEnvelope {
+    pub ok: bool,
+    pub payload: Option<String>,
+    pub error: Option<EnvelopeError>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct EnvelopeError {
+    pub stage: String,
+    #[serde(rename = "type")]
+    pub error_type: Option<String>,
+    pub message: Option<String>,
+}
+
+struct HostState {
+    wasi: WasiP1Ctx,
+    limits: StoreLimits,
+}
+
+/// A compiled flow module, reusable across documents and threads.
+pub struct FlowModule {
+    engine: Arc<Engine>,
+    module: Module,
+    linker: Arc<Linker<HostState>>,
+}
+
+/// The shared wasmtime engine. One per process; flows compile against it.
+pub struct Host {
+    engine: Arc<Engine>,
+    linker: Arc<Linker<HostState>>,
+}
+
+impl Host {
+    pub fn new() -> Result<Self> {
+        let mut config = Config::new();
+        config.epoch_interruption(true);
+        let engine = Arc::new(Engine::new(&config)?);
+
+        let mut linker: Linker<HostState> = Linker::new(&engine);
+        preview1::add_to_linker_sync(&mut linker, |state| &mut state.wasi)
+            .context("link WASI preview1")?;
+
+        // One background thread advances the epoch for every store on this
+        // engine; each store sets its own deadline in ticks.
+        let weak = Arc::downgrade(&engine);
+        std::thread::spawn(move || {
+            while let Some(engine) = weak.upgrade() {
+                engine.increment_epoch();
+                drop(engine);
+                std::thread::sleep(EPOCH_TICK);
+            }
+        });
+
+        Ok(Self {
+            engine,
+            linker: Arc::new(linker),
+        })
+    }
+
+    /// JIT-compile `flows/<flow>.wasm` from the artifact (once per flow).
+    pub fn load_flow(&self, artifact_dir: &Path, flow: &str) -> Result<FlowModule> {
+        let path = artifact_dir.join("flows").join(format!("{flow}.wasm"));
+        let module = Module::from_file(&self.engine, &path)
+            .with_context(|| format!("cannot load flow module {}", path.display()))?;
+        Ok(FlowModule {
+            engine: Arc::clone(&self.engine),
+            module,
+            linker: Arc::clone(&self.linker),
+        })
+    }
+}
+
+impl FlowModule {
+    /// Run one document through the flow: fresh store, write the input
+    /// envelope to stdin, run `_start`, parse the result envelope from stdout.
+    pub fn run(&self, input: &InputEnvelope<'_>) -> Result<ResultEnvelope> {
+        let stdin = serde_json::to_string(input).context("encode input envelope")?;
+        let stdout = MemoryOutputPipe::new(STDOUT_CAP_BYTES);
+
+        let wasi = WasiCtxBuilder::new()
+            .stdin(MemoryInputPipe::new(stdin))
+            .stdout(stdout.clone())
+            .inherit_stderr()
+            .build_p1();
+        let limits = StoreLimitsBuilder::new()
+            .memory_size(MEMORY_CAP_BYTES)
+            .build();
+
+        let mut store = Store::new(&self.engine, HostState { wasi, limits });
+        store.limiter(|state| &mut state.limits);
+        let deadline_ticks = WALL_CLOCK_LIMIT.as_millis() / EPOCH_TICK.as_millis();
+        store.set_epoch_deadline(deadline_ticks as u64);
+
+        let instance = self
+            .linker
+            .instantiate(&mut store, &self.module)
+            .context("instantiate flow module")?;
+        let start = instance
+            .get_typed_func::<(), ()>(&mut store, "_start")
+            .context("flow module has no _start export")?;
+        start
+            .call(&mut store, ())
+            .context("flow module trapped (memory/time limit or internal error)")?;
+        drop(store);
+
+        let bytes = stdout.contents();
+        if bytes.is_empty() {
+            bail!("flow module produced no output");
+        }
+        serde_json::from_slice(&bytes).context("flow module output is not a result envelope")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Host tests that need a real .wasm artifact live in tests/engine.rs (they
+    // depend on `weavster compile` output). Here: envelope shapes only.
+
+    #[test]
+    fn input_envelope_serializes_with_contract_field_names() {
+        let e = InputEnvelope {
+            r#in: "json",
+            out: "xml",
+            payload: "{}",
+        };
+        let json = serde_json::to_string(&e).unwrap();
+        assert_eq!(json, r#"{"in":"json","out":"xml","payload":"{}"}"#);
+    }
+
+    #[test]
+    fn result_envelope_parses_ok_and_error_shapes() {
+        let ok: ResultEnvelope = serde_json::from_str(r#"{"ok":true,"payload":"x"}"#).unwrap();
+        assert!(ok.ok);
+        assert_eq!(ok.payload.as_deref(), Some("x"));
+
+        let err: ResultEnvelope = serde_json::from_str(
+            r#"{"ok":false,"error":{"stage":"parse","type":"JsonParseError","message":"bad"}}"#,
+        )
+        .unwrap();
+        assert!(!err.ok);
+        let detail = err.error.unwrap();
+        assert_eq!(detail.stage, "parse");
+        assert_eq!(detail.message.as_deref(), Some("bad"));
+    }
+}

--- a/engine/src/log.rs
+++ b/engine/src/log.rs
@@ -1,6 +1,7 @@
 //! Structured logs (Engine Plan E3 slice 3): one JSON object per line on
-//! stderr, with pipeline/document/stage fields. Deliberately dependency-free;
-//! a tracing stack can replace this when the engine grows subscribers.
+//! stderr, with pipeline/document/stage fields. Deliberately framework-free
+//! (just serde_json, already a dependency); a tracing stack can replace this
+//! when the engine grows subscribers.
 
 use serde_json::json;
 

--- a/engine/src/log.rs
+++ b/engine/src/log.rs
@@ -1,0 +1,21 @@
+//! Structured logs (Engine Plan E3 slice 3): one JSON object per line on
+//! stderr, with pipeline/document/stage fields. Deliberately dependency-free;
+//! a tracing stack can replace this when the engine grows subscribers.
+
+use serde_json::json;
+
+pub fn done(pipeline: &str, document: usize) {
+    emit(
+        json!({ "level": "info", "event": "document", "pipeline": pipeline, "document": document, "status": "ok" }),
+    );
+}
+
+pub fn error(pipeline: &str, document: usize, stage: &str, error_type: &str, message: &str) {
+    emit(
+        json!({ "level": "error", "event": "document", "pipeline": pipeline, "document": document, "stage": stage, "type": error_type, "message": message }),
+    );
+}
+
+fn emit(record: serde_json::Value) {
+    eprintln!("{record}");
+}

--- a/engine/src/main.rs
+++ b/engine/src/main.rs
@@ -32,7 +32,12 @@ fn run(artifact_dir: &Path) -> anyhow::Result<bool> {
 }
 
 fn main() -> ExitCode {
-    let artifact_dir = std::env::args().nth(1).unwrap_or_else(|| ".".to_string());
+    // E5 replaces this with the mounted-`weavster.yaml` boot (-c/--config);
+    // until then the artifact directory is explicit, never an implicit cwd.
+    let Some(artifact_dir) = std::env::args().nth(1) else {
+        eprintln!("usage: weavster-engine <artifact-dir>");
+        return ExitCode::FAILURE;
+    };
 
     match run(Path::new(&artifact_dir)) {
         Ok(true) => ExitCode::SUCCESS,

--- a/engine/src/main.rs
+++ b/engine/src/main.rs
@@ -1,29 +1,45 @@
 //! Weavster engine — the thin Rust production runtime (RFC 0003).
 //!
-//! E0 stands the crate up inside the (otherwise TS) monorepo. The engine
-//! itself — manifest loading, the wasmtime host over the Javy ABI, and the
-//! per-pipeline run loop — lands in later milestones (E3+). See
-//! `docs/ENGINE_PLAN.md`.
+//! Runs a compiled artifact (`weavster compile` output): loads `manifest.json`,
+//! JIT-compiles each flow module once, and drives every pipeline concurrently
+//! over the Javy stdin/stdout ABI. See `docs/ENGINE_PLAN.md` (E3) and
+//! `docs/ARTIFACT_SPEC.md` for the contract.
+//!
+//! Usage: `weavster-engine <artifact-dir>` (E5 adds the `weavster.yaml` boot).
 
-fn banner() -> String {
-    format!(
-        "weavster-engine {} — not yet implemented (see docs/ENGINE_PLAN.md)",
-        env!("CARGO_PKG_VERSION")
-    )
+mod host;
+mod log;
+mod manifest;
+mod runner;
+
+use std::path::Path;
+use std::process::ExitCode;
+
+fn run(artifact_dir: &Path) -> anyhow::Result<bool> {
+    let manifest = manifest::load(artifact_dir)?;
+    let report = runner::run(artifact_dir, &manifest)?;
+
+    for (pipeline, error) in &report.failures {
+        eprintln!("✗ {pipeline}: {error}");
+    }
+    let total = manifest.pipelines.len();
+    let ran = total - report.failures.len();
+    eprintln!(
+        "{ran}/{total} pipelines ran ({} documents)",
+        report.documents
+    );
+    Ok(report.failures.is_empty())
 }
 
-fn main() {
-    println!("{}", banner());
-}
+fn main() -> ExitCode {
+    let artifact_dir = std::env::args().nth(1).unwrap_or_else(|| ".".to_string());
 
-#[cfg(test)]
-mod tests {
-    use super::banner;
-
-    #[test]
-    fn banner_names_the_engine_and_version() {
-        let b = banner();
-        assert!(b.contains("weavster-engine"));
-        assert!(b.contains(env!("CARGO_PKG_VERSION")));
+    match run(Path::new(&artifact_dir)) {
+        Ok(true) => ExitCode::SUCCESS,
+        Ok(false) => ExitCode::FAILURE,
+        Err(err) => {
+            eprintln!("✗ {err:#}");
+            ExitCode::FAILURE
+        }
     }
 }

--- a/engine/src/manifest.rs
+++ b/engine/src/manifest.rs
@@ -1,0 +1,176 @@
+//! Artifact manifest loading (Engine Plan E3 slice 1).
+//!
+//! `manifest.json` is the CLI↔engine contract (`docs/ARTIFACT_SPEC.md`): the
+//! engine reads it and nothing else from the user's project. Unknown
+//! `manifestVersion` or `abiVersion` values are refused loudly rather than
+//! risking garbage output from a contract we don't understand.
+
+use anyhow::{Context, Result, bail};
+use serde::Deserialize;
+use std::path::Path;
+
+/// The manifest file shape this engine understands.
+pub const MANIFEST_VERSION: &str = "1";
+/// The wasm host ABI this engine can drive (Javy stdin/stdout).
+pub const ABI_VERSION: &str = "javy-1";
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields, rename_all = "camelCase")]
+pub struct Manifest {
+    pub manifest_version: String,
+    pub abi_version: String,
+    pub pipelines: Vec<Pipeline>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct Pipeline {
+    pub name: String,
+    pub source: Source,
+    /// Flow name; resolves by convention to `flows/<flow>.wasm`.
+    pub flow: String,
+    pub sink: Sink,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct Source {
+    pub r#type: String,
+    pub glob: String,
+    pub format: String,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct Sink {
+    pub r#type: String,
+    pub path: String,
+    pub format: String,
+}
+
+/// Parse and validate a manifest from JSON text.
+pub fn parse(text: &str) -> Result<Manifest> {
+    let manifest: Manifest = serde_json::from_str(text).context("manifest.json is not valid")?;
+
+    if manifest.manifest_version != MANIFEST_VERSION {
+        bail!(
+            "unsupported manifestVersion \"{}\" — this engine understands \"{}\"; \
+             recompile the artifact or upgrade the engine",
+            manifest.manifest_version,
+            MANIFEST_VERSION
+        );
+    }
+    if manifest.abi_version != ABI_VERSION {
+        bail!(
+            "unsupported abiVersion \"{}\" — this engine drives \"{}\"; \
+             recompile the artifact or upgrade the engine",
+            manifest.abi_version,
+            ABI_VERSION
+        );
+    }
+    if manifest.pipelines.is_empty() {
+        bail!("manifest has no pipelines");
+    }
+    for pipeline in &manifest.pipelines {
+        // `file` is the only connector this phase; E4 turns this into a registry.
+        if pipeline.source.r#type != "file" {
+            bail!(
+                "pipeline \"{}\": unknown source type \"{}\" (only \"file\" is supported)",
+                pipeline.name,
+                pipeline.source.r#type
+            );
+        }
+        if pipeline.sink.r#type != "file" {
+            bail!(
+                "pipeline \"{}\": unknown sink type \"{}\" (only \"file\" is supported)",
+                pipeline.name,
+                pipeline.sink.r#type
+            );
+        }
+    }
+    Ok(manifest)
+}
+
+/// Load `manifest.json` from an artifact directory.
+pub fn load(artifact_dir: &Path) -> Result<Manifest> {
+    let path = artifact_dir.join("manifest.json");
+    let text = std::fs::read_to_string(&path)
+        .with_context(|| format!("cannot read {}", path.display()))?;
+    parse(&text).with_context(|| format!("invalid manifest at {}", path.display()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const GOLDEN: &str = r#"{
+      "manifestVersion": "1",
+      "abiVersion": "javy-1",
+      "pipelines": [
+        {
+          "name": "orders",
+          "source": { "type": "file", "glob": "in/*.json", "format": "json" },
+          "flow": "order",
+          "sink": { "type": "file", "path": "out/order.json", "format": "json" }
+        }
+      ]
+    }"#;
+
+    #[test]
+    fn parses_the_golden_manifest() {
+        let m = parse(GOLDEN).expect("golden manifest parses");
+        assert_eq!(m.pipelines.len(), 1);
+        assert_eq!(m.pipelines[0].flow, "order");
+        assert_eq!(m.pipelines[0].source.glob, "in/*.json");
+        assert_eq!(m.pipelines[0].sink.format, "json");
+    }
+
+    #[test]
+    fn refuses_an_unknown_manifest_version() {
+        let text = GOLDEN.replace("\"manifestVersion\": \"1\"", "\"manifestVersion\": \"99\"");
+        let err = parse(&text).unwrap_err().to_string();
+        assert!(err.contains("unsupported manifestVersion \"99\""), "{err}");
+        assert!(err.contains("recompile"), "{err}");
+    }
+
+    #[test]
+    fn refuses_an_unknown_abi_version() {
+        let text = GOLDEN.replace("\"abiVersion\": \"javy-1\"", "\"abiVersion\": \"javy-9\"");
+        let err = parse(&text).unwrap_err().to_string();
+        assert!(err.contains("unsupported abiVersion \"javy-9\""), "{err}");
+    }
+
+    #[test]
+    fn refuses_an_empty_pipeline_list() {
+        let text = r#"{"manifestVersion":"1","abiVersion":"javy-1","pipelines":[]}"#;
+        let err = parse(text).unwrap_err().to_string();
+        assert!(err.contains("no pipelines"), "{err}");
+    }
+
+    #[test]
+    fn refuses_malformed_json() {
+        assert!(parse("{ not json").is_err());
+    }
+
+    #[test]
+    fn refuses_an_unknown_connector_type() {
+        let text = GOLDEN.replace(r#"{ "type": "file", "glob""#, r#"{ "type": "rest", "glob""#);
+        let err = parse(&text).unwrap_err().to_string();
+        assert!(err.contains("unknown source type \"rest\""), "{err}");
+    }
+
+    #[test]
+    fn refuses_unknown_fields() {
+        let text = GOLDEN.replace(
+            "\"manifestVersion\"",
+            "\"surprise\": 1, \"manifestVersion\"",
+        );
+        assert!(parse(&text).is_err());
+    }
+
+    #[test]
+    fn load_reports_a_missing_file() {
+        let err = load(Path::new("/nonexistent")).unwrap_err().to_string();
+        assert!(err.contains("cannot read"), "{err}");
+    }
+}

--- a/engine/src/manifest.rs
+++ b/engine/src/manifest.rs
@@ -87,8 +87,38 @@ pub fn parse(text: &str) -> Result<Manifest> {
                 pipeline.sink.r#type
             );
         }
+        // Every path in the manifest resolves against the artifact root; an
+        // absolute path or a `..` component would silently escape it.
+        check_contained(&pipeline.name, "source glob", &pipeline.source.glob)?;
+        check_contained(&pipeline.name, "sink path", &pipeline.sink.path)?;
+        if pipeline.flow.is_empty() || pipeline.flow.contains(['/', '\\']) || pipeline.flow == ".."
+        {
+            bail!(
+                "pipeline \"{}\": flow \"{}\" is not a plain name (it becomes flows/<flow>.wasm)",
+                pipeline.name,
+                pipeline.flow
+            );
+        }
     }
     Ok(manifest)
+}
+
+/// Refuse a path that is empty, absolute, or contains a `..` component —
+/// each would resolve outside the artifact (connector) root.
+fn check_contained(pipeline: &str, field: &str, path: &str) -> Result<()> {
+    if path.is_empty() {
+        bail!("pipeline \"{pipeline}\": {field} is empty");
+    }
+    let p = Path::new(path);
+    if p.is_absolute() {
+        bail!("pipeline \"{pipeline}\": {field} \"{path}\" must be relative to the artifact root");
+    }
+    if p.components()
+        .any(|c| matches!(c, std::path::Component::ParentDir))
+    {
+        bail!("pipeline \"{pipeline}\": {field} \"{path}\" must not contain \"..\"");
+    }
+    Ok(())
 }
 
 /// Load `manifest.json` from an artifact directory.
@@ -157,6 +187,27 @@ mod tests {
         let text = GOLDEN.replace(r#"{ "type": "file", "glob""#, r#"{ "type": "rest", "glob""#);
         let err = parse(&text).unwrap_err().to_string();
         assert!(err.contains("unknown source type \"rest\""), "{err}");
+    }
+
+    #[test]
+    fn refuses_an_absolute_sink_path() {
+        let text = GOLDEN.replace("out/order.json", "/etc/order.json");
+        let err = parse(&text).unwrap_err().to_string();
+        assert!(err.contains("must be relative"), "{err}");
+    }
+
+    #[test]
+    fn refuses_a_parent_dir_component_in_the_glob() {
+        let text = GOLDEN.replace("in/*.json", "../outside/*.json");
+        let err = parse(&text).unwrap_err().to_string();
+        assert!(err.contains("must not contain \"..\""), "{err}");
+    }
+
+    #[test]
+    fn refuses_a_flow_name_with_a_path_separator() {
+        let text = GOLDEN.replace("\"flow\": \"order\"", "\"flow\": \"../order\"");
+        let err = parse(&text).unwrap_err().to_string();
+        assert!(err.contains("not a plain name"), "{err}");
     }
 
     #[test]

--- a/engine/src/runner.rs
+++ b/engine/src/runner.rs
@@ -1,0 +1,172 @@
+//! Per-pipeline run loop (Engine Plan E3 slice 3).
+//!
+//! Each pipeline is `source → transform → sink` behind a FIFO queue with
+//! concurrency 1 (documents stay in input order); pipelines run concurrently
+//! with each other on plain threads. Error scoping per RFC 0002/0003: startup
+//! errors abort the run; per-document failures fail a bounded run and would
+//! log-and-move-on on a live stream (every E3 source is bounded — files).
+
+use crate::host::{FlowModule, Host, InputEnvelope};
+use crate::log;
+use crate::manifest::{Manifest, Pipeline};
+use anyhow::{Context, Result, anyhow, bail};
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+pub struct RunReport {
+    /// Pipeline name → error message, for pipelines that failed.
+    pub failures: Vec<(String, String)>,
+    pub documents: usize,
+}
+
+/// Load every flow the manifest references (deduplicated), then run all
+/// pipelines concurrently. The connector root is the artifact directory.
+pub fn run(artifact_dir: &Path, manifest: &Manifest) -> Result<RunReport> {
+    let host = Host::new()?;
+    let mut flows: HashMap<String, Arc<FlowModule>> = HashMap::new();
+    for pipeline in &manifest.pipelines {
+        if !flows.contains_key(&pipeline.flow) {
+            let module = host
+                .load_flow(artifact_dir, &pipeline.flow)
+                .with_context(|| format!("pipeline \"{}\"", pipeline.name))?;
+            flows.insert(pipeline.flow.clone(), Arc::new(module));
+        }
+    }
+
+    let results: Vec<(String, Result<usize>)> = std::thread::scope(|scope| {
+        let handles: Vec<_> = manifest
+            .pipelines
+            .iter()
+            .map(|pipeline| {
+                let flow = Arc::clone(&flows[&pipeline.flow]);
+                let handle =
+                    scope.spawn(move || run_pipeline(artifact_dir, pipeline, flow.as_ref()));
+                (pipeline.name.clone(), handle)
+            })
+            .collect();
+        handles
+            .into_iter()
+            .map(|(name, handle)| {
+                let result = handle
+                    .join()
+                    .unwrap_or_else(|_| Err(anyhow!("pipeline thread panicked")));
+                (name, result)
+            })
+            .collect()
+    });
+
+    let mut failures = Vec::new();
+    let mut documents = 0;
+    for (name, result) in results {
+        match result {
+            Ok(count) => documents += count,
+            Err(err) => failures.push((name, format!("{err:#}"))),
+        }
+    }
+    Ok(RunReport {
+        failures,
+        documents,
+    })
+}
+
+/// One pipeline: resolve the source glob, run each document through the flow
+/// in order, write each result to the sink. Returns the document count.
+fn run_pipeline(artifact_dir: &Path, pipeline: &Pipeline, flow: &FlowModule) -> Result<usize> {
+    // Startup: resolve inputs before transforming anything.
+    let inputs = resolve_glob(artifact_dir, &pipeline.source.glob)
+        .with_context(|| format!("source glob \"{}\"", pipeline.source.glob))?;
+    if inputs.is_empty() {
+        bail!("source glob \"{}\" matched no files", pipeline.source.glob);
+    }
+    let sink_path = artifact_dir.join(&pipeline.sink.path);
+
+    let mut documents = 0;
+    for input_path in inputs {
+        documents += 1;
+        let payload = std::fs::read_to_string(&input_path)
+            .with_context(|| format!("cannot read {}", input_path.display()))?;
+
+        let result = flow.run(&InputEnvelope {
+            r#in: &pipeline.source.format,
+            out: &pipeline.sink.format,
+            payload: &payload,
+        })?;
+
+        if !result.ok {
+            let error = result.error.as_ref();
+            let stage = error.map_or("unknown", |e| e.stage.as_str());
+            let error_type = error
+                .and_then(|e| e.error_type.as_deref())
+                .unwrap_or("unknown");
+            let message = error
+                .and_then(|e| e.message.as_deref())
+                .unwrap_or("(no message)");
+            log::error(&pipeline.name, documents, stage, error_type, message);
+            // Every E3 source is bounded (files), so a poison document fails
+            // the run. A live stream would log-and-move-on here instead.
+            bail!("document {documents}: {stage}: {message}");
+        }
+
+        let output = result
+            .payload
+            .context("ok envelope is missing its payload")?;
+        if let Some(parent) = sink_path.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+        std::fs::write(&sink_path, output)
+            .with_context(|| format!("cannot write {}", sink_path.display()))?;
+        log::done(&pipeline.name, documents);
+    }
+    Ok(documents)
+}
+
+/// Expand the source glob against the connector root, in sorted (input) order.
+/// E2 emits a literal file path as a one-match glob; real patterns also work.
+/// TODO(E4): moves behind the connector trait/registry.
+fn resolve_glob(root: &Path, pattern: &str) -> Result<Vec<PathBuf>> {
+    let absolute = root.join(pattern);
+    let pattern_str = absolute
+        .to_str()
+        .context("glob pattern is not valid UTF-8")?;
+    let mut paths: Vec<PathBuf> = glob::glob(pattern_str)
+        .context("invalid glob pattern")?
+        .collect::<std::result::Result<_, _>>()
+        .context("cannot read a glob match")?;
+    paths.sort();
+    Ok(paths)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn resolve_glob_returns_sorted_matches() {
+        let dir = std::env::temp_dir().join(format!("wv-glob-{}", std::process::id()));
+        std::fs::create_dir_all(dir.join("in")).unwrap();
+        std::fs::write(dir.join("in/b.json"), "{}").unwrap();
+        std::fs::write(dir.join("in/a.json"), "{}").unwrap();
+
+        let paths = resolve_glob(&dir, "in/*.json").unwrap();
+        let names: Vec<_> = paths
+            .iter()
+            .map(|p| p.file_name().unwrap().to_str().unwrap())
+            .collect();
+        assert_eq!(names, ["a.json", "b.json"]);
+
+        std::fs::remove_dir_all(&dir).unwrap();
+    }
+
+    #[test]
+    fn resolve_glob_treats_a_literal_path_as_one_match() {
+        let dir = std::env::temp_dir().join(format!("wv-glob-lit-{}", std::process::id()));
+        std::fs::create_dir_all(dir.join("in")).unwrap();
+        std::fs::write(dir.join("in/x.json"), "{}").unwrap();
+
+        let paths = resolve_glob(&dir, "in/x.json").unwrap();
+        assert_eq!(paths.len(), 1);
+
+        std::fs::remove_dir_all(&dir).unwrap();
+    }
+}

--- a/engine/src/runner.rs
+++ b/engine/src/runner.rs
@@ -114,6 +114,9 @@ fn run_pipeline(artifact_dir: &Path, pipeline: &Pipeline, flow: &FlowModule) -> 
         if let Some(parent) = sink_path.parent() {
             std::fs::create_dir_all(parent)?;
         }
+        // One sink path, overwritten per document (last write wins) — the TS
+        // file connector's semantics. Per-document naming for multi-match
+        // globs is an E4 sink-semantics decision.
         std::fs::write(&sink_path, output)
             .with_context(|| format!("cannot write {}", sink_path.display()))?;
         log::done(&pipeline.name, documents);
@@ -125,6 +128,11 @@ fn run_pipeline(artifact_dir: &Path, pipeline: &Pipeline, flow: &FlowModule) -> 
 /// E2 emits a literal file path as a one-match glob; real patterns also work.
 /// TODO(E4): moves behind the connector trait/registry.
 fn resolve_glob(root: &Path, pattern: &str) -> Result<Vec<PathBuf>> {
+    // `root.join` silently discards the root for an absolute pattern, which
+    // would let a manifest read outside the connector root.
+    if Path::new(pattern).is_absolute() {
+        bail!("glob pattern must be relative to the connector root, got \"{pattern}\"");
+    }
     let absolute = root.join(pattern);
     let pattern_str = absolute
         .to_str()
@@ -156,6 +164,14 @@ mod tests {
         assert_eq!(names, ["a.json", "b.json"]);
 
         std::fs::remove_dir_all(&dir).unwrap();
+    }
+
+    #[test]
+    fn resolve_glob_rejects_an_absolute_pattern() {
+        let err = resolve_glob(Path::new("/tmp"), "/etc/*.conf")
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("must be relative"), "{err}");
     }
 
     #[test]

--- a/engine/src/runner.rs
+++ b/engine/src/runner.rs
@@ -87,11 +87,13 @@ fn run_pipeline(artifact_dir: &Path, pipeline: &Pipeline, flow: &FlowModule) -> 
         let payload = std::fs::read_to_string(&input_path)
             .with_context(|| format!("cannot read {}", input_path.display()))?;
 
-        let result = flow.run(&InputEnvelope {
-            r#in: &pipeline.source.format,
-            out: &pipeline.sink.format,
-            payload: &payload,
-        })?;
+        let result = flow
+            .run(&InputEnvelope {
+                r#in: &pipeline.source.format,
+                out: &pipeline.sink.format,
+                payload: &payload,
+            })
+            .with_context(|| format!("document {documents} ({})", input_path.display()))?;
 
         if !result.ok {
             let error = result.error.as_ref();

--- a/engine/tests/artifact.rs
+++ b/engine/tests/artifact.rs
@@ -89,6 +89,8 @@ fn processes_glob_matches_in_input_order_with_structured_logs() {
     let Some(artifact) = golden_artifact() else {
         return;
     };
+    // Distinct ids so the sink's last-write-wins semantics are observable.
+    let last = ORDER_DOC.replace("a1", "z9");
     let dir = stage(
         "order",
         &artifact,
@@ -96,7 +98,7 @@ fn processes_glob_matches_in_input_order_with_structured_logs() {
         &[
             ("a.json", ORDER_DOC),
             ("b.json", ORDER_DOC),
-            ("c.json", ORDER_DOC),
+            ("c.json", &last),
         ],
     );
 
@@ -116,6 +118,11 @@ fn processes_glob_matches_in_input_order_with_structured_logs() {
         .map(|v| v["document"].as_u64().unwrap())
         .collect();
     assert_eq!(docs, [1, 2, 3], "{stderr}");
+
+    // One sink path, overwritten per document: the file holds the LAST
+    // input's transform (c.json, id "z9" → "Z9").
+    let written = fs::read_to_string(dir.join("out/order.json")).unwrap();
+    assert!(written.contains("\"id\": \"Z9\""), "{written}");
 
     fs::remove_dir_all(&dir).ok();
 }

--- a/engine/tests/artifact.rs
+++ b/engine/tests/artifact.rs
@@ -1,0 +1,149 @@
+//! End-to-end tests against a real compiled artifact (`weavster compile`
+//! output). These need the TS toolchain's build product, which `cargo test`
+//! can't produce — so they self-skip unless the golden artifact exists at
+//! `examples/golden-path/target/artifact` (or `WEAVSTER_ARTIFACT` points
+//! elsewhere). Build it with: `pnpm --filter @weavster/cli dev compile
+//! examples/golden-path` from the repo root.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output};
+
+fn golden_artifact() -> Option<PathBuf> {
+    let dir = std::env::var("WEAVSTER_ARTIFACT")
+        .map(PathBuf::from)
+        .unwrap_or_else(|_| {
+            Path::new(env!("CARGO_MANIFEST_DIR")).join("../examples/golden-path/target/artifact")
+        });
+    if dir.join("manifest.json").exists() && dir.join("flows/order.wasm").exists() {
+        Some(dir)
+    } else {
+        eprintln!(
+            "skipping: no compiled artifact at {} (run weavster compile)",
+            dir.display()
+        );
+        None
+    }
+}
+
+const ORDER_DOC: &str = r#"{ "id": "a1", "first": "Ada", "last": "Lovelace", "status": "new" }"#;
+
+/// Stage a runnable copy: manifest (with the given source glob) + flows/ +
+/// the provided input files under in/.
+fn stage(name: &str, artifact: &Path, glob: &str, inputs: &[(&str, &str)]) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!("wv-artifact-{}-{}", name, std::process::id()));
+    fs::remove_dir_all(&dir).ok();
+    fs::create_dir_all(dir.join("flows")).unwrap();
+    fs::create_dir_all(dir.join("in")).unwrap();
+    fs::copy(
+        artifact.join("flows/order.wasm"),
+        dir.join("flows/order.wasm"),
+    )
+    .unwrap();
+
+    let manifest = fs::read_to_string(artifact.join("manifest.json"))
+        .unwrap()
+        .replace("in/order.json", glob);
+    fs::write(dir.join("manifest.json"), manifest).unwrap();
+
+    for (file, content) in inputs {
+        fs::write(dir.join("in").join(file), content).unwrap();
+    }
+    dir
+}
+
+fn run_engine(artifact_dir: &Path) -> Output {
+    Command::new(env!("CARGO_BIN_EXE_weavster-engine"))
+        .arg(artifact_dir)
+        .output()
+        .expect("run the weavster-engine binary")
+}
+
+#[test]
+fn runs_the_golden_pipeline_end_to_end() {
+    let Some(artifact) = golden_artifact() else {
+        return;
+    };
+    let dir = stage(
+        "golden",
+        &artifact,
+        "in/order.json",
+        &[("order.json", ORDER_DOC)],
+    );
+
+    let output = run_engine(&dir);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(output.status.success(), "{stderr}");
+
+    let written = fs::read_to_string(dir.join("out/order.json")).unwrap();
+    assert!(written.contains("\"id\": \"A1\""), "{written}");
+    assert!(written.contains("\"name\": \"Ada Lovelace\""), "{written}");
+    assert!(written.contains("\"priority\": \"high\""), "{written}");
+    assert!(written.contains("\"initials\": \"AL\""), "{written}");
+
+    fs::remove_dir_all(&dir).ok();
+}
+
+#[test]
+fn processes_glob_matches_in_input_order_with_structured_logs() {
+    let Some(artifact) = golden_artifact() else {
+        return;
+    };
+    let dir = stage(
+        "order",
+        &artifact,
+        "in/*.json",
+        &[
+            ("a.json", ORDER_DOC),
+            ("b.json", ORDER_DOC),
+            ("c.json", ORDER_DOC),
+        ],
+    );
+
+    let output = run_engine(&dir);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(output.status.success(), "{stderr}");
+    assert!(
+        stderr.contains("1/1 pipelines ran (3 documents)"),
+        "{stderr}"
+    );
+
+    // Structured log lines carry pipeline/document fields, in input order.
+    let docs: Vec<u64> = stderr
+        .lines()
+        .filter_map(|line| serde_json::from_str::<serde_json::Value>(line).ok())
+        .filter(|v| v["event"] == "document")
+        .map(|v| v["document"].as_u64().unwrap())
+        .collect();
+    assert_eq!(docs, [1, 2, 3], "{stderr}");
+
+    fs::remove_dir_all(&dir).ok();
+}
+
+#[test]
+fn a_poison_document_fails_the_bounded_run_with_stage() {
+    let Some(artifact) = golden_artifact() else {
+        return;
+    };
+    let dir = stage(
+        "poison",
+        &artifact,
+        "in/*.json",
+        &[("a.json", ORDER_DOC), ("b.json", "{ not json")],
+    );
+
+    let output = run_engine(&dir);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(!output.status.success());
+    // The failure is scoped: pipeline + document + stage, in the structured log.
+    let error_line = stderr
+        .lines()
+        .filter_map(|line| serde_json::from_str::<serde_json::Value>(line).ok())
+        .find(|v| v["level"] == "error")
+        .unwrap_or_else(|| panic!("no structured error line in: {stderr}"));
+    assert_eq!(error_line["pipeline"], "order");
+    assert_eq!(error_line["document"], 2);
+    assert_eq!(error_line["stage"], "parse");
+
+    fs::remove_dir_all(&dir).ok();
+}

--- a/engine/tests/cli.rs
+++ b/engine/tests/cli.rs
@@ -1,17 +1,86 @@
-//! Run the compiled binary end-to-end. This exercises `main` (which a unit test
-//! cannot), so coverage reflects the whole crate. `CARGO_BIN_EXE_<name>` is set
-//! by Cargo for integration tests — no extra dependency.
+//! Run the compiled binary end-to-end against manifest-level failure cases —
+//! these need no .wasm because manifest validation runs before module loading.
+//! The full artifact-driven path lives in tests/artifact.rs.
 
-use std::process::Command;
+use std::fs;
+use std::path::PathBuf;
+use std::process::{Command, Output};
+
+fn run_engine(artifact_dir: &std::path::Path) -> Output {
+    Command::new(env!("CARGO_BIN_EXE_weavster-engine"))
+        .arg(artifact_dir)
+        .output()
+        .expect("run the weavster-engine binary")
+}
+
+fn temp_artifact(name: &str, manifest: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!("wv-engine-{}-{}", name, std::process::id()));
+    fs::create_dir_all(&dir).expect("create temp artifact dir");
+    fs::write(dir.join("manifest.json"), manifest).expect("write manifest");
+    dir
+}
+
+const GOLDEN_HEAD: &str = r#"{
+  "manifestVersion": "1",
+  "abiVersion": "javy-1",
+  "pipelines": [
+    {
+      "name": "orders",
+      "source": { "type": "file", "glob": "in/*.json", "format": "json" },
+      "flow": "order",
+      "sink": { "type": "file", "path": "out/order.json", "format": "json" }
+    }
+  ]
+}"#;
 
 #[test]
-fn prints_the_banner() {
-    let output = Command::new(env!("CARGO_BIN_EXE_weavster-engine"))
-        .output()
-        .expect("run the weavster-engine binary");
+fn missing_artifact_dir_fails_with_a_clear_message() {
+    let output = run_engine(std::path::Path::new("/nonexistent/artifact"));
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("cannot read"), "{stderr}");
+    assert!(stderr.contains("manifest.json"), "{stderr}");
+}
 
-    assert!(output.status.success());
-    let stdout = String::from_utf8(output.stdout).expect("utf8 stdout");
-    assert!(stdout.contains("weavster-engine"));
-    assert!(stdout.contains(env!("CARGO_PKG_VERSION")));
+#[test]
+fn mismatched_abi_version_fails_fast() {
+    let manifest = GOLDEN_HEAD.replace("javy-1", "javy-99");
+    let dir = temp_artifact("abi", &manifest);
+    let output = run_engine(&dir);
+    fs::remove_dir_all(&dir).ok();
+
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("unsupported abiVersion \"javy-99\""),
+        "{stderr}"
+    );
+    assert!(stderr.contains("recompile"), "{stderr}");
+}
+
+#[test]
+fn unknown_manifest_version_fails_fast() {
+    let manifest = GOLDEN_HEAD.replace("\"manifestVersion\": \"1\"", "\"manifestVersion\": \"2\"");
+    let dir = temp_artifact("mv", &manifest);
+    let output = run_engine(&dir);
+    fs::remove_dir_all(&dir).ok();
+
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("unsupported manifestVersion \"2\""),
+        "{stderr}"
+    );
+}
+
+#[test]
+fn missing_flow_module_fails_at_startup() {
+    // Valid manifest, but flows/order.wasm does not exist.
+    let dir = temp_artifact("noflow", GOLDEN_HEAD);
+    let output = run_engine(&dir);
+    fs::remove_dir_all(&dir).ok();
+
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("cannot load flow module"), "{stderr}");
 }

--- a/engine/tests/cli.rs
+++ b/engine/tests/cli.rs
@@ -34,6 +34,19 @@ const GOLDEN_HEAD: &str = r#"{
 }"#;
 
 #[test]
+fn no_argument_prints_usage_and_fails() {
+    let output = Command::new(env!("CARGO_BIN_EXE_weavster-engine"))
+        .output()
+        .expect("run the weavster-engine binary");
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("usage: weavster-engine <artifact-dir>"),
+        "{stderr}"
+    );
+}
+
+#[test]
 fn missing_artifact_dir_fails_with_a_clear_message() {
     let output = run_engine(std::path::Path::new("/nonexistent/artifact"));
     assert!(!output.status.success());

--- a/notes/DEV_LOG.md
+++ b/notes/DEV_LOG.md
@@ -13,6 +13,34 @@ Newest entries on top. One entry per merged slice.
 
 ---
 
+## 2026-06-10 — E3 engine core (Rust)
+
+- What changed: Implemented the engine core (Engine Plan E3 / RFC 0003 slice 3).
+  `weavster-engine <artifact-dir>` runs a compiled artifact: `manifest.rs` (serde load +
+  validate; refuses unknown `manifestVersion`/`abiVersion`/connector `type` loudly), `host.rs`
+  (wasmtime host over the Javy stdin/stdout ABI with memory cap + epoch wall-clock deadline),
+  `runner.rs` (per-pipeline FIFO concurrency-1 loop on scoped threads, pipelines concurrent;
+  glob source resolved against the artifact root, sorted = input order), `log.rs` (one JSON
+  object per line on stderr with pipeline/document/stage). Verified end-to-end: the golden-path
+  artifact runs through the Rust engine with byte-correct output, a poison document fails the
+  bounded run with a structured `stage:"parse"` log line, and a runaway `_ts` infinite loop
+  traps (`wasm trap: interrupt`) instead of hanging.
+- What I learned: The S4 spike reframed the RFC's "pool instances, re-init between documents" —
+  a Javy module is a WASI _command_ whose `_start` runs exactly once, so instance pooling isn't
+  possible at all. The costs sit elsewhere: `Module::new` JIT compile is ~220 ms (per flow, at
+  startup) and a fresh `Store` + instantiate + full run is ~1.3 ms/doc, byte-stable over 50 runs
+  — per-doc cost is QuickJS init inside the module, not wasmtime instantiation, so Wizer remains
+  the future lever. wasmtime 34 API notes: `WasiCtxBuilder` lives in `p2` and `build_p1()`
+  bridges to preview1 (Javy targets preview1); epoch interruption needs a ticker thread — a
+  `Weak<Engine>` upgrade loop exits cleanly when the engine drops. Engine integration tests
+  split by dependency: manifest-failure cases need no wasm (validation precedes module load);
+  artifact-driven tests self-skip unless `weavster compile` output exists, keeping `cargo test`
+  green without Node (the cross-toolchain gate is E6's job). Glob expansion landed here (sorted
+  matches = input order) though E4 owns the connector trait — the run-loop verify needed
+  multi-document pipelines.
+- What is next: E4 — `Source`/`Sink` traits behind a `type`-keyed registry (formalizing the file
+  connector + glob), then E5 (thin image + `weavster.yaml` boot) and E6 (TS↔Rust parity gate).
+
 ## 2026-06-09 — E2 `weavster compile` (TS side)
 
 - What changed: Built `weavster compile` — the build step that turns a project's enabled pipelines


### PR DESCRIPTION
## Engine Plan E3 — engine core (Rust)

`weavster-engine <artifact-dir>` runs a compiled artifact (E2's `weavster compile` output) end-to-end. Built against the [artifact contract](docs/ARTIFACT_SPEC.md); resolves spike **S4**.

### What it does
- **`manifest.rs`** — serde load + validate; refuses unknown `manifestVersion`/`abiVersion`/connector `type` loudly with a recompile-or-upgrade message.
- **`host.rs`** — wasmtime host over the Javy stdin/stdout envelope ABI. Each flow `Module` JIT-compiles once (~220 ms); every document gets a fresh `Store` + instance (~1.3 ms). Resource limits with `TODO(config)` defaults: 256 MB memory cap, 10 s epoch wall-clock deadline.
- **`runner.rs`** — per-pipeline FIFO concurrency-1 loop on scoped threads; pipelines concurrent with each other. Glob source resolved against the artifact root in sorted (input) order; file sink mirrors the TS connector.
- **`log.rs`** — structured JSON log lines with pipeline/document/stage.

### Spike S4 resolved
`engine/examples/s4_lifecycle.rs`: a Javy module is a WASI *command* — `_start` runs exactly once — so the RFC's "pool instances, re-init between documents" isn't possible. Measured: module compile ~220 ms (once per flow), fresh store + instantiate + run ~1.3 ms/doc, byte-stable over 50 runs. Per-doc cost is QuickJS init inside the module; Wizer preinit remains the future lever.

### Verified (E3 checklist)
- Mismatched `abiVersion` fails fast with a clear message (integration test, no wasm needed).
- 50 documents through one compiled module → byte-stable output (spike) + 3-doc ordered run (test).
- Documents come out in input order (structured logs assert `[1, 2, 3]`).
- A poison document fails the bounded run with a structured `stage:"parse"` log line carrying pipeline/document/stage.
- A runaway `_ts` infinite loop traps (`wasm trap: interrupt`) instead of hanging (manual, crafted artifact).
- Golden-path artifact runs through the engine with correct output (test + README snippet).

### Test strategy
Manifest-failure integration tests need no artifact (validation precedes module load). The wasm-driven tests self-skip when `examples/golden-path/target/artifact` is absent, so `cargo test` stays green without the Node toolchain — the cross-toolchain CI gate is E6's job.

19 engine tests pass; `cargo clippy -D warnings` + `cargo fmt` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Rust engine core is now operational: runs compiled artifacts end-to-end with manifest validation, per-flow JIT, concurrent pipelines with deterministic per-pipeline ordering, per-document isolation, and resource limits
  * Structured JSON logs for startup, per-document success, and scoped failures
* **Documentation**
  * README, changelog, and design docs updated with runtime behavior and local dev instructions
* **Examples**
  * Added lifecycle example demonstrating module instance/exec behavior
* **Tests**
  * Added end-to-end and CLI tests covering artifact execution, processing order, and manifest failures
<!-- end of auto-generated comment: release notes by coderabbit.ai -->