### PR TITLE
Add PR template (fixes #2)

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,31 @@
+## Summary
+
+<!-- What does this PR do and why? Link the issue (e.g. Closes #N). -->
+
+## Type of change
+
+- [ ] Bug fix
+- [ ] New feature
+- [ ] Documentation / tooling
+- [ ] Refactor (no behavior change)
+
+## Verification
+
+<!-- Commands run and their results. -->
+
+- [ ] `gofmt -l .` prints nothing
+- [ ] `go vet ./...` passes clean
+- [ ] `golangci-lint run` passes
+- [ ] `go test -race ./...` passes
+
+## Checklist
+
+- [ ] Tests cover all acceptance criteria; generated code reaches 90% unit-test coverage.
+- [ ] No CGo — the binary still cross-compiles to `linux/amd64`, `linux/arm64`, `darwin/arm64`.
+- [ ] `CHANGELOG.md` updated under `[Unreleased]`.
+- [ ] `README.md` reflects what exists now (no aspirational/roadmap content).
+- [ ] Hexagonal boundaries respected (components depend on ports, not concrete types).
+
+## Notes for reviewers
+
+<!-- Anything reviewers should know: trade-offs, follow-ups, unrelated issues noticed (but not fixed). -->


### PR DESCRIPTION
## Summary

Adds `.github/pull_request_template.md` to satisfy the ACMM L0 prerequisite criterion `acmm:prereq-pr-template`.

Closes #2

## Changes

- New `.github/pull_request_template.md` with a checklist aligned to the repo's own conventions:
  - Gates from `AGENTS.md` / `docs/agent-onboarding.md`: `gofmt -l .`, `go vet ./...`, `golangci-lint run`, `go test -race ./...`
  - No-CGo cross-compile rule (`linux/amd64`, `linux/arm64`, `darwin/arm64`)
  - `CHANGELOG.md` and `README.md` upkeep
  - Hexagonal (ports & adapters) boundary rule

## Verification

Documentation-only change; no Go code touched.
