### PR TITLE
Add issue templates (fixes #3)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,54 @@
+name: Bug report
+description: Report a bug in Weavster.
+title: "[Bug]: "
+labels: ["bug"]
+body:
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: A clear, concise description of the bug and the expected behavior.
+    validations:
+      required: true
+  - type: textarea
+    id: repro
+    attributes:
+      label: Steps to reproduce
+      description: Minimal steps, config/DSL snippets, or commands that trigger the bug.
+      placeholder: |
+        1. Run `weavster server ...`
+        2. ...
+    validations:
+      required: true
+  - type: input
+    id: version
+    attributes:
+      label: Version
+      description: `weavster version` output or commit SHA.
+  - type: dropdown
+    id: area
+    attributes:
+      label: Area
+      description: Which component is affected?
+      options:
+        - gateway
+        - auth
+        - scheduler
+        - executor
+        - compiler
+        - registry
+        - state
+        - adapters
+        - codecs
+        - config
+        - gitstore
+        - migrate
+        - outbox
+        - alerts
+        - notify
+        - secrets
+        - observability
+        - topology
+        - CLI
+        - docs
+        - other

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,6 @@
+blank_issues_enabled: true
+
+contact_links:
+  - name: Weavster documentation
+    url: https://weavster-dev.github.io/weavster/
+    about: Read the docs before opening an issue.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,27 @@
+name: Feature request
+description: Suggest an enhancement to Weavster.
+title: "[Feature]: "
+labels: ["enhancement"]
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem
+      description: What problem does this solve? Link related issues if any.
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposal
+      description: How should it work? Describe the desired behavior or API.
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Other approaches you've considered and why they don't fit.
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional context
+      description: Anything else — specs, links, constraints (no CGo, single static binary, hexagonal boundaries).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ All notable changes to this project are documented here, following
 - P5 control plane: `auth` (AuthProvider/Authorizer ports, Argon2id hashing, password policy, lockout+decay, anti-enumeration, external auth + MFA hooks), `audit` (AuditSink local event store + PHI access logging with sensitive-parameter redaction), `notify` (SMTP + webhook), `alerts` (definitions, evaluation, delivery, enable/disable, import/export, test), `topology` (read-only overview + flow-internal graphs per the data contract), and `gateway` (chi router, OpenAPI 3.1 serving, CSRF marker, security headers, TRACE/TRACK blocking, configurable TLS).
 - P6 composition root: `cmd/weavster` (server wiring all ports/adapters, scriptable CLI shell with batch `-s` mode and §3.3 exit codes, startup flags `-a/-u/-p/-s/-v/-c/-h/-d`, `weavster test --filter/--format/--output` with junit/json output, privileged-run guard; cross-compiles to linux/amd64, linux/arm64, darwin/arm64 with zero CGo).
 - P7 migration + IaC + docs: `migrate` (legacy XML import ETL — extract/transform/load with dry-run report and a versioned legacy→YAML mapping table), Terraform + Pulumi sample modules (`iac/`), multi-stage distroless `Dockerfile`, generated `agent-docs/schemas/*.json`, full `agent-docs/openapi.yaml`, and updated README/MkDocs/llms.txt.
+- GitHub issue templates: bug report + feature request forms and blank-issue config (`.github/ISSUE_TEMPLATE/`).
 
 ### Fixed
 


### PR DESCRIPTION
## Summary

Adds `.github/ISSUE_TEMPLATE/` to satisfy the ACMM L0 prerequisite criterion `acmm:prereq-issue-template`.

Closes #3

## Changes

- `.github/ISSUE_TEMPLATE/config.yml` — enables blank issues and links to the docs site.
- `.github/ISSUE_TEMPLATE/bug_report.yml` — bug report form (steps to reproduce, version, affected component).
- `.github/ISSUE_TEMPLATE/feature_request.yml` — feature request form (problem, proposal, alternatives).
- `CHANGELOG.md` — entry under `[Unreleased]`.

## Verification

Documentation-only change; no Go code touched.
