### PR TITLE
feat(engine): thin Docker image + weavster.yaml boot (E5)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,8 @@
+# The engine image (engine/Dockerfile) only needs the Cargo workspace. Keep the
+# TS toolchain, build output, and tooling out of the build context.
+target
+**/target
+node_modules
+**/node_modules
+website
+.git

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,15 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Added
 
+- Ship the engine as a thin Docker image and boot it from config (Engine Plan E5 / RFC 0003
+  slice 5). The engine no longer takes a positional artifact path; it boots from a mounted
+  `weavster.yaml` (default `/etc/weavster/weavster.yaml`, `-c/--config` to override) and resolves
+  the artifact **by convention** next to it — `<config-dir>/target/artifact`, matching `weavster
+compile`'s default output — overridable with `--artifact` (`engine/src/config.rs`). A
+  multi-stage `engine/Dockerfile` builds with the Rust toolchain and ships only the binary on
+  distroless/cc — no Node, no TS toolchain (a repo-root `.dockerignore` keeps them out of the
+  build context).
+
 - Land the connector trait + registry (Engine Plan E4 / RFC 0003 slice 4). `Source`/`Sink` are
   async traits (`engine/src/connector.rs`); a `type`-keyed registry (`registry.rs`) is the one
   place that knows which connector types exist, so later connectors (rest/blob/tcp/grpc/db) are a

--- a/README.md
+++ b/README.md
@@ -143,9 +143,12 @@ mkdir -p examples/golden-path/target/artifact/in
 cp examples/golden-path/in/order.json examples/golden-path/target/artifact/in/
 cargo run -- -c examples/golden-path/weavster.yaml
 
-# or as the thin Docker image — mount the project at the default config path:
+# or as the thin Docker image — mount the project at the default config path.
+# the image runs as a non-root user, so run as the host user (--user) to keep
+# the bind-mounted sink dir writable.
 docker build -f engine/Dockerfile -t weavster-engine .
-docker run --rm -v "$PWD/examples/golden-path:/etc/weavster" weavster-engine
+docker run --rm --user "$(id -u):$(id -g)" \
+  -v "$PWD/examples/golden-path:/etc/weavster" weavster-engine
 ```
 
 **Build boundary:** Rust and the pnpm/TS packages sit side by side but never mix. The TS

--- a/README.md
+++ b/README.md
@@ -86,13 +86,16 @@ See the [Getting Started guide](https://docs.weavster.dev/getting-started) for t
   the `manifest.json` + `flows/<name>.wasm` artifact layout, and the WASM input/result envelope —
   the contract the Rust engine (RFC 0003) and `weavster compile` are built against. `compile`
   produces this artifact and the engine runs it today.
-- Rust engine core ([`engine/`](engine/)): `weavster-engine <artifact-dir>` loads + validates the
-  manifest (refusing unknown versions loudly), JIT-compiles each flow module once, and runs every
-  pipeline concurrently on a tokio runtime — FIFO per pipeline, fresh wasmtime store per document,
-  with a memory cap and wall-clock deadline so runaway transforms trap instead of hanging.
-  Structured JSON logs carry pipeline/document/stage. Sources and sinks sit behind async
-  `Source`/`Sink` traits in a `type`-keyed registry; `file` (glob source, path sink) is the only
-  connector today, and later ones are additive — no run-loop change.
+- Rust engine core ([`engine/`](engine/)): the engine boots from a mounted `weavster.yaml`
+  (default `/etc/weavster/weavster.yaml`, `-c/--config` to override) and resolves the compiled
+  artifact next to it by convention (`--artifact` to override). It loads + validates the manifest
+  (refusing unknown versions loudly), JIT-compiles each flow module once, and runs every pipeline
+  concurrently on a tokio runtime — FIFO per pipeline, fresh wasmtime store per document, with a
+  memory cap and wall-clock deadline so runaway transforms trap instead of hanging. Structured
+  JSON logs carry pipeline/document/stage. Sources and sinks sit behind async `Source`/`Sink`
+  traits in a `type`-keyed registry; `file` (glob source, path sink) is the only connector today,
+  and later ones are additive — no run-loop change. Ships as a thin multi-stage Docker image
+  ([`engine/Dockerfile`](engine/Dockerfile)) — a static-base binary on distroless, no Node.
 - Dev log ([`notes/DEV_LOG.md`](notes/DEV_LOG.md)) and changelog
   ([`CHANGELOG.md`](CHANGELOG.md)).
 
@@ -125,18 +128,24 @@ pnpm --filter @weavster/cli dev test ./path/to/project
 ### Engine (Rust)
 
 The production runtime ([RFC 0003](docs/rfcs/0003-engine-runtime.md)) lives in
-[`engine/`](engine/), a Rust workspace at the repo root. The engine core works today:
-`weavster-engine <artifact-dir>` runs a compiled artifact (manifest loader, wasmtime host over
-the Javy ABI, per-pipeline run loop with resource limits). The connector registry, Docker
-image, and parity gate land in later milestones (see
+[`engine/`](engine/), a Rust workspace at the repo root. The engine works today: it boots from a
+mounted `weavster.yaml` and runs the compiled artifact resolved beside it (manifest loader,
+wasmtime host over the Javy ABI, per-pipeline run loop with resource limits, connector registry,
+thin Docker image). Only the parity gate lands in a later milestone (see
 [`docs/ENGINE_PLAN.md`](docs/ENGINE_PLAN.md)).
 
 ```bash
-# end to end: compile the golden path, then run the artifact with the engine
+# end to end: compile the golden path, then run the artifact with the engine.
+# the engine boots from weavster.yaml and resolves the artifact at
+# <config-dir>/target/artifact (matching compile's default output).
 pnpm --filter @weavster/cli dev compile ./examples/golden-path
 mkdir -p examples/golden-path/target/artifact/in
 cp examples/golden-path/in/order.json examples/golden-path/target/artifact/in/
-cargo run -- examples/golden-path/target/artifact
+cargo run -- -c examples/golden-path/weavster.yaml
+
+# or as the thin Docker image — mount the project at the default config path:
+docker build -f engine/Dockerfile -t weavster-engine .
+docker run --rm -v "$PWD/examples/golden-path:/etc/weavster" weavster-engine
 ```
 
 **Build boundary:** Rust and the pnpm/TS packages sit side by side but never mix. The TS

--- a/docs/ENGINE_PLAN.md
+++ b/docs/ENGINE_PLAN.md
@@ -141,11 +141,14 @@ connectors (rest/blob/tcp/grpc/db) are additive. (RFC 0003 slice 4.)
 
 Ship the engine as a thin Docker image and define how it boots. (RFC 0003 slice 5.)
 
-- [ ] Multi-stage Dockerfile: build with Rust, ship a static binary on distroless/scratch — no
+- [x] Multi-stage Dockerfile: build with Rust, ship a static binary on distroless/scratch — no
       Node, no TS toolchain. → verify: image builds; `docker run` executes the golden artifact.
-- [ ] Boot from a **mounted `weavster.yaml`** at a default path, `-c/--config` override
-      (nginx/postgres convention). Resolve where the artifact lives from it. → verify:
-      `cargo run -- -c ./weavster.yaml` and the container both run the golden pipeline.
+- [x] Boot from a **mounted `weavster.yaml`** at a default path, `-c/--config` override
+      (nginx/postgres convention). Resolve where the artifact lives from it — `weavster.yaml`'s
+      schema is closed (`additionalProperties: false`), so the artifact is resolved **by
+      convention** as `<config-dir>/target/artifact` (compile's default output), `--artifact` to
+      override. → verify: `cargo run -- -c ./weavster.yaml` and the container both run the golden
+      pipeline.
 
 ## E6 — Parity test (the guardrail)
 

--- a/docs/ENGINE_PLAN.md
+++ b/docs/ENGINE_PLAN.md
@@ -141,8 +141,9 @@ connectors (rest/blob/tcp/grpc/db) are additive. (RFC 0003 slice 4.)
 
 Ship the engine as a thin Docker image and define how it boots. (RFC 0003 slice 5.)
 
-- [x] Multi-stage Dockerfile: build with Rust, ship a static binary on distroless/scratch — no
-      Node, no TS toolchain. → verify: image builds; `docker run` executes the golden artifact.
+- [x] Multi-stage Dockerfile: build with Rust, ship the binary on distroless/cc (Debian 12) — no
+      Node, no TS toolchain. (`cc` over `scratch`: the binary links glibc + libstdc++ dynamically.)
+      → verify: image builds; `docker run` executes the golden artifact.
 - [x] Boot from a **mounted `weavster.yaml`** at a default path, `-c/--config` override
       (nginx/postgres convention). Resolve where the artifact lives from it — `weavster.yaml`'s
       schema is closed (`additionalProperties: false`), so the artifact is resolved **by

--- a/engine/Dockerfile
+++ b/engine/Dockerfile
@@ -1,0 +1,30 @@
+# Thin engine image (Engine Plan E5). Multi-stage: build with the Rust
+# toolchain, then ship only the binary on a minimal glibc base — no Node, no TS
+# toolchain (those ran at compile time, in the CLI). The engine *runs* compiled
+# artifacts; it never sees the DSL.
+#
+# Build from the repo root (the build context is the Cargo workspace root):
+#   docker build -f engine/Dockerfile -t weavster-engine .
+#
+# Run the golden pipeline (artifact built by `weavster compile examples/golden-path`):
+#   docker run --rm -v "$PWD/examples/golden-path:/etc/weavster" weavster-engine
+# The mounted weavster.yaml lands at /etc/weavster/weavster.yaml (the default
+# config path); the artifact resolves by convention to
+# /etc/weavster/target/artifact. Pass `--artifact <dir>` to override.
+
+FROM rust:1.90-slim-bookworm AS build
+WORKDIR /src
+COPY Cargo.toml Cargo.lock ./
+COPY engine ./engine
+RUN cargo build --release -p weavster-engine
+
+# distroless/cc carries glibc + libgcc + libstdc++ — all the engine binary's
+# dynamic deps, and nothing else (no shell, no package manager).
+FROM gcr.io/distroless/cc-debian12
+COPY --from=build /src/target/release/weavster-engine /usr/local/bin/weavster-engine
+# Drop privileges: distroless ships a `nonroot` user (uid 65532). The binary is
+# world-readable/executable from COPY, so it runs fine; mounted volumes must be
+# readable (and the sink dir writable) by this uid.
+USER nonroot
+ENTRYPOINT ["/usr/local/bin/weavster-engine"]
+# Default invocation reads -c /etc/weavster/weavster.yaml.

--- a/engine/src/config.rs
+++ b/engine/src/config.rs
@@ -11,7 +11,7 @@
 //! artifact. The `manifest.json` inside the artifact is the authoritative
 //! contract the engine reads (see `manifest.rs`).
 
-use anyhow::{Result, anyhow, bail};
+use anyhow::{Result, bail};
 use std::path::{Path, PathBuf};
 
 /// Default mounted config path (k8s ConfigMap / volume convention).
@@ -43,8 +43,10 @@ pub enum Cli {
     Help,
 }
 
-/// Parse argv (excluding argv[0]) into a boot plan. Only the directory probe in
-/// `resolve` touches the filesystem; existence checks happen in `main`.
+/// Parse argv (excluding argv[0]) into a boot plan. The only filesystem touch
+/// is `resolve`'s directory probe — and a `-c` path is treated as a project
+/// directory only if it already exists as one at parse time; otherwise it is
+/// taken as the config file. That file's existence is checked in `main`.
 pub fn parse<I: IntoIterator<Item = String>>(args: I) -> Result<Cli> {
     let mut config: Option<PathBuf> = None;
     let mut artifact: Option<PathBuf> = None;
@@ -53,16 +55,8 @@ pub fn parse<I: IntoIterator<Item = String>>(args: I) -> Result<Cli> {
     while let Some(arg) = args.next() {
         match arg.as_str() {
             "-h" | "--help" => return Ok(Cli::Help),
-            "-c" | "--config" => {
-                let value = args.next().ok_or_else(|| anyhow!("{arg} needs a path"))?;
-                config = Some(PathBuf::from(value));
-            }
-            "--artifact" => {
-                let value = args
-                    .next()
-                    .ok_or_else(|| anyhow!("--artifact needs a path"))?;
-                artifact = Some(PathBuf::from(value));
-            }
+            "-c" | "--config" => config = Some(take_path(&mut args, &arg)?),
+            "--artifact" => artifact = Some(take_path(&mut args, &arg)?),
             other => bail!("unknown argument \"{other}\"\n\n{USAGE}"),
         }
     }
@@ -71,11 +65,28 @@ pub fn parse<I: IntoIterator<Item = String>>(args: I) -> Result<Cli> {
     Ok(Cli::Run(resolve(config, artifact)))
 }
 
+/// Take the next argument as a flag's path value. A missing value — whether the
+/// flag is last (`-c`) or followed by another option (`-c --artifact`) — is a
+/// parse error, not a path that silently becomes a bogus file.
+fn take_path<I: Iterator<Item = String>>(args: &mut I, flag: &str) -> Result<PathBuf> {
+    match args.next() {
+        Some(value) if !is_flag(&value) => Ok(PathBuf::from(value)),
+        _ => bail!("{flag} needs a path"),
+    }
+}
+
+/// Whether a token is one of our option flags (so it can't be a flag's value).
+fn is_flag(token: &str) -> bool {
+    matches!(token, "-h" | "--help" | "-c" | "--config" | "--artifact")
+}
+
 /// Resolve the `-c` path to a project file and an artifact directory. If it
-/// points at a directory, treat it as the project root and read `weavster.yaml`
-/// inside it (matching the CLI's `resolveProjectFile`); otherwise it is the
-/// config file itself. The artifact defaults to `<project-dir>/target/artifact`
-/// — `weavster compile`'s default output — unless `--artifact` overrode it.
+/// points at an existing directory (`is_dir` is a filesystem check), treat it
+/// as the project root and read `weavster.yaml` inside it (matching the CLI's
+/// `resolveProjectFile`); otherwise — including a not-yet-created directory
+/// path — it is taken as the config file itself. The artifact defaults to
+/// `<project-dir>/target/artifact` — `weavster compile`'s default output —
+/// unless `--artifact` overrode it.
 fn resolve(config: PathBuf, artifact: Option<PathBuf>) -> Boot {
     let (config, project_dir) = if config.is_dir() {
         let file = config.join(PROJECT_FILE);
@@ -129,7 +140,16 @@ mod tests {
     fn long_config_flag_is_accepted() {
         let boot = parse_run(&["--config", "./weavster.yaml"]);
         assert_eq!(boot.config, Path::new("./weavster.yaml"));
-        // A bare filename has no usable parent: fall back to the cwd.
+        // "./weavster.yaml"'s parent is ".", so the artifact sits under the cwd.
+        assert_eq!(boot.artifact, Path::new("./target/artifact"));
+    }
+
+    #[test]
+    fn a_bare_filename_falls_back_to_the_cwd() {
+        // "weavster.yaml" with no prefix has an empty parent; resolve falls back
+        // to "." so the artifact is "./target/artifact".
+        let boot = parse_run(&["-c", "weavster.yaml"]);
+        assert_eq!(boot.config, Path::new("weavster.yaml"));
         assert_eq!(boot.artifact, Path::new("./target/artifact"));
     }
 
@@ -175,5 +195,15 @@ mod tests {
         assert!(err.contains("needs a path"), "{err}");
         let err = parse(["--artifact".to_string()]).unwrap_err().to_string();
         assert!(err.contains("needs a path"), "{err}");
+    }
+
+    #[test]
+    fn a_flag_value_that_is_another_option_is_rejected() {
+        // `-c --artifact` is a missing config value, not a config path of
+        // "--artifact" that later fails as a bogus file.
+        let err = parse(["-c".to_string(), "--artifact".to_string()])
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("-c needs a path"), "{err}");
     }
 }

--- a/engine/src/config.rs
+++ b/engine/src/config.rs
@@ -1,0 +1,179 @@
+//! Engine boot configuration (Engine Plan E5).
+//!
+//! The engine boots from a mounted `weavster.yaml` — the nginx/postgres
+//! convention: a known default path, overridable with `-c/--config`. The
+//! artifact (`weavster compile` output) is resolved **by convention** relative
+//! to that config — `<config-dir>/target/artifact`, matching compile's default
+//! output — and is overridable with `--artifact`.
+//!
+//! `weavster.yaml`'s content is the project switchboard, consumed at compile
+//! time; for the engine it is the boot anchor whose *location* roots the
+//! artifact. The `manifest.json` inside the artifact is the authoritative
+//! contract the engine reads (see `manifest.rs`).
+
+use anyhow::{Result, anyhow, bail};
+use std::path::{Path, PathBuf};
+
+/// Default mounted config path (k8s ConfigMap / volume convention).
+pub const DEFAULT_CONFIG: &str = "/etc/weavster/weavster.yaml";
+
+/// The project file looked for when `-c` points at a directory.
+pub const PROJECT_FILE: &str = "weavster.yaml";
+
+pub const USAGE: &str = "\
+usage: weavster-engine [-c|--config <weavster.yaml>] [--artifact <dir>]
+
+  -c, --config <path>   project config to boot from
+                        (default: /etc/weavster/weavster.yaml)
+      --artifact <dir>  compiled artifact directory
+                        (default: <config-dir>/target/artifact)
+  -h, --help            show this help";
+
+/// A resolved boot plan: the config to boot from and the artifact to run.
+#[derive(Debug)]
+pub struct Boot {
+    pub config: PathBuf,
+    pub artifact: PathBuf,
+}
+
+/// What the parsed arguments asked for.
+#[derive(Debug)]
+pub enum Cli {
+    Run(Boot),
+    Help,
+}
+
+/// Parse argv (excluding argv[0]) into a boot plan. Only the directory probe in
+/// `resolve` touches the filesystem; existence checks happen in `main`.
+pub fn parse<I: IntoIterator<Item = String>>(args: I) -> Result<Cli> {
+    let mut config: Option<PathBuf> = None;
+    let mut artifact: Option<PathBuf> = None;
+
+    let mut args = args.into_iter();
+    while let Some(arg) = args.next() {
+        match arg.as_str() {
+            "-h" | "--help" => return Ok(Cli::Help),
+            "-c" | "--config" => {
+                let value = args.next().ok_or_else(|| anyhow!("{arg} needs a path"))?;
+                config = Some(PathBuf::from(value));
+            }
+            "--artifact" => {
+                let value = args
+                    .next()
+                    .ok_or_else(|| anyhow!("--artifact needs a path"))?;
+                artifact = Some(PathBuf::from(value));
+            }
+            other => bail!("unknown argument \"{other}\"\n\n{USAGE}"),
+        }
+    }
+
+    let config = config.unwrap_or_else(|| PathBuf::from(DEFAULT_CONFIG));
+    Ok(Cli::Run(resolve(config, artifact)))
+}
+
+/// Resolve the `-c` path to a project file and an artifact directory. If it
+/// points at a directory, treat it as the project root and read `weavster.yaml`
+/// inside it (matching the CLI's `resolveProjectFile`); otherwise it is the
+/// config file itself. The artifact defaults to `<project-dir>/target/artifact`
+/// — `weavster compile`'s default output — unless `--artifact` overrode it.
+fn resolve(config: PathBuf, artifact: Option<PathBuf>) -> Boot {
+    let (config, project_dir) = if config.is_dir() {
+        let file = config.join(PROJECT_FILE);
+        (file, config)
+    } else {
+        let dir = config
+            .parent()
+            .filter(|p| !p.as_os_str().is_empty())
+            .unwrap_or_else(|| Path::new("."))
+            .to_path_buf();
+        (config, dir)
+    };
+    let artifact = artifact.unwrap_or_else(|| project_dir.join("target/artifact"));
+    Boot { config, artifact }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn parse_run(args: &[&str]) -> Boot {
+        match parse(args.iter().map(|s| s.to_string())) {
+            Ok(Cli::Run(boot)) => boot,
+            other => panic!("expected a run plan, got {}", describe(&other)),
+        }
+    }
+
+    fn describe(cli: &Result<Cli>) -> &'static str {
+        match cli {
+            Ok(Cli::Run(_)) => "Run",
+            Ok(Cli::Help) => "Help",
+            Err(_) => "Err",
+        }
+    }
+
+    #[test]
+    fn no_args_uses_the_default_config_and_derived_artifact() {
+        let boot = parse_run(&[]);
+        assert_eq!(boot.config, Path::new(DEFAULT_CONFIG));
+        assert_eq!(boot.artifact, Path::new("/etc/weavster/target/artifact"));
+    }
+
+    #[test]
+    fn config_override_derives_the_artifact_next_to_it() {
+        let boot = parse_run(&["-c", "/run/project/weavster.yaml"]);
+        assert_eq!(boot.config, Path::new("/run/project/weavster.yaml"));
+        assert_eq!(boot.artifact, Path::new("/run/project/target/artifact"));
+    }
+
+    #[test]
+    fn long_config_flag_is_accepted() {
+        let boot = parse_run(&["--config", "./weavster.yaml"]);
+        assert_eq!(boot.config, Path::new("./weavster.yaml"));
+        // A bare filename has no usable parent: fall back to the cwd.
+        assert_eq!(boot.artifact, Path::new("./target/artifact"));
+    }
+
+    #[test]
+    fn a_config_directory_resolves_to_the_project_file_inside_it() {
+        // `-c <dir>` mirrors the CLI: read <dir>/weavster.yaml, artifact under
+        // <dir>/target/artifact. Needs a real directory (the FS probe).
+        let dir = std::env::temp_dir().join(format!("wv-cfg-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let boot = parse_run(&["-c", dir.to_str().unwrap()]);
+        assert_eq!(boot.config, dir.join("weavster.yaml"));
+        assert_eq!(boot.artifact, dir.join("target/artifact"));
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn artifact_override_wins_over_the_convention() {
+        let boot = parse_run(&[
+            "-c",
+            "/etc/weavster/weavster.yaml",
+            "--artifact",
+            "/data/art",
+        ]);
+        assert_eq!(boot.artifact, Path::new("/data/art"));
+    }
+
+    #[test]
+    fn help_flag_short_and_long() {
+        assert!(matches!(parse(["-h".to_string()]).unwrap(), Cli::Help));
+        assert!(matches!(parse(["--help".to_string()]).unwrap(), Cli::Help));
+    }
+
+    #[test]
+    fn unknown_argument_is_rejected_with_usage() {
+        let err = parse(["--nope".to_string()]).unwrap_err().to_string();
+        assert!(err.contains("unknown argument \"--nope\""), "{err}");
+        assert!(err.contains("usage:"), "{err}");
+    }
+
+    #[test]
+    fn a_flag_without_its_value_is_rejected() {
+        let err = parse(["-c".to_string()]).unwrap_err().to_string();
+        assert!(err.contains("needs a path"), "{err}");
+        let err = parse(["--artifact".to_string()]).unwrap_err().to_string();
+        assert!(err.contains("needs a path"), "{err}");
+    }
+}

--- a/engine/src/main.rs
+++ b/engine/src/main.rs
@@ -5,8 +5,11 @@
 //! over the Javy stdin/stdout ABI. See `docs/ENGINE_PLAN.md` (E3) and
 //! `docs/ARTIFACT_SPEC.md` for the contract.
 //!
-//! Usage: `weavster-engine <artifact-dir>` (E5 adds the `weavster.yaml` boot).
+//! Boots from a mounted `weavster.yaml` (default `/etc/weavster/weavster.yaml`,
+//! `-c/--config` to override) and resolves the artifact by convention next to
+//! it — see `config.rs` and Engine Plan E5.
 
+mod config;
 mod connector;
 mod connectors;
 mod host;
@@ -35,12 +38,27 @@ async fn run(artifact_dir: &Path) -> anyhow::Result<bool> {
 }
 
 fn main() -> ExitCode {
-    // E5 replaces this with the mounted-`weavster.yaml` boot (-c/--config);
-    // until then the artifact directory is explicit, never an implicit cwd.
-    let Some(artifact_dir) = std::env::args().nth(1) else {
-        eprintln!("usage: weavster-engine <artifact-dir>");
-        return ExitCode::FAILURE;
+    let boot = match config::parse(std::env::args().skip(1)) {
+        Ok(config::Cli::Run(boot)) => boot,
+        Ok(config::Cli::Help) => {
+            println!("{}", config::USAGE);
+            return ExitCode::SUCCESS;
+        }
+        Err(err) => {
+            eprintln!("✗ {err:#}");
+            return ExitCode::FAILURE;
+        }
     };
+
+    // The mounted config is the boot anchor: refuse to start if it is absent,
+    // rather than silently running whatever artifact happens to sit nearby.
+    if !boot.config.exists() {
+        eprintln!(
+            "✗ no weavster.yaml at {} — mount your project config there or pass -c <path>",
+            boot.config.display()
+        );
+        return ExitCode::FAILURE;
+    }
 
     let runtime = match tokio::runtime::Runtime::new() {
         Ok(rt) => rt,
@@ -50,7 +68,7 @@ fn main() -> ExitCode {
         }
     };
 
-    match runtime.block_on(run(Path::new(&artifact_dir))) {
+    match runtime.block_on(run(&boot.artifact)) {
         Ok(true) => ExitCode::SUCCESS,
         Ok(false) => ExitCode::FAILURE,
         Err(err) => {

--- a/engine/tests/artifact.rs
+++ b/engine/tests/artifact.rs
@@ -53,7 +53,18 @@ fn stage(name: &str, artifact: &Path, glob: &str, inputs: &[(&str, &str)]) -> Pa
 }
 
 fn run_engine(artifact_dir: &Path) -> Output {
+    // Boot from a weavster.yaml beside the staged artifact; the engine resolves
+    // documents/sink paths against the --artifact dir.
+    let config = artifact_dir.join("weavster.yaml");
+    fs::write(
+        &config,
+        "apiVersion: weavster/v0alpha2\nname: golden-path\n",
+    )
+    .expect("write weavster.yaml");
     Command::new(env!("CARGO_BIN_EXE_weavster-engine"))
+        .arg("-c")
+        .arg(&config)
+        .arg("--artifact")
         .arg(artifact_dir)
         .output()
         .expect("run the weavster-engine binary")

--- a/engine/tests/cli.rs
+++ b/engine/tests/cli.rs
@@ -45,7 +45,12 @@ const GOLDEN_HEAD: &str = r#"{
 
 #[test]
 fn missing_default_config_fails_with_a_clear_message() {
-    // No args → the default mounted config path, which is absent in CI.
+    // No args → the default mounted config path. Skip if it happens to exist on
+    // this host, since the assertions assume it is absent.
+    if std::path::Path::new("/etc/weavster/weavster.yaml").exists() {
+        eprintln!("skipping: /etc/weavster/weavster.yaml exists on this host");
+        return;
+    }
     let output = Command::new(env!("CARGO_BIN_EXE_weavster-engine"))
         .output()
         .expect("run the weavster-engine binary");

--- a/engine/tests/cli.rs
+++ b/engine/tests/cli.rs
@@ -6,8 +6,18 @@ use std::fs;
 use std::path::PathBuf;
 use std::process::{Command, Output};
 
+const MIN_CONFIG: &str = "apiVersion: weavster/v0alpha2\nname: test\n";
+
+/// Boot the engine against a staged artifact dir. A real `weavster.yaml` is
+/// written into the dir (the boot anchor the engine requires) and `--artifact`
+/// points at the same dir, so the test does not depend on the path convention.
 fn run_engine(artifact_dir: &std::path::Path) -> Output {
+    let config = artifact_dir.join("weavster.yaml");
+    fs::write(&config, MIN_CONFIG).expect("write weavster.yaml");
     Command::new(env!("CARGO_BIN_EXE_weavster-engine"))
+        .arg("-c")
+        .arg(&config)
+        .arg("--artifact")
         .arg(artifact_dir)
         .output()
         .expect("run the weavster-engine binary")
@@ -34,21 +44,42 @@ const GOLDEN_HEAD: &str = r#"{
 }"#;
 
 #[test]
-fn no_argument_prints_usage_and_fails() {
+fn missing_default_config_fails_with_a_clear_message() {
+    // No args → the default mounted config path, which is absent in CI.
     let output = Command::new(env!("CARGO_BIN_EXE_weavster-engine"))
         .output()
         .expect("run the weavster-engine binary");
     assert!(!output.status.success());
     let stderr = String::from_utf8_lossy(&output.stderr);
-    assert!(
-        stderr.contains("usage: weavster-engine <artifact-dir>"),
-        "{stderr}"
-    );
+    assert!(stderr.contains("no weavster.yaml at"), "{stderr}");
+    assert!(stderr.contains("/etc/weavster/weavster.yaml"), "{stderr}");
+}
+
+#[test]
+fn help_flag_prints_usage_and_succeeds() {
+    let output = Command::new(env!("CARGO_BIN_EXE_weavster-engine"))
+        .arg("--help")
+        .output()
+        .expect("run the weavster-engine binary");
+    assert!(output.status.success());
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("usage: weavster-engine"), "{stdout}");
 }
 
 #[test]
 fn missing_artifact_dir_fails_with_a_clear_message() {
-    let output = run_engine(std::path::Path::new("/nonexistent/artifact"));
+    // Config present (the boot anchor), but the artifact it points at is absent.
+    let dir = temp_artifact("noart", GOLDEN_HEAD);
+    fs::write(dir.join("weavster.yaml"), MIN_CONFIG).unwrap();
+    let output = Command::new(env!("CARGO_BIN_EXE_weavster-engine"))
+        .arg("-c")
+        .arg(dir.join("weavster.yaml"))
+        .arg("--artifact")
+        .arg("/nonexistent/artifact")
+        .output()
+        .expect("run the weavster-engine binary");
+    fs::remove_dir_all(&dir).ok();
+
     assert!(!output.status.success());
     let stderr = String::from_utf8_lossy(&output.stderr);
     assert!(stderr.contains("cannot read"), "{stderr}");


### PR DESCRIPTION
## Summary

Engine Plan **E5** (RFC 0003 slice 5): ship the engine as a thin Docker image and define how it boots.

- **Config boot.** The engine no longer takes a positional artifact path. It boots from a mounted `weavster.yaml` (default `/etc/weavster/weavster.yaml` — the k8s ConfigMap/volume convention), overridable with `-c/--config`. `-c` may name the file or its project directory (matching the CLI's `resolveProjectFile`). New `engine/src/config.rs` owns arg parsing + resolution.
- **Artifact by convention.** `weavster.yaml`'s schema is closed (`additionalProperties: false`), so the engine reads no new field; the config's location roots the artifact at `<project-dir>/target/artifact` — `weavster compile`'s default output — overridable with `--artifact`.
- **Thin image.** Multi-stage `engine/Dockerfile`: build with the Rust toolchain, run the binary as **nonroot** on `distroless/cc` — no Node, no TS toolchain. Repo-root `.dockerignore` keeps them out of the build context.

## Verification

- `cargo run -- -c examples/golden-path/weavster.yaml` and `-c examples/golden-path` (dir form) both run the golden pipeline.
- `docker build -f engine/Dockerfile -t weavster-engine .` then `docker run --rm -v "$PWD/examples/golden-path:/etc/weavster" weavster-engine` — golden pipeline runs as nonroot, output written to the host mount.
- 26 unit + 3 e2e + 7 CLI tests pass; `clippy -D warnings` clean; fmt clean. CodeRabbit clean.

Remaining: E6 parity gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Engine now ships as an optimized multi-stage Docker image and runs from a mounted YAML config with -c/--config plus an --artifact override.

* **Documentation**
  * Updated docs and README to describe config-driven boot, image contract, invocation examples for local and container runs, and runtime behavior.

* **Chores**
  * Docker ignore rules updated to exclude build artifacts and common dependency directories.

* **Tests**
  * CLI and integration tests revised to exercise config-driven invocation and manifest error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->