### PR TITLE
Add Business Source License

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ All notable changes to this project are documented here, following
 - P7 migration + IaC + docs: `migrate` (legacy XML import ETL — extract/transform/load with dry-run report and a versioned legacy→YAML mapping table), Terraform + Pulumi sample modules (`iac/`), multi-stage distroless `Dockerfile`, generated `agent-docs/schemas/*.json`, full `agent-docs/openapi.yaml`, and updated README/MkDocs/llms.txt.
 - `CONTRIBUTING.md` development guide (setup, build, gates, conventions, and PR process).
 - GitHub issue templates: bug report + feature request forms and blank-issue config (`.github/ISSUE_TEMPLATE/`).
+- `LICENSE`: Business Source License 1.1 (Licensor Weavster Dev, Change License MPL 2.0), brought forward from the weavster-old-v2 archive with the copyright year updated to 2026.
 
 ### Fixed
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,118 @@
+Business Source License 1.1
+
+Parameters
+
+Licensor:             Weavster Dev
+Licensed Work:        Weavster
+                      The Licensed Work is (c) 2026 Weavster Dev.
+Additional Use Grant: You may make production use of the Licensed Work,
+                      provided Your use does not include offering the
+                      Licensed Work to third parties on a hosted or embedded
+                      basis in order to compete with Weavster Dev's paid
+                      version(s) of the Licensed Work. For purposes of this
+                      license:
+
+                      A "competitive offering" is a product or service that
+                      is offered to third parties on a paid basis, including
+                      through paid support arrangements, that significantly
+                      overlaps with the capabilities of Weavster Dev's
+                      products.
+
+                      "Embedded" means including the source code or
+                      executable code from the Licensed Work in a
+                      competitive offering. "Embedded" also means packaging
+                      the competitive offering in such a way that the
+                      Licensed Work must be accessed or downloaded for the
+                      competitive offering to operate.
+
+                      Products offered free of charge, and not bundled with
+                      any paid product or service, are not considered
+                      competitive offerings.
+
+Change Date:          Four years from the date the Licensed Work is
+                      published.
+
+Change License:       Mozilla Public License 2.0
+
+For information about alternative licensing arrangements for the Software,
+please visit: https://github.com/weavster-dev/weavster
+
+Notice
+
+The Business Source License (this document, or the "License") is not an Open
+Source license. However, the Licensed Work will eventually be made available
+under an Open Source License, as stated in this License.
+
+License text copyright (c) 2017 MariaDB Corporation Ab, All Rights Reserved.
+"Business Source License" is a trademark of MariaDB Corporation Ab.
+
+-----------------------------------------------------------------------------
+
+Business Source License 1.1
+
+Terms
+
+The Licensor hereby grants you the right to copy, modify, create derivative
+works, redistribute, and make non-production use of the Licensed Work. The
+Licensor may make an Additional Use Grant, above, permitting limited
+production use.
+
+Effective on the Change Date, or the fourth anniversary of the first publicly
+available distribution of a specific version of the Licensed Work under this
+License, whichever comes first, the Licensor hereby grants you rights under
+the terms of the Change License, and the rights granted in the paragraph
+above terminate.
+
+If your use of the Licensed Work does not comply with the requirements
+currently in effect as described in this License, you must purchase a
+commercial license from the Licensor, its affiliated entities, or authorized
+resellers, or you must refrain from using the Licensed Work.
+
+All copies of the original and modified Licensed Work, and derivative works
+of the Licensed Work, are subject to this License. This License applies
+separately for each version of the Licensed Work and the Change Date may vary
+for each version of the Licensed Work released by Licensor.
+
+You must conspicuously display this License on each original or modified copy
+of the Licensed Work. If you receive the Licensed Work in original or
+modified form from a third party, the terms and conditions set forth in this
+License apply to your use of that work.
+
+Any use of the Licensed Work in violation of this License will automatically
+terminate your rights under this License for the current and all other
+versions of the Licensed Work.
+
+This License does not grant you any right in any trademark or logo of
+Licensor or its affiliates (provided that you may use a trademark or logo of
+Licensor as expressly required by this License).
+
+TO THE EXTENT PERMITTED BY APPLICABLE LAW, THE LICENSED WORK IS PROVIDED ON
+AN "AS IS" BASIS. LICENSOR HEREBY DISCLAIMS ALL WARRANTIES AND CONDITIONS,
+EXPRESS OR IMPLIED, INCLUDING (WITHOUT LIMITATION) WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, NON-INFRINGEMENT, AND
+TITLE.
+
+MariaDB hereby grants you permission to use this License's text to license
+your works, and to refer to it using the trademark "Business Source License",
+as long as you comply with the Covenants of Licensor below.
+
+Covenants of Licensor
+
+In consideration of the right to use this License's text and the "Business
+Source License" name and trademark, Licensor covenants to MariaDB, and to all
+other recipients of the licensed work to be provided by Licensor:
+
+1. To specify as the Change License the GPL Version 2.0 or any later version,
+   or a license that is compatible with GPL Version 2.0 or a later version,
+   where "compatible" means that software provided under the Change License can
+   be included in a program with software provided under GPL Version 2.0 or a
+   later version. Licensor may specify additional Change Licenses without
+   limitation.
+
+2. To either: (a) specify an additional grant of rights to use that does not
+   impose any additional restriction on the right granted in this License, as
+   the Additional Use Grant; or (b) insert the text "None".
+
+3. To specify a Change Date.
+
+4. Not to modify this License in any other way.


### PR DESCRIPTION
## Summary

Adds a `LICENSE` to the repo (there was none). No tracking issue — opened per request.

## What this is

Business Source License 1.1, brought over from the `weavster-old-v2` archive.

## Verification against the current repo

| Field | Archive value | Still accurate? |
|---|---|---|
| Licensor | Weavster Dev | ✅ matches `weavster-dev` org |
| Licensed Work | Weavster | ✅ matches module `github.com/weavster-dev/weavster` / binary `weavster` |
| Additional Use Grant | competition clause vs "Weavster Dev's paid version(s)" | ✅ still applies |
| Change License | MPL 2.0 | ✅ GPL-2.0-compatible, satisfies BSL covenant #1 |
| Change Date | four years from publication | ✅ standard parameter, unchanged |
| Alt-licensing link | `https://github.com/weavster-dev/weavster` | ✅ correct URL |
| Copyright year | `(c) 2025` | ⚠️ **stale** — this repo was first published 2026-08-23, updated to `(c) 2026` |

Everything else is byte-for-byte identical to the archive.

## Changes

- `LICENSE` — BSL 1.1 with copyright year updated 2025 → 2026.
- `CHANGELOG.md` — entry under `[Unreleased]`.

## Note

- Named `LICENSE` (not `LICENSE.md`) to match the archive and GitHub auto-detection; happy to rename if `LICENSE.md` is preferred.
- If the Weavster work is considered first published in 2025 (continuity from the old repo), the year should instead be `(c) 2025-2026` — say the word and I'll adjust.
