### PR TITLE
ci: run Claude code review only on /review comment

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -6,10 +6,12 @@ on:
 
 jobs:
   claude-review:
-    # Only run when someone comments "/review" on a pull request.
+    # Only run when a trusted user comments "/review" on a pull request.
+    # The author guard keeps arbitrary accounts from spending Claude runs.
     if: |
       github.event.issue.pull_request &&
-      startsWith(github.event.comment.body, '/review')
+      startsWith(github.event.comment.body, '/review') &&
+      contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association)
 
     runs-on: ubuntu-latest
     permissions:
@@ -48,7 +50,7 @@ jobs:
 
             1. Get all previous Claude comment IDs:
                ```bash
-               gh pr view ${{ github.event.issue.number }} --repo ${{ github.repository }} --json comments --jq '.comments[] | select(.author.login == "claude") | .id'
+               gh pr view ${{ github.event.issue.number }} --repo ${{ github.repository }} --json comments --jq '.comments[] | select(.author.login == "claude" or .author.login == "claude[bot]") | .id'
                ```
 
             2. For each comment ID (node_id), minimize it as OUTDATED:

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -53,11 +53,15 @@ jobs:
                gh pr view ${{ github.event.issue.number }} --repo ${{ github.repository }} --json comments --jq '.comments[] | select(.author.login == "claude" or .author.login == "claude[bot]") | .id'
                ```
 
-            2. For each comment ID (node_id), minimize it as OUTDATED:
+            2. Minimize them all as OUTDATED in one call, using one aliased
+               mutation per comment ID (node_id):
                ```bash
                gh api graphql -f query='
                  mutation {
-                   minimizeComment(input: {subjectId: "COMMENT_NODE_ID_HERE", classifier: OUTDATED}) {
+                   c1: minimizeComment(input: {subjectId: "FIRST_COMMENT_NODE_ID", classifier: OUTDATED}) {
+                     clientMutationId
+                   }
+                   c2: minimizeComment(input: {subjectId: "SECOND_COMMENT_NODE_ID", classifier: OUTDATED}) {
                      clientMutationId
                    }
                  }'

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -1,22 +1,15 @@
 name: Claude Code Review
 
 on:
-  pull_request:
-    types: [opened, synchronize, ready_for_review, reopened]
-    # Optional: Only run on specific file changes
-    # paths:
-    #   - "src/**/*.ts"
-    #   - "src/**/*.tsx"
-    #   - "src/**/*.js"
-    #   - "src/**/*.jsx"
+  issue_comment:
+    types: [created]
 
 jobs:
   claude-review:
-    # Optional: Filter by PR author
-    # if: |
-    #   github.event.pull_request.user.login == 'external-contributor' ||
-    #   github.event.pull_request.user.login == 'new-developer' ||
-    #   github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR'
+    # Only run when someone comments "/review" on a pull request.
+    if: |
+      github.event.issue.pull_request &&
+      startsWith(github.event.comment.body, '/review')
 
     runs-on: ubuntu-latest
     permissions:
@@ -45,18 +38,40 @@ jobs:
           # the PR (even with no findings). Inline findings go on the lines.
           prompt: |
             REPO: ${{ github.repository }}
-            PR NUMBER: ${{ github.event.pull_request.number }}
+            PR NUMBER: ${{ github.event.issue.number }}
 
             Review this pull request by running the code-review plugin:
-            /code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}
+            /code-review:code-review ${{ github.repository }}/pull/${{ github.event.issue.number }}
+
+            IMPORTANT: Before posting your review, minimize any previous Claude Code
+            review comments to reduce clutter:
+
+            1. Get all previous Claude comment IDs:
+               ```bash
+               gh pr view ${{ github.event.issue.number }} --repo ${{ github.repository }} --json comments --jq '.comments[] | select(.author.login == "claude") | .id'
+               ```
+
+            2. For each comment ID (node_id), minimize it as OUTDATED:
+               ```bash
+               gh api graphql -f query='
+                 mutation {
+                   minimizeComment(input: {subjectId: "COMMENT_NODE_ID_HERE", classifier: OUTDATED}) {
+                     clientMutationId
+                   }
+                 }'
+               ```
+
+            This ensures only your latest review is prominently visible while
+            preserving the history.
 
             Then post a concise top-level summary comment on the PR with
             `gh pr comment` — even if there are no issues, say so. Use
             mcp__github_inline_comment__create_inline_comment (with confirmed: true)
             for specific line-level findings. Only post GitHub comments; do not
             return the review as a chat message.
-          # Tools the review needs to read the diff and post comments.
+          # Tools the review needs to read the diff, minimize old review
+          # comments (gh api graphql), and post new comments.
           claude_args: |
-            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*)"
+            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh api graphql:*)"
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### Changed
+
+- Claude code review workflow no longer runs on every PR push; it now runs only when someone
+  comments `/review` on a pull request.
+
 ### Added
 
 - Add `weavster compile` (Engine Plan E2): compile a project's enabled pipelines into a portable


### PR DESCRIPTION
## Summary

- Switch the Claude Code Review workflow from running on every PR event to an opt-in trigger: it now fires only when a comment starting with `/review` is posted on a pull request.
- PR context now comes from `github.event.issue` (comments on PRs arrive as `issue_comment` events, which have no `pull_request` payload).
- The command is `/review` rather than `@claude-review` so it doesn't also match the `@claude` trigger in `claude.yml`.
- Before posting a new review, the prompt now instructs Claude to minimize its previous review comments as OUTDATED (via the `minimizeComment` GraphQL mutation), so only the latest review is prominently visible. `Bash(gh api graphql:*)` added to allowed tools for this.

## Test plan

- [ ] Comment `/review` on this PR and confirm the workflow runs and posts a review
- [ ] Confirm a plain PR push no longer triggers the review workflow
- [ ] Comment `/review` again and confirm the first review comment gets minimized as outdated

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Changed**
  * Claude code review now runs on-demand via a `/review` comment on pull requests instead of automatically on every push.
  * Review prompt refined to minimize redundant prior comments and to support additional review tooling.
  * CHANGELOG updated to document the new on-demand review trigger and behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->