### PR TITLE
Add octocov coverage gate (fixes #5)

### DIFF
--- a/.github/workflows/coverage-gate.yml
+++ b/.github/workflows/coverage-gate.yml
@@ -1,0 +1,22 @@
+name: coverage-gate
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  coverage:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: '1.22'
+      - name: Run tests with coverage
+        run: go test ./... -coverprofile=coverage.out -covermode=atomic
+      - name: Enforce coverage gate (octocov)
+        uses: k1LoW/octocov-action@v1

--- a/.octocov.yml
+++ b/.octocov.yml
@@ -1,0 +1,4 @@
+coverage:
+  paths:
+    - coverage.out
+  acceptable: 70%

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ All notable changes to this project are documented here, following
 - P6 composition root: `cmd/weavster` (server wiring all ports/adapters, scriptable CLI shell with batch `-s` mode and §3.3 exit codes, startup flags `-a/-u/-p/-s/-v/-c/-h/-d`, `weavster test --filter/--format/--output` with junit/json output, privileged-run guard; cross-compiles to linux/amd64, linux/arm64, darwin/arm64 with zero CGo).
 - P7 migration + IaC + docs: `migrate` (legacy XML import ETL — extract/transform/load with dry-run report and a versioned legacy→YAML mapping table), Terraform + Pulumi sample modules (`iac/`), multi-stage distroless `Dockerfile`, generated `agent-docs/schemas/*.json`, full `agent-docs/openapi.yaml`, and updated README/MkDocs/llms.txt.
 - `CONTRIBUTING.md` development guide (setup, build, gates, conventions, and PR process).
+- Coverage gate: octocov (`.octocov.yml`, `acceptable: 70%`) wired into a `.github/workflows/coverage-gate.yml` CI job that runs `go test -coverprofile` and fails below threshold.
 - GitHub issue templates: bug report + feature request forms and blank-issue config (`.github/ISSUE_TEMPLATE/`).
 
 ### Fixed


### PR DESCRIPTION
## Summary

Adds a coverage gate to satisfy the ACMM L0 prerequisite criterion `acmm:prereq-coverage-gate`.

Closes #5

## Changes

- `.octocov.yml` — octocov config reading `coverage.out` with `acceptable: 70%` (current total coverage is 71.2%).
- `.github/workflows/coverage-gate.yml` — runs `go test ./... -coverprofile=coverage.out -covermode=atomic`, then enforces the threshold via `k1LoW/octocov-action@v1`.
- `CHANGELOG.md` — entry under `[Unreleased]`.

## Notes

- Octocov is used for the gate (as requested); the `coverage-gate.yml` workflow file is what satisfies the ACMM file-existence check, since `.octocov.yml` is not in the accepted-files list.
- Threshold set to 70% (current 71.2%) as a regression floor; can be raised over time.

## Verification

- `go test ./... -coverprofile` total coverage measured at 71.2% (> 70% gate).
