### PR TITLE
fix: duplicate test declarations breaking CI on main (closes #48)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,5 +26,6 @@ All notable changes to this project are documented here, following
 
 ### Fixed
 
+- Duplicate test function declarations breaking `go vet`/`go test` on main: renamed `TestAdapterNames` (in `adapters_gap_test.go`) to `TestAdapterNamesGap` and `TestSchedulerReconcile` (in `heartbeat_reconcile_test.go`) to `TestSchedulerReconcileExpiredLease`, preserving both test cases.
 - `weavster test --format junit`: exclude the internal `passed` flag from JUnit XML so output is valid `<testcase name=.../>` elements.
 - MkDocs: complete `mkdocs.yml` (site_url, full nav, exclude internal kickoff doc, lenient link validation), add `requirements.txt`, and a `docs.yml` workflow that deploys to GitHub Pages via `mkdocs gh-deploy` on the `gh-pages` branch.

--- a/internal/adapters/adapters_gap_test.go
+++ b/internal/adapters/adapters_gap_test.go
@@ -11,9 +11,9 @@ import (
 	_ "modernc.org/sqlite"
 )
 
-// TestAdapterNames covers the Name() accessors that are otherwise never
+// TestAdapterNamesGap covers the Name() accessors that are otherwise never
 // exercised by the existing Read/Write-focused tests.
-func TestAdapterNames(t *testing.T) {
+func TestAdapterNamesGap(t *testing.T) {
 	dir := t.TempDir()
 	fileSrc, err := NewFileSource(dir, "*")
 	if err != nil {

--- a/internal/scheduler/heartbeat_reconcile_test.go
+++ b/internal/scheduler/heartbeat_reconcile_test.go
@@ -51,10 +51,10 @@ func TestQueueHeartbeat(t *testing.T) {
 	}
 }
 
-// TestSchedulerReconcile covers Scheduler.Reconcile, which delegates to the
-// underlying queue's Reconcile to re-queue jobs whose lease expired (e.g. a
-// node crashed mid-run), so a new node can claim and run them.
-func TestSchedulerReconcile(t *testing.T) {
+// TestSchedulerReconcileExpiredLease covers Scheduler.Reconcile, which delegates
+// to the underlying queue's Reconcile to re-queue jobs whose lease expired (e.g.
+// a node crashed mid-run), so a new node can claim and run them.
+func TestSchedulerReconcileExpiredLease(t *testing.T) {
 	q := NewMemJobQueue()
 	s := New(q, &fakeRunner{})
 	ctx := context.Background()


### PR DESCRIPTION
## Summary

Fixes the critical `main` build break reported in the Hive advisory report (issue #1, findings **ci-failure** and **regression-risk**) and tracked in #48.

`go vet ./...`, `go build ./...`, and `go test ./...` fail on `main` because two independently-merged test PRs introduced duplicate top-level test function names:

- `TestAdapterNames` declared in both `internal/adapters/adapters_test.go` and `internal/adapters/adapters_gap_test.go`.
- `TestSchedulerReconcile` declared in both `internal/scheduler/scheduler_test.go` and `internal/scheduler/heartbeat_reconcile_test.go`.

## Change

Rename (do not delete) the newer duplicate declarations so both test cases are preserved:

- `internal/adapters/adapters_gap_test.go`: `TestAdapterNames` → `TestAdapterNamesGap`
- `internal/scheduler/heartbeat_reconcile_test.go`: `TestSchedulerReconcile` → `TestSchedulerReconcileExpiredLease`

Test-only change; no production code touched.

## Verification

```bash
gofmt -l .                 # clean
go vet ./...               # clean
golangci-lint run ./internal/adapters/... ./internal/scheduler/...  # 0 issues
go test -race ./internal/adapters/... ./internal/scheduler/...      # ok
go test ./...              # all packages ok
```

Closes #48
