### PR TITLE
docs: add Quick Start guide (closes #50)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ All notable changes to this project are documented here, following
 - E2E tests (`test/e2e/`): real-HTTP tests of the gateway surface (OpenAPI spec, `/system`, security headers, TRACE/TRACK blocking, CSRF marker enforcement).
 - `LICENSE`: Business Source License 1.1 (Licensor Weavster Dev, Change License MPL 2.0), brought forward from the weavster-old-v2 archive with the copyright year updated to 2026.
 - Gateway coverage: unit tests for `POST /api/v1/flows` error branches for malformed JSON (400) and store failures (500).
+- `README.md` Quick Start section: prerequisites, clone/build/run in under 5 minutes, and verification via the OpenAPI and `/api/v1/system` endpoints.
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -7,6 +7,39 @@ search, export, scheduling, alerting, and a REST API + read-only topology graph.
 
 Single static Go binary (no CGo, no external runtime).
 
+## Quick Start
+
+Get the server running locally in under 5 minutes.
+
+**Prerequisites:** Go `>= 1.22` and `git`.
+
+```bash
+git clone https://github.com/weavster-dev/weavster.git
+cd weavster
+go build -o bin/weavster ./cmd/weavster
+./bin/weavster server 0.0.0.0:8080
+```
+
+Verify it's up — the server exposes its OpenAPI contract without auth:
+
+```bash
+curl -s http://localhost:8080/api/openapi.yaml | head -n 5
+```
+
+and the system status endpoint (API routes require the CSRF marker header):
+
+```bash
+curl -s -H 'X-Weavster-CSRF: 1' http://localhost:8080/api/v1/system
+```
+
+Run the test suite to confirm a healthy checkout:
+
+```bash
+go test -race ./...
+```
+
+Full developer workflow and quality gates: see [CONTRIBUTING.md](CONTRIBUTING.md).
+
 ## What exists now
 
 - **Control plane** (`internal/`): API gateway (REST + OpenAPI 3.1, CSRF/security headers, TLS),


### PR DESCRIPTION
## Summary

Adds the Quick Start guide requested in #50 (critical finding **missing-documentation** from the Hive advisory report, issue #1).

A new **Quick Start** section at the top of `README.md` gives new contributors a copy-pasteable path to build and run the binary in under 5 minutes:

- Prerequisites (Go `>= 1.22`, `git`).
- Clone → build → run `weavster server 0.0.0.0:8080`.
- Verification via `curl` of the unauthenticated `/api/openapi.yaml` endpoint and the `/api/v1/system` status endpoint (with the `X-Weavster-CSRF: 1` marker header).
- `go test -race ./...` to confirm a healthy checkout, with a pointer to `CONTRIBUTING.md` for the full workflow.

Commands were verified against a locally built binary.

## Verification

- Built the binary and confirmed `server` binds and serves `/api/openapi.yaml` (unauthenticated) and `/api/v1/system` (with CSRF marker) as documented.
- Markdown-only change (plus CHANGELOG entry); no code touched.

Closes #50
