### PR TITLE
feat(engine): connector trait + registry, async run loop (E4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,17 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Added
 
+- Land the connector trait + registry (Engine Plan E4 / RFC 0003 slice 4). `Source`/`Sink` are
+  async traits (`engine/src/connector.rs`); a `type`-keyed registry (`registry.rs`) is the one
+  place that knows which connector types exist, so later connectors (rest/blob/tcp/grpc/db) are a
+  new match arm plus a module — no run-loop change. The `file` connector (`connectors/file.rs`) is
+  the only entry this phase: a glob source (sorted = input order, one file → one document) and a
+  path sink. The engine now runs on a tokio runtime — pipelines are concurrent tasks, connector
+  I/O is async, and the synchronous wasm transform runs in `spawn_blocking`. Connectors are built
+  at startup (before flow modules load), so an unknown connector type or an empty glob aborts the
+  run with a clear message before any document moves. The manifest `Source`/`Sink` structs are
+  renamed `SourceSpec`/`SinkSpec`; the file-only check moves from the manifest into the registry.
+
 - Implement the engine core (Engine Plan E3 / RFC 0003 slice 3): `weavster-engine <artifact-dir>`
   runs a compiled artifact end-to-end. The engine loads and validates `manifest.json` (refusing
   unknown `manifestVersion`/`abiVersion` or connector types loudly), JIT-compiles each flow's

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2113,9 +2113,11 @@ name = "weavster-engine"
 version = "0.0.0"
 dependencies = [
  "anyhow",
+ "async-trait",
  "glob",
  "serde",
  "serde_json",
+ "tokio",
  "wasmtime",
  "wasmtime-wasi",
 ]

--- a/README.md
+++ b/README.md
@@ -88,9 +88,11 @@ See the [Getting Started guide](https://docs.weavster.dev/getting-started) for t
   produces this artifact and the engine runs it today.
 - Rust engine core ([`engine/`](engine/)): `weavster-engine <artifact-dir>` loads + validates the
   manifest (refusing unknown versions loudly), JIT-compiles each flow module once, and runs every
-  pipeline concurrently — FIFO per pipeline, fresh wasmtime store per document, with a memory cap
-  and wall-clock deadline so runaway transforms trap instead of hanging. Structured JSON logs
-  carry pipeline/document/stage.
+  pipeline concurrently on a tokio runtime — FIFO per pipeline, fresh wasmtime store per document,
+  with a memory cap and wall-clock deadline so runaway transforms trap instead of hanging.
+  Structured JSON logs carry pipeline/document/stage. Sources and sinks sit behind async
+  `Source`/`Sink` traits in a `type`-keyed registry; `file` (glob source, path sink) is the only
+  connector today, and later ones are additive — no run-loop change.
 - Dev log ([`notes/DEV_LOG.md`](notes/DEV_LOG.md)) and changelog
   ([`CHANGELOG.md`](CHANGELOG.md)).
 

--- a/docs/ENGINE_PLAN.md
+++ b/docs/ENGINE_PLAN.md
@@ -130,12 +130,12 @@ The thin binary: load manifest, host the WASM, run the loop. File source/sink on
 Land `Source`/`Sink` behind a `type`-keyed registry with `file` as the only entry, so later
 connectors (rest/blob/tcp/grpc/db) are additive. (RFC 0003 slice 4.)
 
-- [ ] `Source::next()` / `Sink::write()` async traits; `type`-keyed registry. → verify: an unknown
-      `type` in the manifest fails with a clear error.
-- [ ] `file` connector: **glob** source resolved against a connector root; one match → one
+- [x] `Source::next()` / `Sink::write()` async traits; `type`-keyed registry. → verify: an unknown
+      `type` in the manifest fails with a clear error (registry + an end-to-end binary test).
+- [x] `file` connector: **glob** source resolved against a connector root; one match → one
       document (1 file → 1 document; multi-record is a `// TODO` expansion). → verify: a glob
       matching three files yields three documents.
-- [ ] `file` sink: write a path. → verify: golden output matches byte-for-byte.
+- [x] `file` sink: write a path. → verify: golden output matches byte-for-byte.
 
 ## E5 — Thin image + invocation
 

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -13,9 +13,11 @@ path = "src/main.rs"
 
 [dependencies]
 anyhow = "1.0.102"
+async-trait = "0.1.89"
 glob = "0.3.3"
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.150"
+tokio = { version = "1.52.3", features = ["rt-multi-thread", "fs"] }
 wasmtime = "34.0.2"
 wasmtime-wasi = "34.0.2"
 

--- a/engine/src/connector.rs
+++ b/engine/src/connector.rs
@@ -13,7 +13,8 @@ use anyhow::Result;
 use async_trait::async_trait;
 
 /// One document a source yields: its text payload plus an origin label used in
-/// logs and error messages (e.g. the file path it came from).
+/// logs and error messages (e.g. the file path it came from, or a URL). A
+/// `String` keeps the type connector-agnostic — not every origin is a path.
 pub struct SourceDoc {
     pub origin: String,
     pub payload: String,

--- a/engine/src/connector.rs
+++ b/engine/src/connector.rs
@@ -1,0 +1,34 @@
+//! Connector traits (Engine Plan E4): the seam between the engine's run loop
+//! and the outside world. A `Source` yields documents in order; a `Sink`
+//! writes them. `file` is the only connector this phase; later connectors
+//! (rest/blob/tcp/grpc/db) implement the same traits and register in
+//! `registry`, so they are additive — no run-loop change.
+//!
+//! The traits are async because every connector beyond `file` is async I/O;
+//! landing the async shape now means those connectors slot in without a
+//! breaking trait change. The transform itself stays synchronous (it runs in
+//! `spawn_blocking` off the async worker).
+
+use anyhow::Result;
+use async_trait::async_trait;
+
+/// One document a source yields: its text payload plus an origin label used in
+/// logs and error messages (e.g. the file path it came from).
+pub struct SourceDoc {
+    pub origin: String,
+    pub payload: String,
+}
+
+/// A stream of documents, yielded in order, one in flight at a time.
+#[async_trait]
+pub trait Source: Send {
+    /// The next document, or `None` once the source is exhausted.
+    async fn next(&mut self) -> Result<Option<SourceDoc>>;
+}
+
+/// A destination for transformed documents.
+#[async_trait]
+pub trait Sink: Send {
+    /// Write one serialized document.
+    async fn write(&mut self, payload: &str) -> Result<()>;
+}

--- a/engine/src/connectors/file.rs
+++ b/engine/src/connectors/file.rs
@@ -1,0 +1,156 @@
+//! The `file` connector (Engine Plan E4): a glob source and a path sink, both
+//! resolved against the connector root (the artifact directory).
+
+use crate::connector::{Sink, Source, SourceDoc};
+use anyhow::{Context, Result, bail};
+use async_trait::async_trait;
+use std::collections::VecDeque;
+use std::path::{Path, PathBuf};
+
+/// Reads each file a glob matches, in sorted (input) order. One file is one
+/// document this phase; multi-record files are a later expansion.
+pub struct FileSource {
+    remaining: VecDeque<PathBuf>,
+}
+
+impl FileSource {
+    /// Resolve `glob` against `root` now, so an unreadable or empty pattern
+    /// fails at startup rather than mid-run.
+    pub fn new(root: &Path, glob: &str) -> Result<Self> {
+        // `root.join` silently discards the root for an absolute pattern; the
+        // manifest gate already refuses those, but defend the connector too.
+        if Path::new(glob).is_absolute() {
+            bail!("glob pattern must be relative to the connector root, got \"{glob}\"");
+        }
+        let joined = root.join(glob);
+        let pattern = joined.to_str().context("glob pattern is not valid UTF-8")?;
+        let mut paths: Vec<PathBuf> = glob::glob(pattern)
+            .context("invalid glob pattern")?
+            .collect::<std::result::Result<_, _>>()
+            .context("cannot read a glob match")?;
+        paths.sort();
+        if paths.is_empty() {
+            bail!("glob \"{glob}\" matched no files");
+        }
+        Ok(Self {
+            remaining: paths.into(),
+        })
+    }
+}
+
+#[async_trait]
+impl Source for FileSource {
+    async fn next(&mut self) -> Result<Option<SourceDoc>> {
+        let Some(path) = self.remaining.pop_front() else {
+            return Ok(None);
+        };
+        let payload = tokio::fs::read_to_string(&path)
+            .await
+            .with_context(|| format!("cannot read {}", path.display()))?;
+        Ok(Some(SourceDoc {
+            origin: path.display().to_string(),
+            payload,
+        }))
+    }
+}
+
+/// Writes to a single path, overwriting per document (last write wins) — the
+/// TS file connector's semantics. Per-document naming for multi-match globs is
+/// a later decision.
+pub struct FileSink {
+    path: PathBuf,
+}
+
+impl FileSink {
+    pub fn new(root: &Path, path: &str) -> Self {
+        Self {
+            path: root.join(path),
+        }
+    }
+}
+
+#[async_trait]
+impl Sink for FileSink {
+    async fn write(&mut self, payload: &str) -> Result<()> {
+        if let Some(parent) = self.path.parent() {
+            tokio::fs::create_dir_all(parent).await?;
+        }
+        tokio::fs::write(&self.path, payload)
+            .await
+            .with_context(|| format!("cannot write {}", self.path.display()))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn temp(name: &str) -> PathBuf {
+        let dir = std::env::temp_dir().join(format!("wv-file-{name}-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        dir
+    }
+
+    /// Drive an async test body on a fresh current-thread runtime (the `macros`
+    /// feature is off, so there's no `#[tokio::test]`).
+    fn block_on<F: std::future::Future>(future: F) -> F::Output {
+        tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap()
+            .block_on(future)
+    }
+
+    #[test]
+    fn source_yields_each_glob_match_in_sorted_order() {
+        let dir = temp("src");
+        std::fs::create_dir_all(dir.join("in")).unwrap();
+        std::fs::write(dir.join("in/b.json"), "B").unwrap();
+        std::fs::write(dir.join("in/a.json"), "A").unwrap();
+
+        block_on(async {
+            let mut source = FileSource::new(&dir, "in/*.json").unwrap();
+            let first = source.next().await.unwrap().unwrap();
+            let second = source.next().await.unwrap().unwrap();
+            assert_eq!(first.payload, "A");
+            assert_eq!(second.payload, "B");
+            assert!(source.next().await.unwrap().is_none());
+        });
+
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn source_rejects_an_empty_match() {
+        let dir = temp("empty");
+        let err = FileSource::new(&dir, "in/*.json")
+            .err()
+            .unwrap()
+            .to_string();
+        assert!(err.contains("matched no files"), "{err}");
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn source_rejects_an_absolute_pattern() {
+        let err = FileSource::new(Path::new("/tmp"), "/etc/*.conf")
+            .err()
+            .unwrap()
+            .to_string();
+        assert!(err.contains("must be relative"), "{err}");
+    }
+
+    #[test]
+    fn sink_writes_the_payload_creating_parents() {
+        let dir = temp("sink");
+        block_on(async {
+            let mut sink = FileSink::new(&dir, "out/x.json");
+            sink.write("hello").await.unwrap();
+        });
+        assert_eq!(
+            std::fs::read_to_string(dir.join("out/x.json")).unwrap(),
+            "hello"
+        );
+        std::fs::remove_dir_all(&dir).ok();
+    }
+}

--- a/engine/src/connectors/file.rs
+++ b/engine/src/connectors/file.rs
@@ -15,13 +15,10 @@ pub struct FileSource {
 
 impl FileSource {
     /// Resolve `glob` against `root` now, so an unreadable or empty pattern
-    /// fails at startup rather than mid-run.
+    /// fails at startup rather than mid-run. The manifest gate
+    /// (`manifest::check_contained`) guarantees `glob` is relative and free of
+    /// `..`, so `root.join` stays inside the connector root.
     pub fn new(root: &Path, glob: &str) -> Result<Self> {
-        // `root.join` silently discards the root for an absolute pattern; the
-        // manifest gate already refuses those, but defend the connector too.
-        if Path::new(glob).is_absolute() {
-            bail!("glob pattern must be relative to the connector root, got \"{glob}\"");
-        }
         let joined = root.join(glob);
         let pattern = joined.to_str().context("glob pattern is not valid UTF-8")?;
         let mut paths: Vec<PathBuf> = glob::glob(pattern)
@@ -62,19 +59,22 @@ pub struct FileSink {
 }
 
 impl FileSink {
-    pub fn new(root: &Path, path: &str) -> Self {
-        Self {
-            path: root.join(path),
+    /// Create the destination's parent directory now (once), so per-document
+    /// writes don't each re-issue a `create_dir_all`. The manifest gate keeps
+    /// `path` inside the connector root.
+    pub fn new(root: &Path, path: &str) -> Result<Self> {
+        let path = root.join(path);
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent)
+                .with_context(|| format!("cannot create {}", parent.display()))?;
         }
+        Ok(Self { path })
     }
 }
 
 #[async_trait]
 impl Sink for FileSink {
     async fn write(&mut self, payload: &str) -> Result<()> {
-        if let Some(parent) = self.path.parent() {
-            tokio::fs::create_dir_all(parent).await?;
-        }
         tokio::fs::write(&self.path, payload)
             .await
             .with_context(|| format!("cannot write {}", self.path.display()))
@@ -132,19 +132,10 @@ mod tests {
     }
 
     #[test]
-    fn source_rejects_an_absolute_pattern() {
-        let err = FileSource::new(Path::new("/tmp"), "/etc/*.conf")
-            .err()
-            .unwrap()
-            .to_string();
-        assert!(err.contains("must be relative"), "{err}");
-    }
-
-    #[test]
     fn sink_writes_the_payload_creating_parents() {
         let dir = temp("sink");
         block_on(async {
-            let mut sink = FileSink::new(&dir, "out/x.json");
+            let mut sink = FileSink::new(&dir, "out/x.json").unwrap();
             sink.write("hello").await.unwrap();
         });
         assert_eq!(

--- a/engine/src/connectors/file.rs
+++ b/engine/src/connectors/file.rs
@@ -9,7 +9,10 @@ use std::path::{Path, PathBuf};
 
 /// Reads each file a glob matches, in sorted (input) order. One file is one
 /// document this phase; multi-record files are a later expansion.
-pub struct FileSource {
+///
+/// `pub(crate)`: the only caller is `registry::build_source`, reached after
+/// manifest validation, so `new` can trust the glob is root-relative.
+pub(crate) struct FileSource {
     remaining: VecDeque<PathBuf>,
 }
 
@@ -18,7 +21,7 @@ impl FileSource {
     /// fails at startup rather than mid-run. The manifest gate
     /// (`manifest::check_contained`) guarantees `glob` is relative and free of
     /// `..`, so `root.join` stays inside the connector root.
-    pub fn new(root: &Path, glob: &str) -> Result<Self> {
+    pub(crate) fn new(root: &Path, glob: &str) -> Result<Self> {
         let joined = root.join(glob);
         let pattern = joined.to_str().context("glob pattern is not valid UTF-8")?;
         let mut paths: Vec<PathBuf> = glob::glob(pattern)
@@ -53,16 +56,18 @@ impl Source for FileSource {
 
 /// Writes to a single path, overwriting per document (last write wins) — the
 /// TS file connector's semantics. Per-document naming for multi-match globs is
-/// a later decision.
-pub struct FileSink {
+/// a later decision. `pub(crate)`: built only by `registry::build_sink`.
+pub(crate) struct FileSink {
     path: PathBuf,
 }
 
 impl FileSink {
     /// Create the destination's parent directory now (once), so per-document
     /// writes don't each re-issue a `create_dir_all`. The manifest gate keeps
-    /// `path` inside the connector root.
-    pub fn new(root: &Path, path: &str) -> Result<Self> {
+    /// `path` inside the connector root. The `std::fs` call is blocking, but
+    /// it's a one-shot at startup before any task runs — off the hot path, so
+    /// not worth a `spawn_blocking` hop.
+    pub(crate) fn new(root: &Path, path: &str) -> Result<Self> {
         let path = root.join(path);
         if let Some(parent) = path.parent() {
             std::fs::create_dir_all(parent)
@@ -141,6 +146,23 @@ mod tests {
         assert_eq!(
             std::fs::read_to_string(dir.join("out/x.json")).unwrap(),
             "hello"
+        );
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn sink_overwrites_per_write_last_one_wins() {
+        let dir = temp("overwrite");
+        block_on(async {
+            let mut sink = FileSink::new(&dir, "out/x.json").unwrap();
+            sink.write("first").await.unwrap();
+            sink.write("second").await.unwrap();
+        });
+        // The single sink path holds only the last document's output — the
+        // intentional last-write-wins semantics for a multi-match glob.
+        assert_eq!(
+            std::fs::read_to_string(dir.join("out/x.json")).unwrap(),
+            "second"
         );
         std::fs::remove_dir_all(&dir).ok();
     }

--- a/engine/src/connectors/mod.rs
+++ b/engine/src/connectors/mod.rs
@@ -1,0 +1,4 @@
+//! Built-in connectors. `file` is the only one this phase; later connectors
+//! (rest/blob/tcp/grpc/db) land here and register in [`crate::registry`].
+
+pub mod file;

--- a/engine/src/main.rs
+++ b/engine/src/main.rs
@@ -7,17 +7,20 @@
 //!
 //! Usage: `weavster-engine <artifact-dir>` (E5 adds the `weavster.yaml` boot).
 
+mod connector;
+mod connectors;
 mod host;
 mod log;
 mod manifest;
+mod registry;
 mod runner;
 
 use std::path::Path;
 use std::process::ExitCode;
 
-fn run(artifact_dir: &Path) -> anyhow::Result<bool> {
+async fn run(artifact_dir: &Path) -> anyhow::Result<bool> {
     let manifest = manifest::load(artifact_dir)?;
-    let report = runner::run(artifact_dir, &manifest)?;
+    let report = runner::run(artifact_dir, &manifest).await?;
 
     for (pipeline, error) in &report.failures {
         eprintln!("✗ {pipeline}: {error}");
@@ -39,7 +42,15 @@ fn main() -> ExitCode {
         return ExitCode::FAILURE;
     };
 
-    match run(Path::new(&artifact_dir)) {
+    let runtime = match tokio::runtime::Runtime::new() {
+        Ok(rt) => rt,
+        Err(err) => {
+            eprintln!("✗ cannot start the async runtime: {err}");
+            return ExitCode::FAILURE;
+        }
+    };
+
+    match runtime.block_on(run(Path::new(&artifact_dir))) {
         Ok(true) => ExitCode::SUCCESS,
         Ok(false) => ExitCode::FAILURE,
         Err(err) => {

--- a/engine/src/manifest.rs
+++ b/engine/src/manifest.rs
@@ -14,7 +14,7 @@ pub const MANIFEST_VERSION: &str = "1";
 /// The wasm host ABI this engine can drive (Javy stdin/stdout).
 pub const ABI_VERSION: &str = "javy-1";
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Clone, Deserialize)]
 #[serde(deny_unknown_fields, rename_all = "camelCase")]
 pub struct Manifest {
     pub manifest_version: String,
@@ -22,27 +22,27 @@ pub struct Manifest {
     pub pipelines: Vec<Pipeline>,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Clone, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct Pipeline {
     pub name: String,
-    pub source: Source,
+    pub source: SourceSpec,
     /// Flow name; resolves by convention to `flows/<flow>.wasm`.
     pub flow: String,
-    pub sink: Sink,
+    pub sink: SinkSpec,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Clone, Deserialize)]
 #[serde(deny_unknown_fields)]
-pub struct Source {
+pub struct SourceSpec {
     pub r#type: String,
     pub glob: String,
     pub format: String,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Clone, Deserialize)]
 #[serde(deny_unknown_fields)]
-pub struct Sink {
+pub struct SinkSpec {
     pub r#type: String,
     pub path: String,
     pub format: String,
@@ -72,23 +72,10 @@ pub fn parse(text: &str) -> Result<Manifest> {
         bail!("manifest has no pipelines");
     }
     for pipeline in &manifest.pipelines {
-        // `file` is the only connector this phase; E4 turns this into a registry.
-        if pipeline.source.r#type != "file" {
-            bail!(
-                "pipeline \"{}\": unknown source type \"{}\" (only \"file\" is supported)",
-                pipeline.name,
-                pipeline.source.r#type
-            );
-        }
-        if pipeline.sink.r#type != "file" {
-            bail!(
-                "pipeline \"{}\": unknown sink type \"{}\" (only \"file\" is supported)",
-                pipeline.name,
-                pipeline.sink.r#type
-            );
-        }
-        // Every path in the manifest resolves against the artifact root; an
-        // absolute path or a `..` component would silently escape it.
+        // Connector `type` is validated when the registry builds it (E4); here
+        // we guard the path shape regardless of type. Every path in the
+        // manifest resolves against the artifact root, so an absolute path or a
+        // `..` component would silently escape it.
         check_contained(&pipeline.name, "source glob", &pipeline.source.glob)?;
         check_contained(&pipeline.name, "sink path", &pipeline.sink.path)?;
         if pipeline.flow.is_empty() || pipeline.flow.contains(['/', '\\']) || pipeline.flow == ".."
@@ -180,13 +167,6 @@ mod tests {
     #[test]
     fn refuses_malformed_json() {
         assert!(parse("{ not json").is_err());
-    }
-
-    #[test]
-    fn refuses_an_unknown_connector_type() {
-        let text = GOLDEN.replace(r#"{ "type": "file", "glob""#, r#"{ "type": "rest", "glob""#);
-        let err = parse(&text).unwrap_err().to_string();
-        assert!(err.contains("unknown source type \"rest\""), "{err}");
     }
 
     #[test]

--- a/engine/src/manifest.rs
+++ b/engine/src/manifest.rs
@@ -14,7 +14,7 @@ pub const MANIFEST_VERSION: &str = "1";
 /// The wasm host ABI this engine can drive (Javy stdin/stdout).
 pub const ABI_VERSION: &str = "javy-1";
 
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Deserialize)]
 #[serde(deny_unknown_fields, rename_all = "camelCase")]
 pub struct Manifest {
     pub manifest_version: String,
@@ -22,7 +22,7 @@ pub struct Manifest {
     pub pipelines: Vec<Pipeline>,
 }
 
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct Pipeline {
     pub name: String,
@@ -32,7 +32,7 @@ pub struct Pipeline {
     pub sink: SinkSpec,
 }
 
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct SourceSpec {
     pub r#type: String,
@@ -40,7 +40,7 @@ pub struct SourceSpec {
     pub format: String,
 }
 
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct SinkSpec {
     pub r#type: String,

--- a/engine/src/registry.rs
+++ b/engine/src/registry.rs
@@ -1,0 +1,60 @@
+//! Connector registry (Engine Plan E4): maps a manifest connector `type` to a
+//! concrete [`Source`]/[`Sink`]. This is the single place that knows which
+//! connector types exist, so adding one is a new match arm here plus its
+//! module under `connectors/` — nothing in the run loop changes.
+
+use crate::connector::{Sink, Source};
+use crate::connectors::file::{FileSink, FileSource};
+use crate::manifest::{SinkSpec, SourceSpec};
+use anyhow::{Result, bail};
+use std::path::Path;
+
+/// Build the source for a pipeline, resolving paths against the connector root.
+pub fn build_source(root: &Path, spec: &SourceSpec) -> Result<Box<dyn Source>> {
+    match spec.r#type.as_str() {
+        "file" => Ok(Box::new(FileSource::new(root, &spec.glob)?)),
+        other => bail!("unknown source type \"{other}\" (only \"file\" is supported)"),
+    }
+}
+
+/// Build the sink for a pipeline, resolving paths against the connector root.
+pub fn build_sink(root: &Path, spec: &SinkSpec) -> Result<Box<dyn Sink>> {
+    match spec.r#type.as_str() {
+        "file" => Ok(Box::new(FileSink::new(root, &spec.path))),
+        other => bail!("unknown sink type \"{other}\" (only \"file\" is supported)"),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::manifest::{SinkSpec, SourceSpec};
+
+    #[test]
+    fn rejects_an_unknown_source_type() {
+        let spec = SourceSpec {
+            r#type: "rest".into(),
+            glob: "in/*.json".into(),
+            format: "json".into(),
+        };
+        let err = build_source(Path::new("/tmp"), &spec)
+            .err()
+            .unwrap()
+            .to_string();
+        assert!(err.contains("unknown source type \"rest\""), "{err}");
+    }
+
+    #[test]
+    fn rejects_an_unknown_sink_type() {
+        let spec = SinkSpec {
+            r#type: "blob".into(),
+            path: "out/x.json".into(),
+            format: "json".into(),
+        };
+        let err = build_sink(Path::new("/tmp"), &spec)
+            .err()
+            .unwrap()
+            .to_string();
+        assert!(err.contains("unknown sink type \"blob\""), "{err}");
+    }
+}

--- a/engine/src/registry.rs
+++ b/engine/src/registry.rs
@@ -1,7 +1,10 @@
 //! Connector registry (Engine Plan E4): maps a manifest connector `type` to a
 //! concrete [`Source`]/[`Sink`]. This is the single place that knows which
 //! connector types exist, so adding one is a new match arm here plus its
-//! module under `connectors/` — nothing in the run loop changes.
+//! module under `connectors/` — the run loop never changes. The manifest specs
+//! ([`SourceSpec`]/[`SinkSpec`]) are still file-shaped (`glob`/`path`), so a
+//! non-`file` connector also turns those flat structs into a `#[serde(tag =
+//! "type")]` enum — do that rather than bolting on `Option<_>` fields.
 
 use crate::connector::{Sink, Source};
 use crate::connectors::file::{FileSink, FileSource};
@@ -20,7 +23,7 @@ pub fn build_source(root: &Path, spec: &SourceSpec) -> Result<Box<dyn Source>> {
 /// Build the sink for a pipeline, resolving paths against the connector root.
 pub fn build_sink(root: &Path, spec: &SinkSpec) -> Result<Box<dyn Sink>> {
     match spec.r#type.as_str() {
-        "file" => Ok(Box::new(FileSink::new(root, &spec.path))),
+        "file" => Ok(Box::new(FileSink::new(root, &spec.path)?)),
         other => bail!("unknown sink type \"{other}\" (only \"file\" is supported)"),
     }
 }

--- a/engine/src/registry.rs
+++ b/engine/src/registry.rs
@@ -1,10 +1,14 @@
 //! Connector registry (Engine Plan E4): maps a manifest connector `type` to a
 //! concrete [`Source`]/[`Sink`]. This is the single place that knows which
 //! connector types exist, so adding one is a new match arm here plus its
-//! module under `connectors/` — the run loop never changes. The manifest specs
-//! ([`SourceSpec`]/[`SinkSpec`]) are still file-shaped (`glob`/`path`), so a
-//! non-`file` connector also turns those flat structs into a `#[serde(tag =
-//! "type")]` enum — do that rather than bolting on `Option<_>` fields.
+//! module under `connectors/` — the run loop never changes.
+//!
+//! TODO(next connector): the manifest specs ([`SourceSpec`]/[`SinkSpec`]) are
+//! still file-shaped (`glob`/`path`) with `deny_unknown_fields`, so a manifest
+//! with `"type": "rest"` fails to deserialize before it reaches this registry.
+//! The first non-`file` connector must turn those flat structs into a
+//! `#[serde(tag = "type")]` enum — do that rather than bolting on `Option<_>`
+//! fields.
 
 use crate::connector::{Sink, Source};
 use crate::connectors::file::{FileSink, FileSource};

--- a/engine/src/runner.rs
+++ b/engine/src/runner.rs
@@ -57,20 +57,27 @@ pub async fn run(artifact_dir: &Path, manifest: &Manifest) -> Result<RunReport> 
     }
 
     // Spawn one task per pipeline; tasks own their connectors and share the
-    // flow module behind an Arc.
-    let mut set: JoinSet<(String, Result<usize>)> = JoinSet::new();
+    // flow module behind an Arc. The task id → name map lets a panicking
+    // pipeline be recorded as a failure (with its name) without aborting the
+    // others — pipelines stay isolated, as on E3's scoped threads.
+    let mut set: JoinSet<Result<usize>> = JoinSet::new();
+    let mut names: HashMap<tokio::task::Id, String> = HashMap::new();
     for plan in plans {
         let name = plan.name.clone();
-        set.spawn(async move { (name, run_pipeline(plan).await) });
+        let handle = set.spawn(run_pipeline(plan));
+        names.insert(handle.id(), name);
     }
 
     let mut failures = Vec::new();
     let mut documents = 0;
-    while let Some(joined) = set.join_next().await {
-        let (name, result) = joined.context("pipeline task panicked")?;
-        match result {
-            Ok(count) => documents += count,
-            Err(err) => failures.push((name, format!("{err:#}"))),
+    while let Some(joined) = set.join_next_with_id().await {
+        match joined {
+            Ok((_, Ok(count))) => documents += count,
+            Ok((id, Err(err))) => failures.push((names[&id].clone(), format!("{err:#}"))),
+            Err(join_err) => {
+                let name = names.get(&join_err.id()).cloned().unwrap_or_default();
+                failures.push((name, "pipeline task panicked".into()));
+            }
         }
     }
     Ok(RunReport {

--- a/engine/src/runner.rs
+++ b/engine/src/runner.rs
@@ -1,18 +1,23 @@
-//! Per-pipeline run loop (Engine Plan E3 slice 3).
+//! Per-pipeline run loop (Engine Plan E3 slice 3, E4 connectors).
 //!
 //! Each pipeline is `source → transform → sink` behind a FIFO queue with
 //! concurrency 1 (documents stay in input order); pipelines run concurrently
-//! with each other on plain threads. Error scoping per RFC 0002/0003: startup
-//! errors abort the run; per-document failures fail a bounded run and would
-//! log-and-move-on on a live stream (every E3 source is bounded — files).
+//! with each other as tokio tasks. I/O is async (the connector traits); the
+//! transform is synchronous and runs in `spawn_blocking`. Error scoping per
+//! RFC 0002/0003: startup errors abort the run; per-document failures fail a
+//! bounded run and would log-and-move-on on a live stream (every source this
+//! phase is bounded — files).
 
+use crate::connector::{Sink, Source};
 use crate::host::{FlowModule, Host, InputEnvelope};
 use crate::log;
 use crate::manifest::{Manifest, Pipeline};
-use anyhow::{Context, Result, anyhow, bail};
+use crate::registry;
+use anyhow::{Context, Result, bail};
 use std::collections::HashMap;
-use std::path::{Path, PathBuf};
+use std::path::Path;
 use std::sync::Arc;
+use tokio::task::JoinSet;
 
 pub struct RunReport {
     /// Pipeline name → error message, for pipelines that failed.
@@ -22,43 +27,45 @@ pub struct RunReport {
 
 /// Load every flow the manifest references (deduplicated), then run all
 /// pipelines concurrently. The connector root is the artifact directory.
-pub fn run(artifact_dir: &Path, manifest: &Manifest) -> Result<RunReport> {
+pub async fn run(artifact_dir: &Path, manifest: &Manifest) -> Result<RunReport> {
     let host = Host::new()?;
     let mut flows: HashMap<String, Arc<FlowModule>> = HashMap::new();
+
+    // Startup, in declaration order: build each pipeline's connectors (which
+    // validates the connector type and opens the source) and load its flow
+    // module. Any failure here aborts the whole run before a document moves.
+    let mut plans = Vec::with_capacity(manifest.pipelines.len());
     for pipeline in &manifest.pipelines {
+        let source = registry::build_source(artifact_dir, &pipeline.source)
+            .with_context(|| format!("pipeline \"{}\" source", pipeline.name))?;
+        let sink = registry::build_sink(artifact_dir, &pipeline.sink)
+            .with_context(|| format!("pipeline \"{}\" sink", pipeline.name))?;
         if !flows.contains_key(&pipeline.flow) {
             let module = host
                 .load_flow(artifact_dir, &pipeline.flow)
                 .with_context(|| format!("pipeline \"{}\"", pipeline.name))?;
             flows.insert(pipeline.flow.clone(), Arc::new(module));
         }
+        plans.push(PipelinePlan {
+            pipeline: pipeline.clone(),
+            source,
+            sink,
+            flow: Arc::clone(&flows[&pipeline.flow]),
+        });
     }
 
-    let results: Vec<(String, Result<usize>)> = std::thread::scope(|scope| {
-        let handles: Vec<_> = manifest
-            .pipelines
-            .iter()
-            .map(|pipeline| {
-                let flow = Arc::clone(&flows[&pipeline.flow]);
-                let handle =
-                    scope.spawn(move || run_pipeline(artifact_dir, pipeline, flow.as_ref()));
-                (pipeline.name.clone(), handle)
-            })
-            .collect();
-        handles
-            .into_iter()
-            .map(|(name, handle)| {
-                let result = handle
-                    .join()
-                    .unwrap_or_else(|_| Err(anyhow!("pipeline thread panicked")));
-                (name, result)
-            })
-            .collect()
-    });
+    // Spawn one task per pipeline; tasks own their connectors and share the
+    // flow module behind an Arc.
+    let mut set: JoinSet<(String, Result<usize>)> = JoinSet::new();
+    for plan in plans {
+        let name = plan.pipeline.name.clone();
+        set.spawn(async move { (name, run_pipeline(plan).await) });
+    }
 
     let mut failures = Vec::new();
     let mut documents = 0;
-    for (name, result) in results {
+    while let Some(joined) = set.join_next().await {
+        let (name, result) = joined.context("pipeline task panicked")?;
         match result {
             Ok(count) => documents += count,
             Err(err) => failures.push((name, format!("{err:#}"))),
@@ -70,30 +77,47 @@ pub fn run(artifact_dir: &Path, manifest: &Manifest) -> Result<RunReport> {
     })
 }
 
-/// One pipeline: resolve the source glob, run each document through the flow
-/// in order, write each result to the sink. Returns the document count.
-fn run_pipeline(artifact_dir: &Path, pipeline: &Pipeline, flow: &FlowModule) -> Result<usize> {
-    // Startup: resolve inputs before transforming anything.
-    let inputs = resolve_glob(artifact_dir, &pipeline.source.glob)
-        .with_context(|| format!("source glob \"{}\"", pipeline.source.glob))?;
-    if inputs.is_empty() {
-        bail!("source glob \"{}\" matched no files", pipeline.source.glob);
-    }
-    let sink_path = artifact_dir.join(&pipeline.sink.path);
+/// Everything one pipeline task owns: the spec (for formats + name), its built
+/// connectors, and a handle to the shared flow module.
+struct PipelinePlan {
+    pipeline: Pipeline,
+    source: Box<dyn Source>,
+    sink: Box<dyn Sink>,
+    flow: Arc<FlowModule>,
+}
+
+/// One pipeline: pull each document from the source in order, run it through
+/// the flow, write the result to the sink. Returns the document count.
+async fn run_pipeline(plan: PipelinePlan) -> Result<usize> {
+    let PipelinePlan {
+        pipeline,
+        mut source,
+        mut sink,
+        flow,
+    } = plan;
 
     let mut documents = 0;
-    for input_path in inputs {
+    while let Some(doc) = source.next().await? {
         documents += 1;
-        let payload = std::fs::read_to_string(&input_path)
-            .with_context(|| format!("cannot read {}", input_path.display()))?;
 
-        let result = flow
-            .run(&InputEnvelope {
-                r#in: &pipeline.source.format,
-                out: &pipeline.sink.format,
-                payload: &payload,
+        // The transform is synchronous and CPU-bound; run it off the async
+        // worker so it never blocks other pipelines' I/O.
+        let result = {
+            let flow = Arc::clone(&flow);
+            let in_format = pipeline.source.format.clone();
+            let out_format = pipeline.sink.format.clone();
+            let payload = doc.payload;
+            tokio::task::spawn_blocking(move || {
+                flow.run(&InputEnvelope {
+                    r#in: &in_format,
+                    out: &out_format,
+                    payload: &payload,
+                })
             })
-            .with_context(|| format!("document {documents} ({})", input_path.display()))?;
+            .await
+            .context("transform task panicked")?
+            .with_context(|| format!("document {documents} ({})", doc.origin))?
+        };
 
         if !result.ok {
             let error = result.error.as_ref();
@@ -105,86 +129,16 @@ fn run_pipeline(artifact_dir: &Path, pipeline: &Pipeline, flow: &FlowModule) -> 
                 .and_then(|e| e.message.as_deref())
                 .unwrap_or("(no message)");
             log::error(&pipeline.name, documents, stage, error_type, message);
-            // Every E3 source is bounded (files), so a poison document fails
-            // the run. A live stream would log-and-move-on here instead.
+            // Every source this phase is bounded (files), so a poison document
+            // fails the run. A live stream would log-and-move-on here instead.
             bail!("document {documents}: {stage}: {message}");
         }
 
         let output = result
             .payload
             .context("ok envelope is missing its payload")?;
-        if let Some(parent) = sink_path.parent() {
-            std::fs::create_dir_all(parent)?;
-        }
-        // One sink path, overwritten per document (last write wins) — the TS
-        // file connector's semantics. Per-document naming for multi-match
-        // globs is an E4 sink-semantics decision.
-        std::fs::write(&sink_path, output)
-            .with_context(|| format!("cannot write {}", sink_path.display()))?;
+        sink.write(&output).await?;
         log::done(&pipeline.name, documents);
     }
     Ok(documents)
-}
-
-/// Expand the source glob against the connector root, in sorted (input) order.
-/// E2 emits a literal file path as a one-match glob; real patterns also work.
-/// TODO(E4): moves behind the connector trait/registry.
-fn resolve_glob(root: &Path, pattern: &str) -> Result<Vec<PathBuf>> {
-    // `root.join` silently discards the root for an absolute pattern, which
-    // would let a manifest read outside the connector root.
-    if Path::new(pattern).is_absolute() {
-        bail!("glob pattern must be relative to the connector root, got \"{pattern}\"");
-    }
-    let absolute = root.join(pattern);
-    let pattern_str = absolute
-        .to_str()
-        .context("glob pattern is not valid UTF-8")?;
-    let mut paths: Vec<PathBuf> = glob::glob(pattern_str)
-        .context("invalid glob pattern")?
-        .collect::<std::result::Result<_, _>>()
-        .context("cannot read a glob match")?;
-    paths.sort();
-    Ok(paths)
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn resolve_glob_returns_sorted_matches() {
-        let dir = std::env::temp_dir().join(format!("wv-glob-{}", std::process::id()));
-        std::fs::create_dir_all(dir.join("in")).unwrap();
-        std::fs::write(dir.join("in/b.json"), "{}").unwrap();
-        std::fs::write(dir.join("in/a.json"), "{}").unwrap();
-
-        let paths = resolve_glob(&dir, "in/*.json").unwrap();
-        let names: Vec<_> = paths
-            .iter()
-            .map(|p| p.file_name().unwrap().to_str().unwrap())
-            .collect();
-        assert_eq!(names, ["a.json", "b.json"]);
-
-        std::fs::remove_dir_all(&dir).unwrap();
-    }
-
-    #[test]
-    fn resolve_glob_rejects_an_absolute_pattern() {
-        let err = resolve_glob(Path::new("/tmp"), "/etc/*.conf")
-            .unwrap_err()
-            .to_string();
-        assert!(err.contains("must be relative"), "{err}");
-    }
-
-    #[test]
-    fn resolve_glob_treats_a_literal_path_as_one_match() {
-        let dir = std::env::temp_dir().join(format!("wv-glob-lit-{}", std::process::id()));
-        std::fs::create_dir_all(dir.join("in")).unwrap();
-        std::fs::write(dir.join("in/x.json"), "{}").unwrap();
-
-        let paths = resolve_glob(&dir, "in/x.json").unwrap();
-        assert_eq!(paths.len(), 1);
-
-        std::fs::remove_dir_all(&dir).unwrap();
-    }
 }

--- a/engine/src/runner.rs
+++ b/engine/src/runner.rs
@@ -11,7 +11,7 @@
 use crate::connector::{Sink, Source};
 use crate::host::{FlowModule, Host, InputEnvelope};
 use crate::log;
-use crate::manifest::{Manifest, Pipeline};
+use crate::manifest::Manifest;
 use crate::registry;
 use anyhow::{Context, Result, bail};
 use std::collections::HashMap;
@@ -47,7 +47,9 @@ pub async fn run(artifact_dir: &Path, manifest: &Manifest) -> Result<RunReport> 
             flows.insert(pipeline.flow.clone(), Arc::new(module));
         }
         plans.push(PipelinePlan {
-            pipeline: pipeline.clone(),
+            name: pipeline.name.clone(),
+            in_format: pipeline.source.format.as_str().into(),
+            out_format: pipeline.sink.format.as_str().into(),
             source,
             sink,
             flow: Arc::clone(&flows[&pipeline.flow]),
@@ -58,7 +60,7 @@ pub async fn run(artifact_dir: &Path, manifest: &Manifest) -> Result<RunReport> 
     // flow module behind an Arc.
     let mut set: JoinSet<(String, Result<usize>)> = JoinSet::new();
     for plan in plans {
-        let name = plan.pipeline.name.clone();
+        let name = plan.name.clone();
         set.spawn(async move { (name, run_pipeline(plan).await) });
     }
 
@@ -77,10 +79,14 @@ pub async fn run(artifact_dir: &Path, manifest: &Manifest) -> Result<RunReport> 
     })
 }
 
-/// Everything one pipeline task owns: the spec (for formats + name), its built
-/// connectors, and a handle to the shared flow module.
+/// Everything one pipeline task owns: its name and the source/sink formats
+/// (the only manifest fields the loop needs), its built connectors, and a
+/// handle to the shared flow module. The formats are `Arc<str>` so each
+/// document's `spawn_blocking` clone is one atomic bump, not a fresh alloc.
 struct PipelinePlan {
-    pipeline: Pipeline,
+    name: String,
+    in_format: Arc<str>,
+    out_format: Arc<str>,
     source: Box<dyn Source>,
     sink: Box<dyn Sink>,
     flow: Arc<FlowModule>,
@@ -90,7 +96,9 @@ struct PipelinePlan {
 /// the flow, write the result to the sink. Returns the document count.
 async fn run_pipeline(plan: PipelinePlan) -> Result<usize> {
     let PipelinePlan {
-        pipeline,
+        name,
+        in_format,
+        out_format,
         mut source,
         mut sink,
         flow,
@@ -104,8 +112,8 @@ async fn run_pipeline(plan: PipelinePlan) -> Result<usize> {
         // worker so it never blocks other pipelines' I/O.
         let result = {
             let flow = Arc::clone(&flow);
-            let in_format = pipeline.source.format.clone();
-            let out_format = pipeline.sink.format.clone();
+            let in_format = Arc::clone(&in_format);
+            let out_format = Arc::clone(&out_format);
             let payload = doc.payload;
             tokio::task::spawn_blocking(move || {
                 flow.run(&InputEnvelope {
@@ -128,7 +136,7 @@ async fn run_pipeline(plan: PipelinePlan) -> Result<usize> {
             let message = error
                 .and_then(|e| e.message.as_deref())
                 .unwrap_or("(no message)");
-            log::error(&pipeline.name, documents, stage, error_type, message);
+            log::error(&name, documents, stage, error_type, message);
             // Every source this phase is bounded (files), so a poison document
             // fails the run. A live stream would log-and-move-on here instead.
             bail!("document {documents}: {stage}: {message}");
@@ -138,7 +146,7 @@ async fn run_pipeline(plan: PipelinePlan) -> Result<usize> {
             .payload
             .context("ok envelope is missing its payload")?;
         sink.write(&output).await?;
-        log::done(&pipeline.name, documents);
+        log::done(&name, documents);
     }
     Ok(documents)
 }

--- a/engine/tests/cli.rs
+++ b/engine/tests/cli.rs
@@ -88,12 +88,31 @@ fn unknown_manifest_version_fails_fast() {
 
 #[test]
 fn missing_flow_module_fails_at_startup() {
-    // Valid manifest, but flows/order.wasm does not exist.
+    // Valid manifest and a matching input (so the source opens), but
+    // flows/order.wasm does not exist.
     let dir = temp_artifact("noflow", GOLDEN_HEAD);
+    fs::create_dir_all(dir.join("in")).unwrap();
+    fs::write(dir.join("in/order.json"), "{}").unwrap();
     let output = run_engine(&dir);
     fs::remove_dir_all(&dir).ok();
 
     assert!(!output.status.success());
     let stderr = String::from_utf8_lossy(&output.stderr);
     assert!(stderr.contains("cannot load flow module"), "{stderr}");
+}
+
+#[test]
+fn unknown_connector_type_fails_with_a_clear_error() {
+    // The manifest is shape-valid; the registry rejects the connector type.
+    let manifest =
+        GOLDEN_HEAD.replace(r#"{ "type": "file", "glob""#, r#"{ "type": "rest", "glob""#);
+    let dir = temp_artifact("badtype", &manifest);
+    // Connectors are built before flow modules load, so no .wasm is needed —
+    // the unknown type aborts startup first.
+    let output = run_engine(&dir);
+    fs::remove_dir_all(&dir).ok();
+
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("unknown source type \"rest\""), "{stderr}");
 }

--- a/notes/DEV_LOG.md
+++ b/notes/DEV_LOG.md
@@ -13,6 +13,30 @@ Newest entries on top. One entry per merged slice.
 
 ---
 
+## 2026-06-11 — E4 connector trait + registry (Rust)
+
+- What changed: Pulled connector I/O out of the run loop behind async `Source`/`Sink` traits
+  (`connector.rs`) dispatched by a `type`-keyed registry (`registry.rs`); the `file` connector
+  (`connectors/file.rs`) — glob source (sorted = input order), path sink — is the only entry.
+  The engine moved onto a tokio runtime: pipelines are concurrent tasks, connector I/O is async,
+  and the synchronous wasm transform runs in `spawn_blocking`. Connectors are now built at startup
+  before flow modules load, so an unknown connector type or an empty glob aborts the run cleanly
+  before any document moves. Renamed the manifest `Source`/`Sink` structs to `SourceSpec`/
+  `SinkSpec` and moved the file-only check from the manifest into the registry.
+- What I learned: Async was the right call for additivity (every future connector is async I/O),
+  but it's pure plumbing here — `file` is sync underneath, so the win is only that REST/blob/etc
+  slot in without a breaking trait change. Two Rust specifics: `trait Source: Send` makes
+  `Box<dyn Source>` `Send` so it moves into a spawned task without a `+ Send` annotation; and
+  `.unwrap_err()` needs the _Ok_ type to be `Debug`, which trait objects and `FileSource` aren't,
+  so error-path tests use `.err().unwrap()`. Building connectors at startup (rather than inside
+  each task) made the failure ordering deterministic and let the unknown-type test run without a
+  real `.wasm` — but it also reordered errors: the missing-flow test had to gain an input file so
+  the source opens before the flow load it's actually testing fails. Toolchain note: the offline
+  crates index lacked `tokio-macros ~2.7.0`, so I dropped the `macros` feature (the runtime is
+  built by hand anyway) and tests drive async bodies on a hand-built current-thread runtime.
+- What is next: E5 — thin Docker image (Rust build → distroless/scratch, no Node) and the
+  mounted-`weavster.yaml` boot (`-c/--config`), then E6 (TS↔Rust parity gate).
+
 ## 2026-06-10 — E3 engine core (Rust)
 
 - What changed: Implemented the engine core (Engine Plan E3 / RFC 0003 slice 3).


### PR DESCRIPTION
## Engine Plan E4 — connector trait + registry

Lands `Source`/`Sink` behind a `type`-keyed registry with `file` as the only entry, so later connectors (rest/blob/tcp/grpc/db) are additive — RFC 0003 slice 4.

### What it does
- **`connector.rs`** — async `Source::next()` / `Sink::write()` traits (async because every connector beyond `file` is async I/O; landing the shape now keeps them additive).
- **`registry.rs`** — `type`-keyed dispatch, the one place that knows which connector types exist. Unknown type → clear error.
- **`connectors/file.rs`** — the `file` connector: glob source (sorted = input order, one file → one document) and path sink.
- **Async run loop** — the engine moves onto a tokio runtime. Pipelines are concurrent tasks, connector I/O is async, and the synchronous wasm transform runs in `spawn_blocking`. Connectors are built at startup (before flow modules load), so an unknown type or empty glob aborts the run before any document moves.
- Manifest `Source`/`Sink` structs renamed `SourceSpec`/`SinkSpec`; the file-only check moved from the manifest into the registry.

### Verified (E4 checklist)
- Unknown connector `type` fails with a clear error — registry unit tests + an end-to-end binary test (`unknown source type "rest"`).
- A glob matching three files yields three documents, in input order (artifact test).
- File sink output matches byte-for-byte (artifact test).

27 engine tests pass; `clippy -D warnings` + `fmt` clean.

### Note
tokio's `macros` feature is omitted — the offline crates index lacked `tokio-macros ~2.7.0`. The runtime is built by hand and async test bodies run on a hand-built current-thread runtime, so nothing depends on it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Async connector interfaces and a type-keyed connector registry; pipelines run concurrently on a Tokio async runtime with blocking offload for synchronous transforms
  * Built-in file connector: glob-backed source preserving input order and path-backed sink that creates parent directories

* **Bug Fixes**
  * Startup now validates connector types and empty glob patterns with clearer errors

* **Documentation**
  * Architecture and roadmap updated with concurrency model, resource limits, and logging details
<!-- end of auto-generated comment: release notes by coderabbit.ai -->