### PR TITLE
Add contributing guide (fixes #4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ All notable changes to this project are documented here, following
 - P5 control plane: `auth` (AuthProvider/Authorizer ports, Argon2id hashing, password policy, lockout+decay, anti-enumeration, external auth + MFA hooks), `audit` (AuditSink local event store + PHI access logging with sensitive-parameter redaction), `notify` (SMTP + webhook), `alerts` (definitions, evaluation, delivery, enable/disable, import/export, test), `topology` (read-only overview + flow-internal graphs per the data contract), and `gateway` (chi router, OpenAPI 3.1 serving, CSRF marker, security headers, TRACE/TRACK blocking, configurable TLS).
 - P6 composition root: `cmd/weavster` (server wiring all ports/adapters, scriptable CLI shell with batch `-s` mode and §3.3 exit codes, startup flags `-a/-u/-p/-s/-v/-c/-h/-d`, `weavster test --filter/--format/--output` with junit/json output, privileged-run guard; cross-compiles to linux/amd64, linux/arm64, darwin/arm64 with zero CGo).
 - P7 migration + IaC + docs: `migrate` (legacy XML import ETL — extract/transform/load with dry-run report and a versioned legacy→YAML mapping table), Terraform + Pulumi sample modules (`iac/`), multi-stage distroless `Dockerfile`, generated `agent-docs/schemas/*.json`, full `agent-docs/openapi.yaml`, and updated README/MkDocs/llms.txt.
+- `CONTRIBUTING.md` development guide (setup, build, gates, conventions, and PR process).
 
 ### Fixed
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,83 @@
+# Contributing to Weavster
+
+Thanks for contributing! This guide covers how to set up, build, test, and submit
+changes to Weavster — a single-binary, message-oriented integration platform written in Go.
+
+Before writing code, read these (in order of precedence on conflict):
+
+1. `agentic-manifest.json` — the machine-readable build plan (structure).
+2. `specs/` — requirements and architecture (semantics).
+3. `docs/agent-onboarding.md` — non-ambiguous coding rules (tooling).
+
+If these conflict, **surface the conflict — never resolve it silently.** Open an issue.
+
+## Prerequisites
+
+- Go `>= 1.22`
+- `golangci-lint` (uses the repo's `.golangci.yml`)
+
+## Setup
+
+```bash
+git clone https://github.com/weavster-dev/weavster.git
+cd weavster
+go build -o bin/weavster ./cmd/weavster
+```
+
+## Build & run
+
+```bash
+go build -o bin/weavster ./cmd/weavster    # local build
+weavster server 0.0.0.0:8080               # start the server
+weavster test --format junit --output artifacts/
+```
+
+The binary must cross-compile to `linux/amd64`, `linux/arm64`, and `darwin/arm64`
+as a single static binary with **zero CGo**:
+
+```bash
+GOOS=linux   GOARCH=amd64 CGO_ENABLED=0 go build ./cmd/weavster
+GOOS=linux   GOARCH=arm64 CGO_ENABLED=0 go build ./cmd/weavster
+GOOS=darwin  GOARCH=arm64 CGO_ENABLED=0 go build ./cmd/weavster
+```
+
+## Hard rules
+
+- **No CGo.** `import "C"` is a build failure.
+- **Hexagonal (ports & adapters).** Components depend only on Go interfaces (ports),
+  never another component's concrete type. Interface definitions live in the consuming package.
+- **Layout.** `cmd/weavster` (entrypoint) · `internal/<module>` (private) · `pkg/` (exported libs only).
+- **Simplicity first.** Minimum code that solves the problem; no speculative abstractions.
+- **Surgical changes.** Touch only what the task requires; match existing style.
+- **Tests never require Postgres.** Use SQLite in-memory (`:memory:`) or temp files.
+
+## Development workflow
+
+1. Open an issue (or pick an existing one) — use the issue templates.
+2. Create a branch from `main`.
+3. Make the change; keep it minimal and focused.
+4. Run the full gate before opening a PR:
+
+   ```bash
+   gofmt -l .                 # MUST print nothing
+   go vet ./...               # MUST pass clean
+   golangci-lint run          # MUST pass (fix, don't //nolint)
+   go test -race ./...        # MUST pass
+   ```
+
+5. Add a `CHANGELOG.md` entry under `[Unreleased]` (Added/Changed/Fixed/Removed).
+6. Ensure `README.md` reflects what exists now — never aspirational.
+7. Open a pull request using the PR template and reference the issue (`Closes #N`).
+
+## Commit style
+
+Lowercase imperative summary, no scope noise:
+
+```
+add issue templates
+fix HL7 v2 segment parsing
+```
+
+## Questions?
+
+Open an issue or ask in the repository discussions.


### PR DESCRIPTION
## Summary

Adds `CONTRIBUTING.md` to satisfy the ACMM L0 prerequisite criterion `acmm:prereq-contrib-guide`.

Closes #4

## Changes

- New `CONTRIBUTING.md` covering: prerequisites, setup, build/run, the no-CGo + hexagonal hard rules, the full dev workflow (`gofmt`/`go vet`/`golangci-lint`/`go test -race` gate), changelog/README upkeep, and commit style.
- `CHANGELOG.md` — entry under `[Unreleased]`.

## Verification

Documentation-only change; no Go code touched.
